### PR TITLE
Enable all crypto + test fixes

### DIFF
--- a/scripts/utils-wolfssl.sh
+++ b/scripts/utils-wolfssl.sh
@@ -59,7 +59,7 @@ install_wolfssl() {
     if [ ! -d ${WOLFSSL_INSTALL_DIR} ]; then
         printf "\tConfigure wolfSSL ${WOLFSSL_TAG} ... "
         if [ -z "$WOLFSSL_CONFIG_OPTS" ]; then
-            WOLFSSL_CONFIG_OPTS='--with-max-ecc-bits=1024 --enable-opensslcoexist --enable-cmac --enable-keygen --enable-sha --enable-aesctr --enable-aesccm --enable-x963kdf --enable-compkey --enable-certgen --enable-aeskeywrap --enable-enckeys --enable-base16 --enable-aesgcm-stream --enable-curve25519 --enable-curve448 --enable-ed25519 --enable-ed448 --enable-pwdbased'
+            WOLFSSL_CONFIG_OPTS='--enable-all-crypto --with-max-ecc-bits=1024 --enable-opensslcoexist --enable-cmac --enable-keygen --enable-sha --enable-aesctr --enable-aesccm --enable-x963kdf --enable-compkey --enable-certgen --enable-aeskeywrap --enable-enckeys --enable-base16 --enable-aesgcm-stream --enable-curve25519 --enable-curve448 --enable-ed25519 --enable-ed448 --enable-pwdbased'
             WOLFSSL_CONFIG_CFLAGS="-I${OPENSSL_INSTALL_DIR}/include -DHAVE_AES_ECB -DWOLFSSL_AES_DIRECT -DWC_RSA_NO_PADDING -DWOLFSSL_PUBLIC_MP -DECC_MIN_KEY_SZ=192 -DHAVE_PUBLIC_FFDHE -DHAVE_FFDHE_6144 -DHAVE_FFDHE_8192 -DWOLFSSL_DH_EXTRA -DWOLFSSL_PSS_LONG_SALT -DWOLFSSL_PSS_SALT_LEN_DISCOVER"
         fi
 

--- a/test/test_hkdf.c
+++ b/test/test_hkdf.c
@@ -199,9 +199,9 @@ static int test_hkdf_hexstr_calc(OSSL_LIB_CTX* libCtx, unsigned char *key,
 {
     int err = 0;
     EVP_PKEY_CTX *ctx = NULL;
-    const char* inKey = "00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00";
-    const char* salt = "00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00";
-    const char* info = "00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00";
+    const char* inKey = "00000000000000000000000000000000";
+    const char* salt = "00000000000000000000000000000000";
+    const char* info = "00000000000000000000000000000000";
     size_t len = keyLen;
 
     if (strncmp("EXTRACT_ONLY", mode, 12) == 0) {

--- a/test/test_tls1_prf.c
+++ b/test/test_tls1_prf.c
@@ -180,9 +180,9 @@ static int test_tls1_prf_hexstr_calc(OSSL_LIB_CTX* libCtx, unsigned char *key,
 {
     int err = 0;
     EVP_PKEY_CTX *ctx = NULL;
-    const char* secret = "00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00";
-    const char* label = "31:32:33:34:34:35:36";
-    const char* seed = "00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00";
+    const char* secret = "00000000000000000000000000000000";
+    const char* label = "31323334343536";
+    const char* seed = "00000000000000000000000000000000";
     size_t len = keyLen;
 
     ctx = EVP_PKEY_CTX_new_from_name(libCtx, "TLS1-PRF", NULL);


### PR DESCRIPTION
Latest OpenSSL code fails on these tests due to invalid input.