### PR TITLE
Add in simple logging for wolfProvider

### DIFF
--- a/include/wolfprovider/internal.h
+++ b/include/wolfprovider/internal.h
@@ -21,6 +21,7 @@
 #include <openssl/core.h>
 #include <openssl/core_names.h>
 #include <openssl/types.h>
+#include <openssl/bio.h>
 
 #ifdef WOLFENGINE_USER_SETTINGS
     #include "user_settings.h"
@@ -129,6 +130,7 @@ typedef struct WOLFPROV_CTX {
    /** Mutex for use of random number generator. */
    wolfSSL_Mutex rng_mutex;
 #endif
+   BIO_METHOD *coreBioMethod;
 } WOLFPROV_CTX;
 
 
@@ -157,8 +159,8 @@ int wp_encrypt_key(WOLFPROV_CTX* provCtx, const char* cipherName,
     unsigned char* keyData, size_t* keyLen, word32 pkcs8Len,
     OSSL_PASSPHRASE_CALLBACK *pwCb, void *pwCbArg, byte** cipherInfo);
 
-int wp_read_der_bio(OSSL_CORE_BIO *coreBio, unsigned char** data, word32* len);
-BIO* wp_corebio_get_bio(OSSL_CORE_BIO *coreBio);
+int wp_read_der_bio(WOLFPROV_CTX* provCtx, OSSL_CORE_BIO *coreBio, unsigned char** data, word32* len);
+BIO* wp_corebio_get_bio(WOLFPROV_CTX* provCtx, OSSL_CORE_BIO *coreBio);
 
 byte wp_ct_byte_mask_eq(byte a, byte b);
 byte wp_ct_byte_mask_ne(byte a, byte b);

--- a/include/wolfprovider/wp_logging.h
+++ b/include/wolfprovider/wp_logging.h
@@ -129,6 +129,9 @@ int wolfProv_SetLogComponents(int componentMask);
 
 #ifdef WOLFPROV_DEBUG
 
+#define WOLFPROV_STRINGIZE_HELPER(x) #x
+#define WOLFPROV_STRINGIZE(x) WOLFPROV_STRINGIZE_HELPER(x)
+
 #define WOLFPROV_ERROR(type, err)                                           \
     WOLFPROV_ERROR_LINE(type, err, __FILE__, __LINE__)
 #define WOLFPROV_ERROR_MSG(type, msg)                                       \

--- a/include/wolfprovider/wp_wolfprov.h
+++ b/include/wolfprovider/wp_wolfprov.h
@@ -23,7 +23,9 @@
 #ifndef WP_WOLFPROV_H
 #define WP_WOLFPROV_H
 
-const char* wolfprovider_id = "libwolfprov";
+extern const char* wolfprovider_id;
+
+int wolfssl_prov_bio_up_ref(OSSL_CORE_BIO *bio);
 
 /* Prototype of public function that initializes the wolfSSL provider. */
 OSSL_provider_init_fn wolfssl_provider_init;

--- a/src/wp_aes_aead.c
+++ b/src/wp_aes_aead.c
@@ -288,6 +288,7 @@ static int wp_aead_cache_aad(wp_AeadCtx *ctx, const unsigned char *in,
         ctx->aadSet = 1;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 #endif
@@ -320,6 +321,7 @@ static int wp_aead_cache_in(wp_AeadCtx *ctx, const unsigned char *in,
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 #endif
@@ -423,6 +425,7 @@ static int wp_aead_get_ctx_params(wp_AeadCtx* ctx, OSSL_PARAM params[])
     }
 #endif
 
+    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -459,6 +462,7 @@ static int wp_aead_set_param_tag(wp_AeadCtx* ctx,
         ctx->tagLen = sz;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -490,6 +494,7 @@ static int wp_aead_set_param_iv_len(wp_AeadCtx* ctx,
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -522,6 +527,7 @@ static int wp_aead_set_param_tls1_aad(wp_AeadCtx* ctx,
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -560,6 +566,7 @@ static int wp_aead_set_param_tls1_iv_fixed(wp_AeadCtx* ctx,
     #endif
     }
 
+    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -591,6 +598,7 @@ static int wp_aead_set_param_tls1_iv_rand(wp_AeadCtx* ctx,
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 #else
     (void)ctx;
@@ -630,6 +638,7 @@ static int wp_aead_set_ctx_params(wp_AeadCtx* ctx, const OSSL_PARAM params[])
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -720,6 +729,7 @@ static int wp_aead_get_params(OSSL_PARAM params[], unsigned int md,
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -843,6 +853,7 @@ static int wp_aesgcm_get_rand_iv(wp_AeadCtx* ctx, unsigned char* out,
         ctx->ivState = IV_STATE_COPIED;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -871,6 +882,7 @@ static int wp_aesgcm_set_rand_iv(wp_AeadCtx *ctx, unsigned char *in,
         ctx->ivState = IV_STATE_COPIED;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -931,6 +943,7 @@ static int wp_aesgcm_tls_iv_set_fixed(wp_AeadCtx* ctx, unsigned char* iv,
         ctx->ivState = IV_STATE_BUFFERED;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1007,6 +1020,7 @@ static int wp_aesgcm_einit(wp_AeadCtx* ctx, const unsigned char *key,
         ok = wp_aead_set_ctx_params(ctx, params);
     }
 
+    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1068,6 +1082,7 @@ static int wp_aesgcm_dinit(wp_AeadCtx *ctx, const unsigned char *key,
         ok = wp_aead_set_ctx_params(ctx, params);
     }
 
+    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1150,6 +1165,7 @@ static int wp_aesgcm_tls_cipher(wp_AeadCtx* ctx, unsigned char* out,
     ctx->ivState = IV_STATE_FINISHED;
     ctx->tlsAadLen = UNINITIALISED_SIZET;
     *outLen = oLen;
+    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1216,6 +1232,7 @@ static int wp_aesgcm_stream_update(wp_AeadCtx *ctx, unsigned char *out,
         *outLen = oLen;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1273,6 +1290,7 @@ static int wp_aesgcm_stream_final(wp_AeadCtx *ctx, unsigned char *out,
         *outLen = 0;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1346,6 +1364,7 @@ static int wp_aesgcm_encdec(wp_AeadCtx *ctx, unsigned char *out, size_t* outLen)
     ctx->in = NULL;
     ctx->inLen = 0;
 
+    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1395,6 +1414,7 @@ static int wp_aesgcm_stream_update(wp_AeadCtx *ctx, unsigned char *out,
         *outLen = oLen;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1425,6 +1445,7 @@ static int wp_aesgcm_stream_final(wp_AeadCtx *ctx, unsigned char *out,
         ctx->ivSet = 0;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1462,6 +1483,7 @@ static int wp_aesgcm_cipher(wp_AeadCtx *ctx, unsigned char *out,
         *outLen += finalLen;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1542,6 +1564,7 @@ static int wp_aesccm_tls_iv_set_fixed(wp_AeadCtx* ctx, unsigned char* iv,
         memcpy(ctx->iv, iv, len);
     }
 
+    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1590,6 +1613,7 @@ static int wp_aesccm_init(wp_AeadCtx* ctx, const unsigned char *key,
         ok = wp_aead_set_ctx_params(ctx, params);
     }
 
+    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1706,6 +1730,7 @@ static int wp_aesccm_tls_cipher(wp_AeadCtx* ctx, unsigned char* out,
     }
 
     *outLen = olen;
+    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1767,6 +1792,7 @@ static int wp_aesccm_encdec(wp_AeadCtx *ctx, unsigned char *out,
     ctx->aadLen = 0;
     ctx->aadSet = 0;
 
+    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 /**
@@ -1822,6 +1848,7 @@ static int wp_aesccm_stream_update(wp_AeadCtx *ctx, unsigned char *out,
         *outLen = (size_t)oLen;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1857,6 +1884,7 @@ static int wp_aesccm_stream_final(wp_AeadCtx *ctx, unsigned char *out,
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1892,6 +1920,7 @@ static int wp_aesccm_cipher(wp_AeadCtx *ctx, unsigned char *out,
         *outLen += finalLen;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 

--- a/src/wp_aes_block.c
+++ b/src/wp_aes_block.c
@@ -181,6 +181,7 @@ static int wp_aes_block_get_params(OSSL_PARAM params[], unsigned int mode,
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -266,6 +267,7 @@ static int wp_aes_init_iv(wp_AesBlockCtx *ctx, const unsigned char *iv,
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 #endif
@@ -329,6 +331,7 @@ static int wp_aes_block_init(wp_AesBlockCtx *ctx, const unsigned char *key,
         ok = wp_aes_block_set_ctx_params(ctx, params);
     }
 
+    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -516,6 +519,7 @@ static int wp_aes_block_update(wp_AesBlockCtx *ctx, unsigned char *out,
         ok = invalid == 0;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -564,6 +568,7 @@ static int wp_aes_block_final_enc(wp_AesBlockCtx* ctx, unsigned char *out,
         ctx->bufSz = 0;
         *outLen = oLen;
     }
+    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -629,6 +634,7 @@ static int wp_aes_block_final_dec(wp_AesBlockCtx* ctx, unsigned char *out,
         *outLen = 0;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -660,6 +666,7 @@ static int wp_aes_block_final(wp_AesBlockCtx* ctx, unsigned char *out,
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -693,6 +700,7 @@ static int wp_aes_block_cipher(wp_AesBlockCtx* ctx, unsigned char* out,
         *outLen = inLen;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -748,6 +756,7 @@ static int wp_aes_block_get_ctx_params(wp_AesBlockCtx* ctx, OSSL_PARAM params[])
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -794,6 +803,7 @@ static int wp_aes_block_set_ctx_params(wp_AesBlockCtx *ctx,
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 

--- a/src/wp_aes_stream.c
+++ b/src/wp_aes_stream.c
@@ -171,6 +171,7 @@ static int wp_aes_stream_get_params(OSSL_PARAM params[], unsigned int mode,
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -245,6 +246,7 @@ static int wp_aes_init_iv(wp_AesStreamCtx *ctx, const unsigned char *iv,
         XMEMCPY(ctx->oiv, iv, ivLen);
     }
 
+    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -303,6 +305,7 @@ static int wp_aes_stream_init(wp_AesStreamCtx *ctx, const unsigned char *key,
         ok = wp_aes_stream_set_ctx_params(ctx, params);
     }
 
+    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -394,6 +397,7 @@ static int wp_aes_stream_doit(wp_AesStreamCtx *ctx, unsigned char *out,
 #endif
     {}
 
+    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -424,6 +428,7 @@ static int wp_aes_stream_update(wp_AesStreamCtx *ctx, unsigned char *out,
         *outLen = inLen;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -476,6 +481,7 @@ static int wp_aes_stream_cipher(wp_AesStreamCtx* ctx, unsigned char* out,
     }
 
     *outLen = inLen;
+    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -526,6 +532,7 @@ static int wp_aes_stream_get_ctx_params(wp_AesStreamCtx* ctx,
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -560,6 +567,7 @@ static int wp_aes_stream_set_ctx_params(wp_AesStreamCtx *ctx,
         (void)val;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 

--- a/src/wp_aes_wrap.c
+++ b/src/wp_aes_wrap.c
@@ -168,6 +168,7 @@ static int wp_aes_wrap_get_params(OSSL_PARAM params[], unsigned int mode,
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -276,6 +277,7 @@ static int wp_aes_wrap_init(wp_AesWrapCtx *ctx, const unsigned char *key,
         ok = wp_aes_wrap_set_ctx_params(ctx, params);
     }
 
+    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -388,6 +390,7 @@ static int wp_aes_wrap_update(wp_AesWrapCtx *ctx, unsigned char *out,
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -417,6 +420,7 @@ static int wp_aes_wrap_final(wp_AesWrapCtx* ctx, unsigned char *out,
         *outLen = 0;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -459,6 +463,7 @@ static int wp_aes_wrap_get_ctx_params(wp_AesWrapCtx* ctx, OSSL_PARAM params[])
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -496,6 +501,7 @@ static int wp_aes_wrap_set_ctx_params(wp_AesWrapCtx *ctx,
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 

--- a/src/wp_cmac.c
+++ b/src/wp_cmac.c
@@ -137,6 +137,7 @@ static int wp_cmac_set_key(wp_CmacCtx* macCtx, const unsigned char* key,
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_MAC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -199,6 +200,7 @@ static int wp_cmac_init(wp_CmacCtx* macCtx, const unsigned char* key,
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_MAC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -222,6 +224,7 @@ static int wp_cmac_update(wp_CmacCtx* macCtx, const unsigned char* data,
         ok = 0;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_MAC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -260,6 +263,7 @@ static int wp_cmac_final(wp_CmacCtx* macCtx, unsigned char* out, size_t* outl,
         *outl = outSz;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_MAC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -311,6 +315,7 @@ static int wp_cmac_get_ctx_params(wp_CmacCtx* macCtx, OSSL_PARAM params[])
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_MAC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -398,6 +403,7 @@ static int wp_cmac_setup_cipher(wp_CmacCtx* macCtx, const OSSL_PARAM params[])
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_MAC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -423,6 +429,7 @@ static int wp_cmac_set_param_key(wp_CmacCtx* macCtx, const OSSL_PARAM params[])
         ok = 0;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_MAC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -447,6 +454,7 @@ static int wp_cmac_set_ctx_params(wp_CmacCtx* macCtx, const OSSL_PARAM params[])
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_MAC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 

--- a/src/wp_dec_epki2pki.c
+++ b/src/wp_dec_epki2pki.c
@@ -31,11 +31,13 @@
 
 #include <wolfssl/wolfcrypt/asn_public.h>
 
-/* Dummy type for EPKI to PKI context. */
-typedef void wp_Epki2Pki;
-
-/* A fake static global context. */
-static unsigned char fakeCtx[1];
+/**
+ * EPKI to PKI context.
+ */
+typedef struct wp_Epki2Pki {
+    /** Provider context - useful when duplicating. */
+    WOLFPROV_CTX* provCtx;
+} wp_Epki2Pki;
 
 /**
  * Create a new EPKI to PKI context.
@@ -47,20 +49,26 @@ static unsigned char fakeCtx[1];
  */
 static wp_Epki2Pki* wp_epki2pki_newctx(WOLFPROV_CTX* provCtx)
 {
-    (void)provCtx;
-    return fakeCtx;
+    wp_Epki2Pki* ctx = NULL;
+
+    if (wolfssl_prov_is_running()) {
+        ctx = (wp_Epki2Pki*)OPENSSL_zalloc(sizeof(*ctx));
+    }
+    if (ctx != NULL) {
+        ctx->provCtx = provCtx;
+    }
+
+    return ctx;
 }
 
 /**
  * Dispose of EPKI to PKI context.
  *
- * Nothing to do as it is a global context.
- *
- * @param [in] ctx  EPKI to PKI context. Unused.
+ * @param [in] ctx  EPKI to PKI context.
  */
 static void wp_epki2pki_freectx(wp_Epki2Pki* ctx)
 {
-    (void)ctx;
+    OPENSSL_free(ctx);
 }
 
 #if LIBWOLFSSL_VERSION_HEX < 0x05000000

--- a/src/wp_dec_epki2pki.c
+++ b/src/wp_dec_epki2pki.c
@@ -231,6 +231,7 @@ static int wp_epki2pki_decode(wp_Epki2Pki* ctx, OSSL_CORE_BIO* coreBio,
     /* Dispose of the EPKI data buffer. */
     OPENSSL_free(data);
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 

--- a/src/wp_dec_epki2pki.c
+++ b/src/wp_dec_epki2pki.c
@@ -197,7 +197,7 @@ static int wp_epki2pki_decode(wp_Epki2Pki* ctx, OSSL_CORE_BIO* coreBio,
     (void)selection;
 
     /* Read the data from the BIO into buffer that is allocated on the fly. */
-    if (!wp_read_der_bio(coreBio, &data, &len)) {
+    if (!wp_read_der_bio(ctx->provCtx, coreBio, &data, &len)) {
         ok = 0;
     }
     /* No data - nothing to do. */

--- a/src/wp_dec_pem2der.c
+++ b/src/wp_dec_pem2der.c
@@ -391,7 +391,7 @@ static int wp_pem2der_decode(wp_Pem2Der* ctx, OSSL_CORE_BIO* coreBio,
     (void)selection;
 
     /* Read the data from the BIO into buffer that is allocated on the fly. */
-    if (!wp_read_der_bio(coreBio, &data, &len)) {
+    if (!wp_read_der_bio(ctx->provCtx, coreBio, &data, &len)) {
         ok = 0;
     }
     /* No data - nothing to do. */

--- a/src/wp_dec_pem2der.c
+++ b/src/wp_dec_pem2der.c
@@ -31,36 +31,42 @@
 
 #include <wolfssl/wolfcrypt/asn_public.h>
 
-/* Dummy type for PEM to DER context. */
-typedef void wp_Pem2Der;
-
-/* A fake static global context. */
-static unsigned char fakeCtx[1];
+/**
+ * PEM to DER context.
+ */
+typedef struct wp_Pem2Der {
+    /** Provider context - useful when duplicating. */
+    WOLFPROV_CTX* provCtx;
+} wp_Pem2Der;
 
 /**
  * Create a new PEM to DER context.
  *
- * No context data required so returning a global context.
- *
- * @param [in] provCtx  Provider context. Unused.
+ * @param [in] provCtx  Provider context.
  * @return  Pointer to context.
  */
 static wp_Pem2Der* wp_pem2der_newctx(WOLFPROV_CTX* provCtx)
 {
-    (void)provCtx;
-    return fakeCtx;
+    wp_Pem2Der* ctx = NULL;
+
+    if (wolfssl_prov_is_running()) {
+        ctx = (wp_Pem2Der*)OPENSSL_zalloc(sizeof(*ctx));
+    }
+    if (ctx != NULL) {
+        ctx->provCtx = provCtx;
+    }
+
+    return ctx;
 }
 
 /**
  * Dispose of PEM to DER context.
  *
- * Nothing to do as it is a global context.
- *
- * @param [in] ctx  PEM to DER context. Unused.
+ * @param [in] ctx  PEM to DER context.
  */
 static void wp_pem2der_freectx(wp_Pem2Der* ctx)
 {
-    (void)ctx;
+    OPENSSL_free(ctx);
 }
 
 /**

--- a/src/wp_dec_pem2der.c
+++ b/src/wp_dec_pem2der.c
@@ -171,6 +171,7 @@ static int wp_pem2der_ec_params(const char* data, word32 len, DerBuffer** pDer,
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -353,6 +354,7 @@ static int wp_pem2der_decode_data(const unsigned char* data, word32 len,
     /* Dispose of the DER data buffer now that callback has used it. */
     wc_FreeDer(&der);
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -404,6 +406,7 @@ static int wp_pem2der_decode(wp_Pem2Der* ctx, OSSL_CORE_BIO* coreBio,
     /* Dispose of the PEM data buffer. */
     OPENSSL_free(data);
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 

--- a/src/wp_dh_exch.c
+++ b/src/wp_dh_exch.c
@@ -195,6 +195,7 @@ static int wp_dh_init(wp_DhCtx* ctx, wp_Dh* dh, const OSSL_PARAM params[])
         ok = wp_dh_set_ctx_params(ctx, params);
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -239,6 +240,7 @@ static int wp_dh_kdf_derive(wp_DhCtx* ctx, unsigned char* key,
 #endif
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -294,6 +296,7 @@ static int wp_dh_derive_secret(wp_DhCtx* ctx, unsigned char* secret,
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -373,6 +376,7 @@ static int wp_dh_derive(wp_DhCtx* ctx, unsigned char* secret,
 
     OPENSSL_clear_free(tmp, maxLen);
 
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -434,6 +438,7 @@ static int wp_dh_set_peer(wp_DhCtx* ctx, wp_Dh* peer)
         ctx->peer = peer;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -467,6 +472,7 @@ static int wp_dh_set_param_kdf(wp_DhCtx* ctx, const OSSL_PARAM params[])
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -504,6 +510,7 @@ static int wp_dh_set_param_kdf_digest(wp_DhCtx* ctx, const OSSL_PARAM params[])
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -539,6 +546,7 @@ static int wp_dh_set_ctx_params(wp_DhCtx* ctx, const OSSL_PARAM params[])
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -593,6 +601,7 @@ static int wp_dh_get_params_kdf(wp_DhCtx* ctx, OSSL_PARAM params[])
          }
      }
 
+     WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
      return ok;
 }
 
@@ -636,6 +645,7 @@ static int wp_dh_get_ctx_params(wp_DhCtx* ctx, OSSL_PARAM params[])
          }
      }
 
+     WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
      return ok;
 }
 

--- a/src/wp_dh_kmgmt.c
+++ b/src/wp_dh_kmgmt.c
@@ -217,6 +217,7 @@ static int wp_dh_map_group_name(wp_Dh* dh, const char* name)
         ok = 0;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -271,6 +272,7 @@ int wp_dh_up_ref(wp_Dh* dh)
         wc_UnLockMutex(&dh->mutex);
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 #else
     dh->refCnt++;
@@ -324,6 +326,7 @@ int wp_dh_get_priv(wp_Dh* dh, unsigned char** priv, word32* privSz)
         *privSz = (word32)dh->privSz;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -351,6 +354,7 @@ int wp_dh_get_pub(wp_Dh* dh, unsigned char** pub, word32* pubSz)
         *pubSz = (word32)dh->pubSz;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -471,6 +475,7 @@ static int wp_dh_copy_params(const wp_Dh *src, wp_Dh *dst)
         dst->bits = src->bits;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -605,6 +610,7 @@ static int wp_dh_set_params(wp_Dh *dh, const OSSL_PARAM params[])
         ok = 0;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -695,6 +701,7 @@ static int wp_dh_get_params_encoded_public_key(wp_Dh* dh, OSSL_PARAM params[])
         p->return_size = outLen;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -743,6 +750,7 @@ static int wp_dh_get_params(wp_Dh* dh, OSSL_PARAM params[])
         ok = 0;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -774,6 +782,7 @@ static int wp_dh_has(const wp_Dh* dh, int selection)
         ok &= (dh->id != 0) || (!mp_iszero((mp_int*)&dh->key.p));
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -816,6 +825,7 @@ int wp_dh_match(const wp_Dh* dh1, const wp_Dh* dh2, int selection)
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -852,6 +862,7 @@ static int wp_dh_validate_pub_key_quick(const wp_Dh* dh)
     }
     OPENSSL_free(prime);
 
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 #endif
@@ -900,6 +911,7 @@ static int wp_dh_validate(const wp_Dh* dh, int selection, int checkType)
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -952,6 +964,7 @@ static int wp_dh_import_group(wp_Dh* dh, const OSSL_PARAM params[])
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -978,6 +991,7 @@ static int wp_dh_import_keypair(wp_Dh* dh, const OSSL_PARAM params[],
         ok = 0;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1013,6 +1027,7 @@ static int wp_dh_import(wp_Dh* dh, int selection, const OSSL_PARAM params[])
         ok = 0;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1172,6 +1187,7 @@ static int wp_dh_export_group(wp_Dh* dh, OSSL_PARAM params[], int* pIdx,
     }
 
     *pIdx = i;
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1217,6 +1233,7 @@ static int wp_dh_export_keypair(wp_Dh* dh, OSSL_PARAM params[], int* pIdx,
     }
 
     *pIdx = i;
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1272,6 +1289,7 @@ static int wp_dh_export(wp_Dh *dh, int selection, OSSL_CALLBACK *paramCb,
     }
     OPENSSL_secure_clear_free(data, sz);
 
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1381,6 +1399,7 @@ static int wp_dh_gen_set_template(wp_DhGenCtx* ctx, const wp_Dh* dh)
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1418,6 +1437,7 @@ static int wp_dh_gen_set_params(wp_DhGenCtx* ctx, const OSSL_PARAM params[])
         ok = 0;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1439,6 +1459,7 @@ static int wp_dh_gen_parameters(wp_DhGenCtx *ctx, wp_Dh* dh)
         ok = 0;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1486,6 +1507,7 @@ static int wp_dh_gen_copy_parameters(wp_DhGenCtx *ctx, wp_Dh* dh)
         ok = 0;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1563,6 +1585,7 @@ static int wp_dh_gen_keypair(wp_DhGenCtx *ctx, wp_Dh* dh)
         dh->privSz = privSz;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1617,6 +1640,7 @@ static int wp_dh_params_validate(wp_Dh* dh)
         mp_clear(&t);
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1841,6 +1865,7 @@ static int wp_dh_enc_dec_set_ctx_params(wp_DhEncDecCtx* ctx,
         ok = 0;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1884,6 +1909,7 @@ static int wp_dh_decode_spki(wp_Dh* dh, unsigned char* data, word32 len)
         dh->bits = mp_count_bits(&dh->key.p);
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 #else
@@ -1971,6 +1997,7 @@ static int wp_dh_decode_pki(wp_Dh* dh, unsigned char* data, word32 len)
     }
 
     OPENSSL_free(base);
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 #else
@@ -2015,6 +2042,7 @@ static int wp_dh_decode_params(wp_Dh* dh, unsigned char* data, word32 len)
         dh->bits = mp_count_bits(&dh->key.p);
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -2048,6 +2076,7 @@ static int wp_dh_dec_send_params(wp_Dh* dh, OSSL_CALLBACK *dataCb,
         ok = 0;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -2128,6 +2157,7 @@ static int wp_dh_decode(wp_DhEncDecCtx* ctx, OSSL_CORE_BIO *cBio,
             ok = 1;
         }
     }
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -2154,6 +2184,7 @@ static int wp_dh_encode_params_size(const wp_Dh *dh, size_t* keyLen)
         *keyLen = len;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -2182,6 +2213,7 @@ static int wp_dh_encode_params(const wp_Dh *dh, unsigned char* keyData,
         *keyLen = len;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -2207,6 +2239,7 @@ static int wp_dh_encode_spki_size(const wp_Dh *dh, size_t* keyLen)
         *keyLen = len;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -2239,6 +2272,7 @@ static int wp_dh_encode_spki(const wp_Dh *dh, unsigned char* keyData,
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -2264,6 +2298,7 @@ static int wp_dh_encode_pki_size(const wp_Dh *dh, size_t* keyLen)
         *keyLen = len;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -2296,6 +2331,7 @@ static int wp_dh_encode_pki(const wp_Dh *dh, unsigned char* keyData,
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -2323,6 +2359,7 @@ static int wp_dh_encode_epki_size(const wp_Dh *dh, size_t* keyLen)
         *keyLen = ((len + 15) / 16) * 16;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -2358,6 +2395,7 @@ static int wp_dh_encode_epki(const wp_DhEncDecCtx* ctx, const wp_Dh *dh,
         ok = 0;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 #endif
@@ -2517,6 +2555,7 @@ static int wp_dh_encode(wp_DhEncDecCtx* ctx, OSSL_CORE_BIO *cBio,
     (void)pwCbArg;
 #endif
 
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -2578,6 +2617,7 @@ static int wp_dh_type_specific_does_selection(WOLFPROV_CTX* provCtx,
         ok = (selection & OSSL_KEYMGMT_SELECT_ALL_PARAMETERS) != 0;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -2691,6 +2731,7 @@ static int wp_dh_spki_does_selection(WOLFPROV_CTX* provCtx, int selection)
         ok = (selection & OSSL_KEYMGMT_SELECT_PUBLIC_KEY) != 0;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -2799,6 +2840,7 @@ static int wp_dh_pki_does_selection(WOLFPROV_CTX* provCtx, int selection)
         ok = (selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY) != 0;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 

--- a/src/wp_dh_kmgmt.c
+++ b/src/wp_dh_kmgmt.c
@@ -2114,7 +2114,7 @@ static int wp_dh_decode(wp_DhEncDecCtx* ctx, OSSL_CORE_BIO *cBio,
     if (dh == NULL) {
         ok = 0;
     }
-    if (ok && (!wp_read_der_bio(cBio, &data, &len))) {
+    if (ok && (!wp_read_der_bio(ctx->provCtx, cBio, &data, &len))) {
         ok = 0;
     }
     if (ok && (ctx->format == WP_ENC_FORMAT_TYPE_SPECIFIC)) {
@@ -2421,7 +2421,7 @@ static int wp_dh_encode(wp_DhEncDecCtx* ctx, OSSL_CORE_BIO *cBio,
     int ok = 1;
 #if (LIBWOLFSSL_VERSION_HEX >= 0x05000000 && defined(WOLFSSL_DH_EXTRA))
     int rc;
-    BIO* out = wp_corebio_get_bio(cBio);
+    BIO* out = wp_corebio_get_bio(ctx->provCtx, cBio);
     unsigned char* keyData = NULL;
     size_t keyLen;
     unsigned char* derData = NULL;

--- a/src/wp_digests.c
+++ b/src/wp_digests.c
@@ -132,6 +132,7 @@ static int name##_init(CTX* ctx, const OSSL_PARAM params[])                    \
             ok = 0;                                                            \
         }                                                                      \
     }                                                                          \
+    WOLFPROV_LEAVE(WP_LOG_DIGEST, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);\
     return ok;                                                                 \
 }                                                                              \
 
@@ -153,6 +154,7 @@ static int name##_update(void* ctx, const unsigned char* in, size_t inLen)     \
     if (rc != 0) {                                                             \
         ok = 0;                                                                \
     }                                                                          \
+    WOLFPROV_LEAVE(WP_LOG_DIGEST, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);\
     return ok;                                                                 \
 }
 
@@ -187,6 +189,7 @@ static int name##_final(void* ctx, unsigned char* out, size_t* outLen,         \
             *outLen = dgstSize;                                                \
         }                                                                      \
     }                                                                          \
+    WOLFPROV_LEAVE(WP_LOG_DIGEST, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);\
     return ok;                                                                 \
 }
 
@@ -259,6 +262,7 @@ static int wp_digest_get_params(OSSL_PARAM params[], size_t blkSize,
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_DIGEST, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -552,6 +556,7 @@ static int name##_init(CTX* ctx, const OSSL_PARAM params[])                    \
     if (ok && (!wp_##alg##_set_ctx_params(ctx, params))) {                     \
         ok = 0;                                                                \
     }                                                                          \
+    WOLFPROV_LEAVE(WP_LOG_DIGEST, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);\
     return ok;                                                                 \
 }                                                                              \
 
@@ -586,6 +591,7 @@ static int name##_final(CTX* ctx, unsigned char* out, size_t* outLen,          \
            *outLen = ctx->outLen;                                             \
         }                                                                      \
     }                                                                          \
+    WOLFPROV_LEAVE(WP_LOG_DIGEST, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);\
     return ok;                                                                 \
 }
 
@@ -654,6 +660,7 @@ static int name##_set_ctx_params(CTX* ctx, const OSSL_PARAM params[])          \
                 OSSL_DIGEST_PARAM_XOFLEN, &ctx->outLen))) {                    \
         ok = 0;                                                                \
     }                                                                          \
+    WOLFPROV_LEAVE(WP_LOG_DIGEST, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);\
     return ok;                                                                 \
 }
 

--- a/src/wp_drbg.c
+++ b/src/wp_drbg.c
@@ -148,6 +148,7 @@ static int wp_drbg_instantiate(wp_DrbgCtx* ctx, unsigned int strength,
     #endif
     }
 
+    WOLFPROV_LEAVE(WP_LOG_RNG, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -210,6 +211,7 @@ static int wp_drbg_generate(wp_DrbgCtx* ctx, unsigned char* out,
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_RNG, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -256,6 +258,7 @@ static int wp_drbg_reseed(wp_DrbgCtx* ctx, int predResist,
 
     (void)predResist;
 
+    WOLFPROV_LEAVE(WP_LOG_RNG, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -286,6 +289,7 @@ static int wp_drbg_enable_locking(wp_DrbgCtx* ctx)
     }
 #endif
 
+    WOLFPROV_LEAVE(WP_LOG_RNG, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -310,6 +314,7 @@ static int wp_drbg_lock(wp_DrbgCtx* ctx)
     }
 #endif
 
+    WOLFPROV_LEAVE(WP_LOG_RNG, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -378,6 +383,7 @@ static int wp_drbg_get_ctx_params(wp_DrbgCtx* ctx, OSSL_PARAM params[])
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_RNG, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -480,6 +486,7 @@ static size_t wp_drbg_get_seed(wp_DrbgCtx* ctx, unsigned char** pSeed,
         OPENSSL_secure_free(buffer);
     }
 
+    WOLFPROV_LEAVE(WP_LOG_RNG, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 

--- a/src/wp_ecc_kmgmt.c
+++ b/src/wp_ecc_kmgmt.c
@@ -151,6 +151,7 @@ static int wp_ecc_map_group_name(wp_Ecc* ecc, const char* name)
         ok = 0;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -198,6 +199,7 @@ static int wp_ecc_set_bits(wp_Ecc* ecc)
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -250,6 +252,7 @@ int wp_ecc_up_ref(wp_Ecc* ecc)
         wc_UnLockMutex(&ecc->mutex);
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 #else
     ecc->refCnt++;
@@ -530,6 +533,7 @@ static int wp_ecc_set_params_x_y(wp_Ecc *ecc, const OSSL_PARAM params[])
         ecc->hasPub = 1;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -563,6 +567,7 @@ static int wp_ecc_set_params_enc_pub_key(wp_Ecc *ecc, const OSSL_PARAM params[],
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -602,6 +607,7 @@ static int wp_ecc_set_params(wp_Ecc *ecc, const OSSL_PARAM params[])
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -695,6 +701,7 @@ static int wp_ecc_get_params_enc_pub_key(wp_Ecc* ecc, OSSL_PARAM params[],
         p->return_size = outLen;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -793,6 +800,7 @@ static int wp_ecc_get_params(wp_Ecc* ecc, OSSL_PARAM params[])
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -823,6 +831,7 @@ static int wp_ecc_has(const wp_Ecc* ecc, int selection)
             ok &= ecc->curveId != 0;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -862,6 +871,7 @@ static int wp_ecc_match(wp_Ecc* ecc1, wp_Ecc* ecc2, int selection)
         ok = 0;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -889,6 +899,7 @@ static int wp_ecc_validate_public_key_quick(const wp_Ecc* ecc)
     }
 #endif
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 #endif
@@ -949,6 +960,7 @@ static int wp_ecc_validate(const wp_Ecc* ecc, int selection, int checkType)
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -985,6 +997,7 @@ static int wp_ecc_import_group(wp_Ecc* ecc, const OSSL_PARAM params[])
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1028,6 +1041,7 @@ static int wp_ecc_import_keypair(wp_Ecc* ecc, const OSSL_PARAM params[],
         ecc->hasPriv = 1;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1058,6 +1072,7 @@ static int wp_ecc_import_other(wp_Ecc* ecc, const OSSL_PARAM params[])
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1099,6 +1114,7 @@ static int wp_ecc_import(wp_Ecc* ecc, int selection, const OSSL_PARAM params[])
         ok = 0;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1262,6 +1278,7 @@ static int wp_ecc_export_params(wp_Ecc* ecc, OSSL_PARAM* params, int* pIdx)
         wp_ecc_get_group_name(ecc));
 
     *pIdx = i;
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1333,6 +1350,7 @@ static int wp_ecc_export_keypair(wp_Ecc* ecc, OSSL_PARAM* params, int* pIdx,
     }
 
     *pIdx = i;
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1356,6 +1374,7 @@ static int wp_ecc_export_other(wp_Ecc* ecc, OSSL_PARAM* params, int* pIdx)
         &ecc->includePublic);
 
     *pIdx = i;
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1419,6 +1438,7 @@ static int wp_ecc_export(wp_Ecc *ecc, int selection, OSSL_CALLBACK *paramCb,
     }
     OPENSSL_clear_free(data, len);
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1525,6 +1545,7 @@ static int wp_ecc_gen_set_template(wp_EccGenCtx* ctx, wp_Ecc* ecc)
         ctx->curveName[sizeof(ctx->curveName)-1] = '\0';
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1550,6 +1571,7 @@ static int wp_ecc_gen_set_params(wp_EccGenCtx* ctx, const OSSL_PARAM params[])
         ok = 0;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1771,6 +1793,7 @@ static int wp_ecc_enc_dec_set_ctx_params(wp_EccEncDecCtx* ctx,
         ok = 0;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1875,6 +1898,7 @@ static int wp_ecc_decode_params(wp_Ecc* ecc, unsigned char* data, word32 len)
         ok = 0;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1906,6 +1930,7 @@ static int wp_ecc_decode_spki(wp_Ecc* ecc, unsigned char* data, word32 len)
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1951,6 +1976,7 @@ static int wp_ecc_decode_pki(wp_Ecc* ecc, unsigned char* data, word32 len)
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1984,6 +2010,7 @@ static int wp_ecc_dec_send_params(wp_Ecc* ecc, OSSL_CALLBACK *dataCb,
         ok = 0;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -2064,6 +2091,7 @@ static int wp_ecc_decode(wp_EccEncDecCtx* ctx, OSSL_CORE_BIO *cBio,
             ok = 1;
         }
     }
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -2139,6 +2167,7 @@ static int wp_ecc_encode_priv_size(const wp_Ecc *ecc, size_t* keyLen)
     }
 #endif
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -2167,6 +2196,7 @@ static int wp_ecc_encode_priv(const wp_Ecc *ecc, unsigned char* keyData,
         *keyLen = rc;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -2191,6 +2221,7 @@ static int wp_ecc_encode_spki_size(const wp_Ecc *ecc, size_t* keyLen)
         *keyLen = rc;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -2219,6 +2250,7 @@ static int wp_ecc_encode_spki(const wp_Ecc *ecc, unsigned char* keyData,
         *keyLen = rc;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -2244,6 +2276,7 @@ static int wp_ecc_encode_pki_size(const wp_Ecc *ecc, size_t* keyLen)
         *keyLen = len;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -2273,6 +2306,7 @@ static int wp_ecc_encode_pki(const wp_Ecc *ecc, unsigned char* keyData,
         *keyLen = len;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -2299,6 +2333,7 @@ static int wp_ecc_encode_epki_size(const wp_Ecc *ecc, size_t* keyLen)
         *keyLen = ((len + 15) / 16) * 16;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -2334,6 +2369,7 @@ static int wp_ecc_encode_epki(const wp_EccEncDecCtx* ctx, const wp_Ecc *ecc,
         ok = 0;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 #endif
@@ -2504,6 +2540,7 @@ static int wp_ecc_encode(wp_EccEncDecCtx* ctx, OSSL_CORE_BIO *cBio,
         OPENSSL_free(pemData);
     }
     OPENSSL_free(cipherInfo);
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -2564,6 +2601,7 @@ static int wp_ecc_type_specific_does_selection(WOLFPROV_CTX* provCtx,
         ok = (selection & OSSL_KEYMGMT_SELECT_ALL_PARAMETERS) != 0;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -2678,6 +2716,7 @@ static int wp_ecc_spki_does_selection(WOLFPROV_CTX* provCtx, int selection)
         ok = (selection & OSSL_KEYMGMT_SELECT_PUBLIC_KEY) != 0;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -2786,6 +2825,7 @@ static int wp_ecc_pki_does_selection(WOLFPROV_CTX* provCtx, int selection)
         ok = (selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY) != 0;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 

--- a/src/wp_ecc_kmgmt.c
+++ b/src/wp_ecc_kmgmt.c
@@ -2048,7 +2048,7 @@ static int wp_ecc_decode(wp_EccEncDecCtx* ctx, OSSL_CORE_BIO *cBio,
     if (ecc == NULL) {
         ok = 0;
     }
-    if (ok && (!wp_read_der_bio(cBio, &data, &len))) {
+    if (ok && (!wp_read_der_bio(ctx->provCtx, cBio, &data, &len))) {
         ok = 0;
     }
     if (ok && (ctx->format == WP_ENC_FORMAT_TYPE_SPECIFIC)) {
@@ -2393,7 +2393,7 @@ static int wp_ecc_encode(wp_EccEncDecCtx* ctx, OSSL_CORE_BIO *cBio,
 {
     int ok = 1;
     int rc;
-    BIO* out = wp_corebio_get_bio(cBio);
+    BIO* out = wp_corebio_get_bio(ctx->provCtx, cBio);
     unsigned char* keyData = NULL;
     size_t keyLen;
     unsigned char* derData = NULL;

--- a/src/wp_ecdh_exch.c
+++ b/src/wp_ecdh_exch.c
@@ -196,6 +196,7 @@ static int wp_ecdh_init(wp_EcdhCtx* ctx, wp_Ecc* ecc, const OSSL_PARAM params[])
         ok = wp_ecdh_set_ctx_params(ctx, params);
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -239,6 +240,7 @@ static int wp_ecdh_kdf_derive(wp_EcdhCtx* ctx, unsigned char* key,
 #endif
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -278,6 +280,7 @@ static int wp_ecdh_derive_secret(wp_EcdhCtx* ctx, unsigned char* secret,
         *secLen = len;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -348,6 +351,7 @@ static int wp_ecdh_derive(wp_EcdhCtx* ctx, unsigned char* secret,
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -378,6 +382,7 @@ static int wp_ecdh_set_peer(wp_EcdhCtx* ctx, wp_Ecc* peer)
         ctx->peer = peer;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -411,6 +416,7 @@ static int wp_ecdh_set_param_kdf(wp_EcdhCtx* ctx, const OSSL_PARAM params[])
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -449,6 +455,7 @@ static int wp_ecdh_set_param_kdf_digest(wp_EcdhCtx* ctx,
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -488,6 +495,7 @@ static int wp_ecdh_set_ctx_params(wp_EcdhCtx* ctx, const OSSL_PARAM params[])
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -542,6 +550,7 @@ static int wp_ecdh_get_params_kdf(wp_EcdhCtx* ctx, OSSL_PARAM params[])
          }
      }
 
+     WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
      return ok;
 }
 
@@ -585,6 +594,7 @@ static int wp_ecdh_get_ctx_params(wp_EcdhCtx* ctx, OSSL_PARAM params[])
          }
      }
 
+     WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
      return ok;
 }
 

--- a/src/wp_ecdsa_sig.c
+++ b/src/wp_ecdsa_sig.c
@@ -193,6 +193,7 @@ static int wp_ecdsa_signverify_init(wp_EcdsaSigCtx *ctx, wp_Ecc* ecc,
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -217,6 +218,7 @@ static int wp_ecdsa_sign_init(wp_EcdsaSigCtx *ctx, wp_Ecc *ecc,
         ok = wp_ecdsa_signverify_init(ctx, ecc, params, EVP_PKEY_OP_SIGN);
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -272,6 +274,7 @@ static int wp_ecdsa_sign(wp_EcdsaSigCtx *ctx, unsigned char *sig,
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -296,6 +299,7 @@ static int wp_ecdsa_verify_init(wp_EcdsaSigCtx *ctx, wp_Ecc *ecc,
         ok = wp_ecdsa_signverify_init(ctx, ecc, params, EVP_PKEY_OP_VERIFY);
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -330,6 +334,7 @@ static int wp_ecdsa_verify(wp_EcdsaSigCtx *ctx, const unsigned char *sig,
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -355,6 +360,7 @@ static int wp_ecdsa_verify_recover_init(wp_EcdsaSigCtx *ctx, wp_Ecc *ecc,
             EVP_PKEY_OP_VERIFYRECOVER);
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -424,6 +430,7 @@ static int wp_ecdsa_setup_md(wp_EcdsaSigCtx *ctx, const char *mdName,
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -451,6 +458,7 @@ static int wp_ecdsa_digest_signverify_init(wp_EcdsaSigCtx *ctx,
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -471,6 +479,7 @@ static int wp_ecdsa_digest_signverify_update(wp_EcdsaSigCtx *ctx,
     if (rc != 0) {
         ok = 0;
     }
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -497,6 +506,7 @@ static int wp_ecdsa_digest_sign_init(wp_EcdsaSigCtx *ctx, const char *mdName,
             EVP_PKEY_OP_SIGN);
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -534,6 +544,7 @@ static int wp_ecdsa_digest_sign_final(wp_EcdsaSigCtx *ctx, unsigned char *sig,
             wc_HashGetDigestSize(ctx->hashType));
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -560,6 +571,7 @@ static int wp_ecdsa_digest_verify_init(wp_EcdsaSigCtx *ctx, const char *mdName,
             EVP_PKEY_OP_VERIFY);
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -593,6 +605,7 @@ static int wp_ecdsa_digest_verify_final(wp_EcdsaSigCtx *ctx, unsigned char *sig,
             wc_HashGetDigestSize(ctx->hashType));
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -643,6 +656,7 @@ static int wp_ecdsa_get_ctx_params(wp_EcdsaSigCtx *ctx, OSSL_PARAM *params)
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -699,6 +713,7 @@ static int wp_ecdsa_set_digest(wp_EcdsaSigCtx *ctx, const OSSL_PARAM *p,
         ok = wp_ecdsa_setup_md(ctx, mdName, pmdProps, ctx->op);
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -725,6 +740,7 @@ static int wp_ecdsa_set_ctx_params(wp_EcdsaSigCtx *ctx, const OSSL_PARAM params[
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 

--- a/src/wp_ecx_exch.c
+++ b/src/wp_ecx_exch.c
@@ -153,6 +153,7 @@ static int wp_ecx_init(wp_EcxCtx* ctx, wp_Ecx* ecx, const OSSL_PARAM params[])
         ctx->key = ecx;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -184,6 +185,7 @@ static int wp_ecx_set_peer(wp_EcxCtx* ctx, wp_Ecx* peer)
         ctx->peer = peer;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -264,6 +266,7 @@ static int wp_x25519_derive(wp_EcxCtx* ctx, unsigned char* secret,
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -333,6 +336,7 @@ static int wp_x448_derive(wp_EcxCtx* ctx, unsigned char* secret,
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 

--- a/src/wp_ecx_kmgmt.c
+++ b/src/wp_ecx_kmgmt.c
@@ -220,6 +220,7 @@ int wp_ecx_up_ref(wp_Ecx* ecx)
         wc_UnLockMutex(&ecx->mutex);
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 #else
     ecx->refCnt++;
@@ -412,6 +413,7 @@ static int wp_ecx_set_params(wp_Ecx* ecx, const OSSL_PARAM params[])
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -491,6 +493,7 @@ static int wp_ecx_get_params_enc_pub_key(wp_Ecx* ecx, OSSL_PARAM params[],
         p->return_size = outLen;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -524,6 +527,7 @@ static int wp_ecx_get_params_priv_key(wp_Ecx* ecx, OSSL_PARAM params[])
         p->return_size = outLen;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -569,6 +573,7 @@ static int wp_ecx_get_params(wp_Ecx* ecx, OSSL_PARAM params[])
         ok = 0;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -597,6 +602,7 @@ static int wp_ecx_has(const wp_Ecx* ecx, int selection)
             ok &= ecx->hasPriv;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -641,6 +647,7 @@ static int wp_ecx_match_priv_key(const wp_Ecx* ecx1, const wp_Ecx* ecx2)
         ok = 0;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -687,6 +694,7 @@ static int wp_ecx_match_pub_key(const wp_Ecx* ecx1, const wp_Ecx* ecx2)
         ok = 0;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -719,6 +727,7 @@ static int wp_ecx_match(const wp_Ecx* ecx1, const wp_Ecx* ecx2, int selection)
         ok = 0;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -754,6 +763,7 @@ static int wp_ecx_validate_pub_key(const wp_Ecx* ecx)
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -783,6 +793,7 @@ static int wp_ecx_x_validate(const wp_Ecx* ecx, int selection, int checkType)
         /* Nothing to do. The private key is valid as it has been clamped. */
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 #endif
@@ -821,6 +832,7 @@ static int wp_ecx_ed_validate(const wp_Ecx* ecx, int selection, int checkType)
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 #endif
@@ -887,6 +899,7 @@ static int wp_ecx_import(wp_Ecx* ecx, int selection, const OSSL_PARAM params[])
         ok = 0;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1014,6 +1027,7 @@ static int wp_ecx_export_keypair(wp_Ecx* ecx, OSSL_PARAM* params, int* pIdx,
     }
 
     *pIdx = i;
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1053,6 +1067,7 @@ static int wp_ecx_export(wp_Ecx* ecx, int selection, OSSL_CALLBACK* paramCb,
     }
     OPENSSL_clear_free(data, len);
 
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1169,6 +1184,7 @@ static int wp_ecx_gen_set_params(wp_EcxGenCtx* ctx, const OSSL_PARAM params[])
         ok = 0;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1818,6 +1834,7 @@ static int wp_ecx_enc_dec_set_ctx_params(wp_EcxEncDecCtx* ctx,
         ok = 0;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1851,6 +1868,7 @@ static int wp_ecx_dec_send_params(wp_Ecx* ecx, const char* dataType,
         ok = 0;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1951,6 +1969,7 @@ static int wp_ecx_decode(wp_EcxEncDecCtx* ctx, OSSL_CORE_BIO* cBio,
             ok = 1;
         }
     }
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -2052,6 +2071,7 @@ static int wp_ecx_encode(wp_EcxEncDecCtx* ctx, OSSL_CORE_BIO *cBio,
         OPENSSL_free(pemData);
     }
     OPENSSL_free(cipherInfo);
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -2099,6 +2119,7 @@ static int wp_ecx_spki_does_selection(WOLFPROV_CTX* provCtx, int selection)
         ok = (selection & OSSL_KEYMGMT_SELECT_PUBLIC_KEY) != 0;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -2127,6 +2148,7 @@ static int wp_ecx_pki_does_selection(WOLFPROV_CTX* provCtx, int selection)
         ok = (selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY) != 0;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 

--- a/src/wp_ecx_kmgmt.c
+++ b/src/wp_ecx_kmgmt.c
@@ -1940,7 +1940,7 @@ static int wp_ecx_decode(wp_EcxEncDecCtx* ctx, OSSL_CORE_BIO* cBio,
     }
 
     if (ok) {
-        ok = wp_read_der_bio(cBio, &data, &len);
+        ok = wp_read_der_bio(ctx->provCtx, cBio, &data, &len);
     }
     if (ok) {
         rc = ctx->decode(data, &idx, (void*)&ecx->key, len);
@@ -1992,7 +1992,7 @@ static int wp_ecx_encode(wp_EcxEncDecCtx* ctx, OSSL_CORE_BIO *cBio,
 {
     int ok = 1;
     int rc;
-    BIO* out = wp_corebio_get_bio(cBio);
+    BIO* out = wp_corebio_get_bio(ctx->provCtx, cBio);
     unsigned char* keyData = NULL;
     size_t keyLen = 0;
     unsigned char derData[160];

--- a/src/wp_ecx_sig.c
+++ b/src/wp_ecx_sig.c
@@ -191,6 +191,7 @@ static int wp_ecx_digest_signverify_init(wp_EcxSigCtx *ctx,
         ctx->op = op;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -217,6 +218,7 @@ static int wp_ecx_digest_sign_init(wp_EcxSigCtx *ctx, const char *mdName,
             EVP_PKEY_OP_SIGN);
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -243,6 +245,7 @@ static int wp_ecx_digest_verify_init(wp_EcxSigCtx *ctx, const char *mdName,
             EVP_PKEY_OP_VERIFY);
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -286,6 +289,7 @@ static int wp_ecx_get_ctx_params(wp_EcxSigCtx *ctx, OSSL_PARAM *params)
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -377,6 +381,7 @@ static int wp_ed25519_digest_sign(wp_EcxSigCtx *ctx, unsigned char *sig,
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -431,6 +436,7 @@ static int wp_ed25519_digest_verify(wp_EcxSigCtx *ctx, unsigned char *sig,
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -518,6 +524,7 @@ static int wp_ed448_digest_sign(wp_EcxSigCtx *ctx, unsigned char *sig,
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -577,6 +584,7 @@ static int wp_ed448_digest_verify(wp_EcxSigCtx *ctx, unsigned char *sig,
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 

--- a/src/wp_file_store.c
+++ b/src/wp_file_store.c
@@ -115,6 +115,9 @@ static wp_FileCtx* wp_file_open(WOLFPROV_CTX* provCtx, const char* uri)
             ok = 0;
         }
         if (ok) {
+            if (ctx->bio != NULL) {
+                BIO_free(ctx->bio);
+            }
             /* Create a BIO to access file. */
             ctx->bio = BIO_new_file(uri, "rb");
             if (ctx->bio == NULL) {
@@ -145,8 +148,11 @@ static wp_FileCtx* wp_file_attach(WOLFPROV_CTX* provCtx, OSSL_CORE_BIO* cBio)
 
     ctx = wp_filectx_new(provCtx);
     if (ctx != NULL) {
+        if (ctx->bio != NULL) {
+            BIO_free(ctx->bio);
+        }
         /* Get the internal BIO. */
-        ctx->bio = wp_corebio_get_bio(cBio);
+        ctx->bio = wp_corebio_get_bio(provCtx, cBio);
     }
 
     return ctx;

--- a/src/wp_file_store.c
+++ b/src/wp_file_store.c
@@ -216,6 +216,7 @@ static int wp_file_set_ctx_params(wp_FileCtx* ctx, const OSSL_PARAM params[])
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PROVIDER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -284,6 +285,7 @@ static int wp_file_decoder_set_input_structure(OSSL_DECODER_CTX* decCtx,
             break;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PROVIDER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -361,6 +363,7 @@ static int wp_file_set_decoder(wp_FileCtx* ctx, OSSL_DECODER_CTX* decCtx)
         OSSL_DECODER_free(decoder);
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PROVIDER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -444,6 +447,7 @@ static int wp_file_load(wp_FileCtx* ctx, OSSL_CALLBACK* objCb, void* objCbArg,
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PROVIDER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 

--- a/src/wp_gmac.c
+++ b/src/wp_gmac.c
@@ -135,6 +135,7 @@ static int wp_gmac_set_key(wp_GmacCtx* macCtx, const unsigned char *key,
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_MAC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -199,6 +200,7 @@ static int wp_gmac_init(wp_GmacCtx* macCtx, const unsigned char* key,
         ok = 0;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_MAC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -228,6 +230,7 @@ static int wp_gmac_update(wp_GmacCtx* macCtx, const unsigned char* data,
         macCtx->dataLen += dataLen;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_MAC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -266,6 +269,7 @@ static int wp_gmac_final(wp_GmacCtx* macCtx, unsigned char* out, size_t* outl,
         *outl = AES_BLOCK_SIZE;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_MAC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -305,6 +309,7 @@ static int wp_gmac_get_params(OSSL_PARAM params[])
         ok = 0;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_MAC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -390,6 +395,7 @@ static int wp_gmac_setup_cipher(wp_GmacCtx* macCtx, const OSSL_PARAM params[])
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_MAC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -415,6 +421,7 @@ static int wp_gmac_set_param_key(wp_GmacCtx* macCtx, const OSSL_PARAM params[])
         ok = 0;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_MAC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -446,6 +453,7 @@ static int wp_gmac_set_param_iv(wp_GmacCtx* macCtx, const OSSL_PARAM params[])
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_MAC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -474,6 +482,7 @@ static int wp_gmac_set_ctx_params(wp_GmacCtx* macCtx, const OSSL_PARAM params[])
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_MAC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 

--- a/src/wp_hkdf.c
+++ b/src/wp_hkdf.c
@@ -231,6 +231,7 @@ static int wp_kdf_hkdf_derive(wp_HkdfCtx* ctx, unsigned char* key,
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KDF, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -278,6 +279,7 @@ static int wp_hkdf_base_get_mode(const OSSL_PARAM params[], int* mode)
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KDF, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -312,6 +314,7 @@ static int wp_hkdf_base_set_ctx_params(wp_HkdfCtx* ctx,
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KDF, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -343,6 +346,7 @@ static int wp_kdf_hkdf_get_ctx_params(wp_HkdfCtx* ctx, OSSL_PARAM params[])
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KDF, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -378,6 +382,7 @@ static int wp_hkdf_base_set_info(wp_HkdfCtx* ctx, const OSSL_PARAM params[])
         params = p + 1;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KDF, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -402,6 +407,7 @@ static int wp_kdf_hkdf_set_ctx_params(wp_HkdfCtx* ctx,
             ok = 0;
         }
     }
+    WOLFPROV_LEAVE(WP_LOG_KDF, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -527,6 +533,7 @@ static int wp_tls13_hkdf_expand(wp_HkdfCtx* ctx, unsigned char* inKey,
         ok = 0;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KDF, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -595,6 +602,7 @@ static int wp_tls13_hkdf_extract(wp_HkdfCtx* ctx, unsigned char* key,
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KDF, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -634,6 +642,7 @@ static int wp_kdf_tls1_3_derive(wp_HkdfCtx* ctx, unsigned char* key,
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KDF, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -671,6 +680,7 @@ static int wp_kdf_tls1_3_set_ctx_params(wp_HkdfCtx* ctx,
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KDF, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 

--- a/src/wp_hmac.c
+++ b/src/wp_hmac.c
@@ -159,6 +159,7 @@ static int wp_hmac_set_key(wp_HmacCtx* macCtx, const unsigned char* key,
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_MAC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -222,6 +223,7 @@ static int wp_hmac_init(wp_HmacCtx* macCtx, const unsigned char* key,
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_MAC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -245,6 +247,7 @@ static int wp_hmac_update(wp_HmacCtx* macCtx, const unsigned char* data,
         ok = 0;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_MAC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -281,6 +284,7 @@ static int wp_hmac_final(wp_HmacCtx* macCtx, unsigned char* out, size_t* outl,
         *outl = macCtx->size;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_MAC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -333,6 +337,7 @@ static int wp_hmac_get_ctx_params(wp_HmacCtx* macCtx, OSSL_PARAM params[])
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_MAC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -393,6 +398,7 @@ static int wp_hmac_set_ctx_params(wp_HmacCtx* macCtx, const OSSL_PARAM params[])
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_MAC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 

--- a/src/wp_internal.c
+++ b/src/wp_internal.c
@@ -23,6 +23,7 @@
 
 #include <wolfprovider/settings.h>
 #include <wolfprovider/internal.h>
+#include <wolfprovider/wp_wolfprov.h>
 #include <wolfprovider/wp_logging.h>
 
 #include <wolfssl/wolfcrypt/rsa.h>
@@ -733,14 +734,6 @@ int wp_read_der_bio(WOLFPROV_CTX *provctx, OSSL_CORE_BIO *coreBio, unsigned char
     BIO_free(bio);
     WOLFPROV_LEAVE(WP_LOG_PROVIDER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
-}
-
-static OSSL_FUNC_BIO_up_ref_fn *c_bio_up_ref = NULL;
-static int wolfssl_prov_bio_up_ref(OSSL_CORE_BIO *bio)
-{
-    if (c_bio_up_ref == NULL)
-        return 0;
-    return c_bio_up_ref(bio);
 }
 
 /**

--- a/src/wp_internal.c
+++ b/src/wp_internal.c
@@ -23,6 +23,7 @@
 
 #include <wolfprovider/settings.h>
 #include <wolfprovider/internal.h>
+#include <wolfprovider/wp_logging.h>
 
 #include <wolfssl/wolfcrypt/rsa.h>
 #include <wolfssl/wolfcrypt/pwdbased.h>
@@ -56,6 +57,7 @@ int wp_provctx_lock_rng(WOLFPROV_CTX* provCtx)
         ok = 0;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PROVIDER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -354,6 +356,7 @@ int wp_hash_copy(wc_HashAlg* src, wc_HashAlg* dst, enum wc_HashType hashType)
         ok = 0;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PROVIDER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -432,6 +435,7 @@ int wp_cipher_from_params(const OSSL_PARAM params[], int* cipher,
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PROVIDER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -668,6 +672,7 @@ int wp_encrypt_key(WOLFPROV_CTX* provCtx, const char* cipherName,
         *keyLen = len;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PROVIDER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 #else
     (void)provCtx;
@@ -742,6 +747,7 @@ int wp_read_der_bio(OSSL_CORE_BIO *coreBio, unsigned char** data, word32* len)
     }
     while (ok && (readLen > 0));
 
+    WOLFPROV_LEAVE(WP_LOG_PROVIDER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 

--- a/src/wp_kdf_exch.c
+++ b/src/wp_kdf_exch.c
@@ -168,6 +168,7 @@ static int wp_kdf_init(wp_KdfCtx* ctx, wp_Kdf* kdf, const OSSL_PARAM params[])
         ok = wp_kdf_set_ctx_params(ctx, params);
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KDF, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -199,6 +200,7 @@ static int wp_kdf_derive(wp_KdfCtx* ctx, unsigned char* secret, size_t* secLen,
         ok = 0;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KDF, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 

--- a/src/wp_kdf_kmgmt.c
+++ b/src/wp_kdf_kmgmt.c
@@ -67,6 +67,7 @@ int wp_kdf_up_ref(wp_Kdf* kdf)
         wc_UnLockMutex(&kdf->mutex);
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KDF, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 #else
     kdf->refCnt++;

--- a/src/wp_mac_kmgmt.c
+++ b/src/wp_mac_kmgmt.c
@@ -104,6 +104,7 @@ int wp_mac_up_ref(wp_Mac* mac)
         wc_UnLockMutex(&mac->mutex);
     }
 
+    WOLFPROV_LEAVE(WP_LOG_MAC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 #else
     mac->refCnt++;
@@ -141,6 +142,7 @@ int wp_mac_get_private_key(wp_Mac* mac, unsigned char** priv, size_t* privLen)
         ok = 1;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_MAC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -309,6 +311,7 @@ static int wp_mac_has(const wp_Mac* mac, int selection)
         ok &= mac->key != NULL;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_MAC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -335,6 +338,7 @@ static int wp_mac_match(const wp_Mac* mac1, const wp_Mac* mac2, int selection)
         ok = 0;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_MAC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -376,6 +380,7 @@ static int wp_mac_import(wp_Mac *mac, int selection, const OSSL_PARAM params[])
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_MAC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -475,6 +480,7 @@ static int wp_mac_export(wp_Mac *mac, int selection, OSSL_CALLBACK *paramCb,
     }
     OPENSSL_clear_free(data, len);
 
+    WOLFPROV_LEAVE(WP_LOG_MAC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -534,6 +540,7 @@ static int wp_mac_gen_set_params(wp_MacGenCtx* ctx, const OSSL_PARAM params[])
         ok = 0;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_MAC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -626,6 +633,7 @@ static int wp_mac_get_params(wp_Mac* mac, OSSL_PARAM params[])
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_MAC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 

--- a/src/wp_mac_sig.c
+++ b/src/wp_mac_sig.c
@@ -245,6 +245,7 @@ static int wp_mac_digest_sign_init(wp_MacSigCtx *ctx, const char *mdName,
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_MAC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -266,6 +267,7 @@ static int wp_mac_digest_sign_update(wp_MacSigCtx *ctx,
         ok = 0;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_MAC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -297,6 +299,7 @@ static int wp_mac_digest_sign_final(wp_MacSigCtx *ctx, unsigned char *sig,
         ok = 0;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_MAC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 

--- a/src/wp_params.c
+++ b/src/wp_params.c
@@ -23,6 +23,7 @@
 
 #include "wolfprovider/internal.h"
 #include "wolfprovider/wp_params.h"
+#include "wolfprovider/wp_logging.h"
 
 
 /**
@@ -53,6 +54,7 @@ int wp_mp_read_unsigned_bin_le(mp_int* mp, const unsigned char* data,
         ok = 0;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PROVIDER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -85,6 +87,7 @@ int wp_mp_to_unsigned_bin_le(mp_int* mp, unsigned char* data, size_t len)
     }
 #endif
 
+    WOLFPROV_LEAVE(WP_LOG_PROVIDER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -162,6 +165,7 @@ int wp_param_set_mp(OSSL_PARAM* p, const char* key, mp_int* mp,
         ok = 0;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PROVIDER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 /**
@@ -238,6 +242,7 @@ int wp_params_get_digest(const OSSL_PARAM* params, char* name,
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PROVIDER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -266,6 +271,7 @@ int wp_params_get_mp(const OSSL_PARAM* params, const char* key, mp_int* mp)
         ok = 0;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PROVIDER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -302,6 +308,7 @@ int wp_params_get_octet_string(const OSSL_PARAM* params, const char* key,
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PROVIDER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -355,6 +362,7 @@ int wp_params_get_bn_be(const OSSL_PARAM* params, const char* key,
 #endif
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PROVIDER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -385,6 +393,7 @@ int wp_params_get_octet_string_ptr(const OSSL_PARAM* params, const char* key,
         *len  = p->data_size;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PROVIDER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -417,6 +426,7 @@ int wp_params_get_utf8_string(const OSSL_PARAM* params, const char* key,
         XSTRNCPY(str, p->data, len);
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PROVIDER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -445,6 +455,7 @@ int wp_params_get_utf8_string_ptr(const OSSL_PARAM* params, const char* key,
         *data = (char *)p->data;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PROVIDER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -469,6 +480,7 @@ int wp_params_get_size_t(const OSSL_PARAM* params, const char* key, size_t* val)
         ok = 0;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PROVIDER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -494,6 +506,7 @@ int wp_params_get_uint64(const OSSL_PARAM* params, const char* key,
         ok = 0;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PROVIDER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -518,6 +531,7 @@ int wp_params_get_int(const OSSL_PARAM* params, const char* key, int* val)
         ok = 0;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PROVIDER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -550,6 +564,7 @@ int wp_params_get_uint(const OSSL_PARAM* params, const char* key,
         *set = 1;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PROVIDER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -584,6 +599,7 @@ int wp_params_set_mp(OSSL_PARAM params[], const char* key, mp_int* mp)
         p->return_size = outLen;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PROVIDER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -625,6 +641,7 @@ int wp_params_set_octet_string_be(OSSL_PARAM params[], const char* key,
         p->return_size = len;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PROVIDER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 

--- a/src/wp_pbkdf2.c
+++ b/src/wp_pbkdf2.c
@@ -168,6 +168,7 @@ static int wp_pbkdf2_base_set_ctx_params(wp_Pbkdf2Ctx* ctx,
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KDF, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -193,6 +194,7 @@ static int wp_kdf_pbkdf2_get_ctx_params(wp_Pbkdf2Ctx* ctx, OSSL_PARAM params[])
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KDF, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -268,6 +270,7 @@ static int wp_kdf_pbkdf2_derive(wp_Pbkdf2Ctx* ctx, unsigned char* key,
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KDF, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -289,6 +292,7 @@ static int wp_kdf_pbkdf2_set_ctx_params(wp_Pbkdf2Ctx* ctx,
         ok = 0;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KDF, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -378,6 +382,7 @@ static int wp_kdf_pkcs12_derive(wp_Pbkdf2Ctx* ctx, unsigned char* key,
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KDF, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -400,6 +405,7 @@ static int wp_kdf_pkcs12_set_ctx_params(wp_Pbkdf2Ctx* ctx,
         ok = 0;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KDF, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 

--- a/src/wp_rsa_asym.c
+++ b/src/wp_rsa_asym.c
@@ -234,6 +234,7 @@ static int wp_rsaa_init(wp_RsaAsymCtx* ctx, wp_Rsa* rsa,
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -258,6 +259,7 @@ static int wp_rsaa_encrypt_init(wp_RsaAsymCtx* ctx, wp_Rsa* rsa,
         ok = wp_rsaa_init(ctx, rsa, params, EVP_PKEY_OP_SIGN);
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -324,6 +326,7 @@ static int wp_rsaa_encrypt(wp_RsaAsymCtx* ctx, unsigned char* out,
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -348,6 +351,7 @@ static int wp_rsaa_decrypt_init(wp_RsaAsymCtx* ctx, wp_Rsa* rsa,
         ok = wp_rsaa_init(ctx, rsa, params, EVP_PKEY_OP_DECRYPT);
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -462,6 +466,7 @@ static int wp_rsaa_decrypt(wp_RsaAsymCtx* ctx, unsigned char* out,
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -503,6 +508,7 @@ static int wp_rsaa_setup_md(wp_RsaAsymCtx* ctx, const char* mdName,
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -529,6 +535,7 @@ static int wp_rsaa_setup_mgf1_md(wp_RsaAsymCtx* ctx, const char* mdName,
         ctx->mgfSet = 1;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -565,6 +572,7 @@ static int wp_rsaa_get_pad_mode(int padMode, OSSL_PARAM* p)
         ok = 0;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -630,6 +638,7 @@ static int wp_rsaa_get_ctx_params(wp_RsaAsymCtx* ctx, OSSL_PARAM* params)
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -694,6 +703,7 @@ static int wp_rsaa_set_digest(wp_RsaAsymCtx* ctx, const OSSL_PARAM* p,
         ok = wp_rsaa_setup_md(ctx, mdName, pmdProps);
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -736,6 +746,7 @@ static int wp_rsaa_set_pad_mode(wp_RsaAsymCtx* ctx, const OSSL_PARAM* p)
         ctx->padMode = padMode;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -771,6 +782,7 @@ static int wp_rsaa_set_mgf1_digest(wp_RsaAsymCtx* ctx, const OSSL_PARAM* p,
         ok = wp_rsaa_setup_mgf1_md(ctx, mgfMdName, pmgfMdProps);
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -843,6 +855,7 @@ static int wp_rsaa_set_ctx_params(wp_RsaAsymCtx* ctx, const OSSL_PARAM params[])
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 

--- a/src/wp_rsa_kem.c
+++ b/src/wp_rsa_kem.c
@@ -264,6 +264,7 @@ static int wp_rsasve_gen_rand_bytes(wp_RsaKemCtx* ctx, unsigned char* out)
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -336,6 +337,7 @@ static int wp_rsasve_generate(wp_RsaKemCtx* ctx, unsigned char* out,
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -365,6 +367,7 @@ static int wp_rsakem_encapsulate(wp_RsaKemCtx* ctx, unsigned char* out,
             break;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -424,6 +427,7 @@ static int wp_rsasve_recover(wp_RsaKemCtx* ctx, unsigned char* out,
         *outLen = nLen;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -453,6 +457,7 @@ static int wp_rsakem_decapsulate(wp_RsaKemCtx* ctx, unsigned char* out,
             break;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -521,6 +526,7 @@ static int wp_rsakem_set_ctx_params(wp_RsaKemCtx* ctx,
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 

--- a/src/wp_rsa_kmgmt.c
+++ b/src/wp_rsa_kmgmt.c
@@ -1936,7 +1936,7 @@ static int wp_rsa_decode(wp_RsaEncDecCtx* ctx, OSSL_CORE_BIO* cBio,
         ok = 0;
     }
     if (ok) {
-        ok = wp_read_der_bio(cBio, &data, &len);
+        ok = wp_read_der_bio(ctx->provCtx, cBio, &data, &len);
     }
     if (ok && (ctx->format == WP_ENC_FORMAT_SPKI)) {
         if (!wp_rsa_decode_spki(rsa, data, len)) {
@@ -2333,7 +2333,7 @@ static int wp_rsa_encode(wp_RsaEncDecCtx* ctx, OSSL_CORE_BIO* cBio,
 {
     int ok = 1;
     int rc;
-    BIO* out = wp_corebio_get_bio(cBio);
+    BIO *out = wp_corebio_get_bio(ctx->provCtx, cBio);
     unsigned char* keyData = NULL;
     size_t keyLen;
     unsigned char* derData = NULL;
@@ -2468,6 +2468,7 @@ static int wp_rsa_encode(wp_RsaEncDecCtx* ctx, OSSL_CORE_BIO* cBio,
         OPENSSL_free(derData);
         OPENSSL_free(pemData);
     }
+    BIO_free(out);
     WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }

--- a/src/wp_rsa_kmgmt.c
+++ b/src/wp_rsa_kmgmt.c
@@ -195,6 +195,7 @@ int wp_rsa_up_ref(wp_Rsa* rsa)
         wc_UnLockMutex(&rsa->mutex);
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 #else
     rsa->refCnt++;
@@ -262,6 +263,7 @@ static int wp_rsa_check_key_size_int(int keySize, int allow1024)
     (void)allow1024;
 #endif
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -490,6 +492,7 @@ static int wp_rsa_pss_params_setup_mgf1_md(wp_RsaPssParams* pss,
         ok = 0;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -522,6 +525,7 @@ static int wp_rsa_pss_params_setup_md(wp_RsaPssParams* pss, const char* mdName,
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -558,6 +562,7 @@ static int wp_rsa_pss_params_set_digest(wp_RsaPssParams* pss,
         ok = wp_rsa_pss_params_setup_md(pss, mdName, mdProps, libCtx);
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -594,6 +599,7 @@ static int wp_rsa_pss_params_set_mgf1_digest(wp_RsaPssParams* pss,
         ok = wp_rsa_pss_params_setup_mgf1_md(pss, mdName, mdProps, libCtx);
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -659,6 +665,7 @@ static int wp_rsa_pss_params_set_params(wp_RsaPssParams* pss,
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -746,6 +753,7 @@ static int wp_rsa_get_params_key_data(wp_Rsa* rsa,  OSSL_PARAM params[])
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -782,6 +790,7 @@ static int wp_rsa_get_params_pss(wp_RsaPssParams* pss,  OSSL_PARAM params[])
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -831,6 +840,7 @@ static int wp_rsa_get_params(wp_Rsa* rsa, OSSL_PARAM params[])
         ok = 0;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -859,6 +869,7 @@ static int wp_rsa_has(const wp_Rsa* rsa, int selection)
             ok &= rsa->hasPriv;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -886,6 +897,7 @@ static int wp_rsa_match(const wp_Rsa* rsa1, const wp_Rsa* rsa2, int selection)
         ok = 0;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -930,6 +942,7 @@ static int wp_rsa_validate(const wp_Rsa* rsa, int selection, int checkType)
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -970,6 +983,7 @@ static int wp_rsa_import_key_data(wp_Rsa* rsa, const OSSL_PARAM params[],
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1010,6 +1024,7 @@ static int wp_rsa_import(wp_Rsa* rsa, int selection, const OSSL_PARAM params[])
         rsa->hasPriv = importPriv;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1142,6 +1157,7 @@ static int wp_rsa_export_keypair(wp_Rsa* rsa, OSSL_PARAM* params, int* pIdx,
     }
 
     *pIdx = i;
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1197,6 +1213,7 @@ static int wp_rsa_export(wp_Rsa* rsa, int selection, OSSL_CALLBACK* paramCb,
     (void)paramSz;
     OPENSSL_clear_free(data, len);
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1368,6 +1385,7 @@ static int wp_rsa_gen_set_params(wp_RsaGenCtx* ctx, const OSSL_PARAM params[])
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1721,6 +1739,7 @@ static int wp_rsa_enc_dec_set_ctx_params(wp_RsaEncDecCtx* ctx,
         ok = 0;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1769,6 +1788,7 @@ static int wp_rsa_find_oid(wp_Rsa* rsa, unsigned char* data, word32 len)
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1799,6 +1819,7 @@ static int wp_rsa_decode_spki(wp_Rsa* rsa, unsigned char* data, word32 len)
         rsa->hasPub = 1;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1842,6 +1863,7 @@ static int wp_rsa_decode_pki(wp_Rsa* rsa, unsigned char* data, word32 len)
         rsa->hasPriv = 1;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1875,6 +1897,7 @@ static int wp_rsa_dec_send_params(wp_Rsa* rsa, OSSL_CALLBACK* dataCb,
         ok = 0;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1959,6 +1982,7 @@ static int wp_rsa_decode(wp_RsaEncDecCtx* ctx, OSSL_CORE_BIO* cBio,
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1994,6 +2018,7 @@ static int wp_rsa_encode_spki_size(const wp_Rsa* rsa, size_t* keyLen)
     }
 #endif
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -2021,6 +2046,7 @@ static int wp_rsa_encode_spki(const wp_Rsa* rsa, unsigned char* keyData,
         *keyLen = ret;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -2049,6 +2075,7 @@ static int wp_rsa_encode_pub_size(const wp_Rsa* rsa, size_t* keyLen)
         *keyLen = ret;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -2085,6 +2112,7 @@ static int wp_rsa_encode_pub(const wp_Rsa* rsa, unsigned char* keyData,
         *keyLen = ret;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -2119,6 +2147,7 @@ static int wp_rsa_encode_pki_size(const wp_Rsa* rsa, size_t* keyLen)
         *keyLen = len;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -2172,6 +2201,7 @@ static int wp_rsa_encode_pki(const wp_Rsa* rsa, unsigned char* keyData,
     }
 
     OPENSSL_clear_free(pkcs1Data, pkcs1Len);
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -2196,6 +2226,7 @@ static int wp_rsa_encode_priv_size(const wp_Rsa* rsa, size_t* keyLen)
         *keyLen = ret;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -2223,6 +2254,7 @@ static int wp_rsa_encode_priv(const wp_Rsa* rsa, unsigned char* keyData,
         *keyLen = ret;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -2245,6 +2277,7 @@ static int wp_rsa_encode_epki_size(const wp_Rsa* rsa, size_t* keyLen)
         *keyLen = ((len + 15) / 16) * 16;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -2276,6 +2309,7 @@ static int wp_rsa_encode_epki(const wp_RsaEncDecCtx* ctx, const wp_Rsa* rsa,
         ok = 0;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 #endif
@@ -2434,6 +2468,7 @@ static int wp_rsa_encode(wp_RsaEncDecCtx* ctx, OSSL_CORE_BIO* cBio,
         OPENSSL_free(derData);
         OPENSSL_free(pemData);
     }
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -2494,6 +2529,7 @@ static int wp_rsa_spki_does_selection(WOLFPROV_CTX* provCtx, int selection)
         ok = (selection & OSSL_KEYMGMT_SELECT_PUBLIC_KEY) != 0;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -2605,6 +2641,7 @@ static int wp_rsa_pki_does_selection(WOLFPROV_CTX* provCtx, int selection)
         ok = (selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY) != 0;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -2778,6 +2815,7 @@ static int wp_rsa_legacy_does_selection(WOLFPROV_CTX* provCtx, int selection)
         ok = (selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY) != 0;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -2829,6 +2867,7 @@ static int wp_rsa_kp_does_selection(WOLFPROV_CTX* provCtx, int selection)
         ok = (selection & OSSL_KEYMGMT_SELECT_KEYPAIR) != 0;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 

--- a/src/wp_rsa_sig.c
+++ b/src/wp_rsa_sig.c
@@ -174,6 +174,7 @@ static int wp_rsa_setup_md(wp_RsaSigCtx* ctx, const char* mdName,
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -207,6 +208,7 @@ static int wp_rsa_setup_mgf1_md(wp_RsaSigCtx* ctx, const char* mdName,
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -396,6 +398,7 @@ static int wp_rsa_check_pss_salt_len(wp_RsaSigCtx* ctx)
         ok = 0;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -466,6 +469,7 @@ static int wp_rsa_signverify_init(wp_RsaSigCtx* ctx, wp_Rsa* rsa,
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -490,6 +494,7 @@ static int wp_rsa_sign_init(wp_RsaSigCtx* ctx, wp_Rsa* rsa,
         ok = wp_rsa_signverify_init(ctx, rsa, params, EVP_PKEY_OP_SIGN);
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -553,6 +558,7 @@ static int wp_rsa_sign_pkcs1(wp_RsaSigCtx* ctx, unsigned char* sig,
 
     OPENSSL_free(encodedDigest);
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -588,6 +594,7 @@ static int wp_rsa_sign_pss(wp_RsaSigCtx* ctx, unsigned char* sig,
         *sigLen = rc;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -627,6 +634,7 @@ static int wp_rsa_sign_no_pad(wp_RsaSigCtx* ctx, unsigned char* sig,
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -677,6 +685,7 @@ static int wp_rsa_sign(wp_RsaSigCtx* ctx, unsigned char* sig, size_t* sigLen,
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -701,6 +710,7 @@ static int wp_rsa_verify_init(wp_RsaSigCtx* ctx, wp_Rsa* rsa,
         ok = wp_rsa_signverify_init(ctx, rsa, params, EVP_PKEY_OP_VERIFY);
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -755,6 +765,7 @@ static int wp_rsa_verify_pkcs1(wp_RsaSigCtx* ctx, const unsigned char* sig,
         ok = 0;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -800,6 +811,7 @@ static int wp_rsa_verify_pss(wp_RsaSigCtx* ctx, const unsigned char* sig,
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -833,6 +845,7 @@ static int wp_rsa_verify_no_pad(wp_RsaSigCtx* ctx, const unsigned char* sig,
         ok = 0;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -884,6 +897,7 @@ static int wp_rsa_verify(wp_RsaSigCtx* ctx, const unsigned char* sig,
         OPENSSL_free(decryptedSig);
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -909,6 +923,7 @@ static int wp_rsa_verify_recover_init(wp_RsaSigCtx* ctx, wp_Rsa* rsa,
             EVP_PKEY_OP_VERIFYRECOVER);
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -958,6 +973,7 @@ static int wp_rsa_digest_signverify_init(wp_RsaSigCtx* ctx, const char* mdName,
         ok = wp_rsa_setup_md(ctx, mdName, ctx->propQuery, op);
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -978,6 +994,7 @@ static int wp_rsa_digest_signverify_update(wp_RsaSigCtx* ctx,
     if (rc != 0) {
         ok = 0;
     }
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1004,6 +1021,7 @@ static int wp_rsa_digest_sign_init(wp_RsaSigCtx* ctx, const char* mdName,
             EVP_PKEY_OP_SIGN);
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1041,6 +1059,7 @@ static int wp_rsa_digest_sign_final(wp_RsaSigCtx* ctx, unsigned char* sig,
             wc_HashGetDigestSize(ctx->hashType));
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1067,6 +1086,7 @@ static int wp_rsa_digest_verify_init(wp_RsaSigCtx* ctx, const char* mdName,
             EVP_PKEY_OP_VERIFY);
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1100,6 +1120,7 @@ static int wp_rsa_digest_verify_final(wp_RsaSigCtx* ctx, unsigned char* sig,
             wc_HashGetDigestSize(ctx->hashType));
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1152,6 +1173,7 @@ static int wp_rsa_get_pad_mode(int padMode, OSSL_PARAM* p)
         ok = 0;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1205,6 +1227,7 @@ static int wp_rsa_get_salt_len(int saltLen, OSSL_PARAM* p)
         ok = 0;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1260,6 +1283,7 @@ static int wp_rsa_get_ctx_params(wp_RsaSigCtx* ctx, OSSL_PARAM* params)
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1319,6 +1343,7 @@ static int wp_rsa_set_digest(wp_RsaSigCtx* ctx, const OSSL_PARAM* p,
         ok = wp_rsa_setup_md(ctx, mdName, pmdProps, ctx->op);
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1379,6 +1404,7 @@ static int wp_rsa_set_pad_mode(wp_RsaSigCtx* ctx, const OSSL_PARAM* p)
         ctx->padMode = padMode;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1428,6 +1454,7 @@ static int wp_rsa_set_salt_len(wp_RsaSigCtx* ctx, const OSSL_PARAM* p)
         ok = 0;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1463,6 +1490,7 @@ static int wp_rsa_set_mgf1_digest(wp_RsaSigCtx* ctx, const OSSL_PARAM* p,
         ok = wp_rsa_setup_mgf1_md(ctx, mgfMdName, pmgfMdProps);
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1525,6 +1553,7 @@ static int wp_rsa_set_ctx_params(wp_RsaSigCtx* ctx, const OSSL_PARAM params[])
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 

--- a/src/wp_tls1_prf.c
+++ b/src/wp_tls1_prf.c
@@ -192,6 +192,7 @@ static int wp_kdf_tls1_prf_derive(wp_Tls1Prf_Ctx* ctx, unsigned char* key,
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KDF, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -229,6 +230,7 @@ static int wp_kdf_tls1_prf_get_seed(wp_Tls1Prf_Ctx* ctx,
         params = p + 1;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KDF, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 /**
@@ -258,6 +260,7 @@ static int wp_kdf_tls1_prf_set_ctx_params(wp_Tls1Prf_Ctx* ctx,
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KDF, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -308,6 +311,7 @@ static int wp_kdf_tls1_prf_get_ctx_params(wp_Tls1Prf_Ctx* ctx,
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KDF, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 

--- a/src/wp_tls_capa.c
+++ b/src/wp_tls_capa.c
@@ -27,6 +27,7 @@
 #include <openssl/params.h>
 #include <openssl/prov_ssl.h>
 
+#include <wolfprovider/wp_logging.h>
 #include "wolfprovider/internal.h"
 
 
@@ -157,6 +158,7 @@ static int wp_tls_group_capability(OSSL_CALLBACK *cb, void *arg)
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PROVIDER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -182,6 +184,7 @@ int wolfssl_prov_get_capabilities(void *provCtx, const char *capability,
     if (strcasecmp(capability, "TLS-GROUP") == 0) {
         ok = wp_tls_group_capability(cb, arg);
     }
+    WOLFPROV_LEAVE(WP_LOG_PROVIDER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 

--- a/src/wp_wolfprov.c
+++ b/src/wp_wolfprov.c
@@ -33,6 +33,7 @@
 #include "wolfprovider/wp_wolfprov.h"
 #include "wolfprovider/alg_funcs.h"
 
+const char* wolfprovider_id = "libwolfprov";
 
 /* Core function that gets the table of parameters. */
 static OSSL_FUNC_core_gettable_params_fn* c_gettable_params = NULL;
@@ -86,6 +87,7 @@ static OSSL_FUNC_BIO_gets_fn *c_bio_gets = NULL;
 static OSSL_FUNC_BIO_puts_fn *c_bio_puts = NULL;
 static OSSL_FUNC_BIO_ctrl_fn *c_bio_ctrl = NULL;
 static OSSL_FUNC_BIO_free_fn *c_bio_free = NULL;
+static OSSL_FUNC_BIO_up_ref_fn *c_bio_up_ref = NULL;
 
 static int wolfssl_prov_bio_read_ex(OSSL_CORE_BIO *bio, void *data, size_t data_len,
                           size_t *bytes_read)
@@ -129,6 +131,13 @@ static int wolfssl_prov_bio_free(OSSL_CORE_BIO *bio)
     if (c_bio_free == NULL)
         return 0;
     return c_bio_free(bio);
+}
+
+int wolfssl_prov_bio_up_ref(OSSL_CORE_BIO *bio)
+{
+    if (c_bio_up_ref == NULL)
+        return 0;
+    return c_bio_up_ref(bio);
 }
 
 
@@ -1134,6 +1143,27 @@ int wolfssl_provider_init(const OSSL_CORE_HANDLE* handle,
                 break;
             case OSSL_FUNC_CORE_GET_LIBCTX:
                 c_get_libctx = OSSL_FUNC_core_get_libctx(in);
+                break;
+            case OSSL_FUNC_BIO_READ_EX:
+                c_bio_read_ex = OSSL_FUNC_BIO_read_ex(in);
+                break;
+            case OSSL_FUNC_BIO_WRITE_EX:
+                c_bio_write_ex = OSSL_FUNC_BIO_write_ex(in);
+                break;
+            case OSSL_FUNC_BIO_GETS:
+                c_bio_gets = OSSL_FUNC_BIO_gets(in);
+                break;
+            case OSSL_FUNC_BIO_PUTS:
+                c_bio_puts = OSSL_FUNC_BIO_puts(in);
+                break;
+            case OSSL_FUNC_BIO_CTRL:
+                c_bio_ctrl = OSSL_FUNC_BIO_ctrl(in);
+                break;
+            case OSSL_FUNC_BIO_FREE:
+                c_bio_free = OSSL_FUNC_BIO_free(in);
+                break;
+            case OSSL_FUNC_BIO_UP_REF:
+                c_bio_up_ref = OSSL_FUNC_BIO_up_ref(in);
                 break;
             default:
                 /* Just ignore anything we don't understand */

--- a/src/wp_wolfprov.c
+++ b/src/wp_wolfprov.c
@@ -199,6 +199,7 @@ static int wolfprov_get_params(void* provCtx, OSSL_PARAM params[])
             ok = 0;
         }
     }
+    WOLFPROV_LEAVE(WP_LOG_PROVIDER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1046,6 +1047,7 @@ int wolfssl_provider_init(const OSSL_CORE_HANDLE* handle,
         *out = wolfprov_dispatch_table;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_PROVIDER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 

--- a/src/wp_wolfprov.c
+++ b/src/wp_wolfprov.c
@@ -201,22 +201,24 @@ static WOLFPROV_CTX* wolfssl_prov_ctx_new(void)
     }
 #endif
 
-    ctx->coreBioMethod = BIO_meth_new(BIO_TYPE_CORE_TO_PROV, "BIO to Core filter");
-    if (ctx->coreBioMethod == NULL
-        || !BIO_meth_set_write_ex(ctx->coreBioMethod, bio_core_write_ex)
-        || !BIO_meth_set_read_ex(ctx->coreBioMethod, bio_core_read_ex)
-        || !BIO_meth_set_puts(ctx->coreBioMethod, bio_core_puts)
-        || !BIO_meth_set_gets(ctx->coreBioMethod, bio_core_gets)
-        || !BIO_meth_set_ctrl(ctx->coreBioMethod, bio_core_ctrl)
-        || !BIO_meth_set_create(ctx->coreBioMethod, bio_core_new)
-        || !BIO_meth_set_destroy(ctx->coreBioMethod, bio_core_free)) {
-        BIO_meth_free(ctx->coreBioMethod);
+    if (ctx != NULL) {
+        ctx->coreBioMethod = BIO_meth_new(BIO_TYPE_CORE_TO_PROV, "BIO to Core filter");
+        if (ctx->coreBioMethod == NULL
+            || !BIO_meth_set_write_ex(ctx->coreBioMethod, bio_core_write_ex)
+            || !BIO_meth_set_read_ex(ctx->coreBioMethod, bio_core_read_ex)
+            || !BIO_meth_set_puts(ctx->coreBioMethod, bio_core_puts)
+            || !BIO_meth_set_gets(ctx->coreBioMethod, bio_core_gets)
+            || !BIO_meth_set_ctrl(ctx->coreBioMethod, bio_core_ctrl)
+            || !BIO_meth_set_create(ctx->coreBioMethod, bio_core_new)
+            || !BIO_meth_set_destroy(ctx->coreBioMethod, bio_core_free)) {
+            BIO_meth_free(ctx->coreBioMethod);
 #ifndef WP_SINGLE_THREADED
-        wc_FreeMutex(&ctx->rng_mutex);
+            wc_FreeMutex(&ctx->rng_mutex);
 #endif
-        wc_FreeRng(&ctx->rng);
-        OPENSSL_free(ctx);
-        ctx = NULL;
+            wc_FreeRng(&ctx->rng);
+            OPENSSL_free(ctx);
+            ctx = NULL;
+        }
     }
 
     return ctx;


### PR DESCRIPTION
Super simplistic logging that at least gives you a trace of the majority of function calls.

Also removed the opaque BIO structure that provider shouldn't use.