### PR TITLE
Fix settable func

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,8 +53,11 @@
 *.gcda
 
 # Installed dependencies
-/openssl*
-/wolfssl*
+/openssl-source/
+/openssl-install/
+/wolfssl-source/
+/wolfssl-install/
+/wolfprov-install/
 /artifacts
 
 IDE/Android/android-ndk-r26b/

--- a/provider-fips.conf
+++ b/provider-fips.conf
@@ -1,0 +1,14 @@
+openssl_conf = openssl_init
+
+[openssl_init]
+providers = provider_sect
+alg_section = algorithm_sect
+
+[provider_sect]
+libwolfprov = libwolfprov_sect
+
+[libwolfprov_sect]
+activate = 1
+
+[algorithm_sect]
+default_properties = fips=yes

--- a/scripts/utils-openssl.sh
+++ b/scripts/utils-openssl.sh
@@ -122,7 +122,7 @@ init_openssl() {
     OPENSSL_BIN=${OPENSSL_INSTALL_DIR}/bin/openssl
     OPENSSL_TEST=${OPENSSL_SOURCE_DIR}/test
 
-    OSSL_VER=`LD_LIBRARY_PATH=${OPENSSL_INSTALL_DIR}/lib64 $OPENSSL_BIN version`
+    OSSL_VER=`LD_LIBRARY_PATH=${OPENSSL_INSTALL_DIR}/lib64 $OPENSSL_BIN version | tail -n1`
     case $OSSL_VER in
         OpenSSL\ 3.*) ;;
         *)

--- a/scripts/utils-wolfprovider.sh
+++ b/scripts/utils-wolfprovider.sh
@@ -25,11 +25,14 @@ source ${SCRIPT_DIR}/utils-wolfssl.sh
 
 WOLFPROV_SOURCE_DIR=${SCRIPT_DIR}/..
 WOLFPROV_INSTALL_DIR=${SCRIPT_DIR}/../wolfprov-install
-WOLFPROV_CONFIG=${WOLFPROV_CONFIG:-"$WOLFPROV_SOURCE_DIR/provider.conf"}
+if [ "$WOLFSSL_ISFIPS" -eq "1" ]; then
+    WOLFPROV_CONFIG=${WOLFPROV_CONFIG:-"$WOLFPROV_SOURCE_DIR/provider-fips.conf"}
+else
+    WOLFPROV_CONFIG=${WOLFPROV_CONFIG:-"$WOLFPROV_SOURCE_DIR/provider.conf"}
+fi
 
 WOLFPROV_NAME="libwolfprov"
 WOLFPROV_PATH=$WOLFPROV_INSTALL_DIR/lib
-export OPENSSL_MODULES=$WOLFPROV_PATH
 
 WOLFPROV_DEBUG=${WOLFPROV_DEBUG:-0}
 
@@ -95,5 +98,8 @@ install_wolfprov() {
 init_wolfprov() {
     install_wolfprov
     printf "\twolfProvider installed in: ${WOLFPROV_INSTALL_DIR}\n"
+
+    export OPENSSL_MODULES=$WOLFPROV_PATH
+    export OPENSSL_CONF=${WOLFPROV_CONFIG}
 }
 

--- a/src/wp_kdf_exch.c
+++ b/src/wp_kdf_exch.c
@@ -216,17 +216,50 @@ static int wp_kdf_set_ctx_params(wp_KdfCtx* ctx, const OSSL_PARAM params[])
 }
 
 /**
- * Return an array of supported settable parameters for the KDF ke context.
+ * Return an array of supported settable parameters for the HKDF ke context.
  *
  * @param [in] ctx      ECDH key exchange context object. Unused.
  * @param [in] provCtx  Provider context object. Unused.
  * @return  Array of parameters with data type.
  */
-static const OSSL_PARAM* wp_kdf_settable_ctx_params(wp_KdfCtx* ctx,
+static const OSSL_PARAM* wp_hkdf_settable_ctx_params(wp_KdfCtx* ctx,
     WOLFPROV_CTX* provCtx)
 {
+    (void)ctx;
     (void)provCtx;
-    return EVP_KDF_settable_ctx_params(EVP_KDF_CTX_kdf(ctx->kdfCtx));
+    static const OSSL_PARAM settable_ctx_params[] = {
+        OSSL_PARAM_utf8_string(OSSL_KDF_PARAM_MODE, NULL, 0),
+        OSSL_PARAM_int(OSSL_KDF_PARAM_MODE, NULL),
+        OSSL_PARAM_utf8_string(OSSL_KDF_PARAM_PROPERTIES, NULL, 0),
+        OSSL_PARAM_utf8_string(OSSL_KDF_PARAM_DIGEST, NULL, 0),
+        OSSL_PARAM_octet_string(OSSL_KDF_PARAM_KEY, NULL, 0),
+        OSSL_PARAM_octet_string(OSSL_KDF_PARAM_SALT, NULL, 0),
+        OSSL_PARAM_octet_string(OSSL_KDF_PARAM_INFO, NULL, 0),
+        OSSL_PARAM_END
+    };    
+    return settable_ctx_params;
+}
+
+/**
+ * Return an array of supported settable parameters for the HKDF ke context.
+ *
+ * @param [in] ctx      ECDH key exchange context object. Unused.
+ * @param [in] provCtx  Provider context object. Unused.
+ * @return  Array of parameters with data type.
+ */
+static const OSSL_PARAM* wp_tls1_prf_settable_ctx_params(wp_KdfCtx* ctx,
+    WOLFPROV_CTX* provCtx)
+{
+    (void)ctx;
+    (void)provCtx;
+    static const OSSL_PARAM settable_ctx_params[] = {
+        OSSL_PARAM_utf8_string(OSSL_KDF_PARAM_PROPERTIES, NULL, 0),
+        OSSL_PARAM_utf8_string(OSSL_KDF_PARAM_DIGEST, NULL, 0),
+        OSSL_PARAM_octet_string(OSSL_KDF_PARAM_SECRET, NULL, 0),
+        OSSL_PARAM_octet_string(OSSL_KDF_PARAM_SEED, NULL, 0),
+        OSSL_PARAM_END
+    };    
+    return settable_ctx_params;
 }
 
 /*
@@ -254,7 +287,7 @@ const OSSL_DISPATCH wp_hkdf_keyexch_functions[] = {
     { OSSL_FUNC_KEYEXCH_DERIVE,              (DFUNC)wp_kdf_derive             },
     { OSSL_FUNC_KEYEXCH_SET_CTX_PARAMS,      (DFUNC)wp_kdf_set_ctx_params     },
     { OSSL_FUNC_KEYEXCH_SETTABLE_CTX_PARAMS,
-                                            (DFUNC)wp_kdf_settable_ctx_params },
+                                            (DFUNC)wp_hkdf_settable_ctx_params },
     { 0, NULL }
 };
 
@@ -283,7 +316,7 @@ const OSSL_DISPATCH wp_tls1_prf_keyexch_functions[] = {
     { OSSL_FUNC_KEYEXCH_DERIVE,              (DFUNC)wp_kdf_derive             },
     { OSSL_FUNC_KEYEXCH_SET_CTX_PARAMS,      (DFUNC)wp_kdf_set_ctx_params     },
     { OSSL_FUNC_KEYEXCH_SETTABLE_CTX_PARAMS,
-                                            (DFUNC)wp_kdf_settable_ctx_params },
+                                            (DFUNC)wp_tls1_prf_settable_ctx_params },
     { 0, NULL }
 };
 

--- a/src/wp_mac_sig.c
+++ b/src/wp_mac_sig.c
@@ -323,8 +323,18 @@ static int wp_mac_set_ctx_params(wp_MacSigCtx *ctx, const OSSL_PARAM params[])
 static const OSSL_PARAM *wp_mac_settable_ctx_params(wp_MacSigCtx *ctx,
     WOLFPROV_CTX* provCtx)
 {
+    (void)ctx;
     (void)provCtx;
-    return EVP_MAC_settable_ctx_params(EVP_MAC_CTX_get0_mac(ctx->macCtx));
+    static const OSSL_PARAM settable_ctx_params[] = {
+        OSSL_PARAM_utf8_string(OSSL_MAC_PARAM_DIGEST, NULL, 0),
+        OSSL_PARAM_utf8_string(OSSL_MAC_PARAM_PROPERTIES, NULL, 0),
+        OSSL_PARAM_octet_string(OSSL_MAC_PARAM_KEY, NULL, 0),
+        OSSL_PARAM_int(OSSL_MAC_PARAM_DIGEST_NOINIT, NULL),
+        OSSL_PARAM_int(OSSL_MAC_PARAM_DIGEST_ONESHOT, NULL),
+        OSSL_PARAM_size_t(OSSL_MAC_PARAM_TLS_DATA_SIZE, NULL),
+        OSSL_PARAM_END
+    };    
+    return settable_ctx_params;
 }
 
 /*


### PR DESCRIPTION
Add in fixes for FIPS mode execution and testing scripts. Explicitly declared the parameters supported by the functions for HMAC, HKDF, and TLS1_PRF.