### PR TITLE
Fix builds

### DIFF
--- a/include/wolfprovider/internal.h
+++ b/include/wolfprovider/internal.h
@@ -150,7 +150,7 @@ enum wc_HashType wp_nid_to_wc_hash_type(int nid);
 int wp_name_to_wc_mgf(OSSL_LIB_CTX* libCtx, const char* name,
     const char* propQ);
 int wp_mgf1_from_hash(int nid);
-int wp_hash_copy(wc_HashAlg* src, wc_HashAlg* dst, enum wc_HashType hashType);
+int wp_hash_copy(wc_HashAlg* src, wc_HashAlg* dst);
 
 int wp_cipher_from_params(const OSSL_PARAM params[], int* cipher,
     const char** cipherName);

--- a/include/wolfprovider/internal.h
+++ b/include/wolfprovider/internal.h
@@ -150,7 +150,7 @@ enum wc_HashType wp_nid_to_wc_hash_type(int nid);
 int wp_name_to_wc_mgf(OSSL_LIB_CTX* libCtx, const char* name,
     const char* propQ);
 int wp_mgf1_from_hash(int nid);
-int wp_hash_copy(wc_HashAlg* src, wc_HashAlg* dst);
+int wp_hash_copy(wc_HashAlg* src, wc_HashAlg* dst, enum wc_HashType hashType);
 
 int wp_cipher_from_params(const OSSL_PARAM params[], int* cipher,
     const char** cipherName);

--- a/include/wolfprovider/internal.h
+++ b/include/wolfprovider/internal.h
@@ -150,7 +150,11 @@ enum wc_HashType wp_nid_to_wc_hash_type(int nid);
 int wp_name_to_wc_mgf(OSSL_LIB_CTX* libCtx, const char* name,
     const char* propQ);
 int wp_mgf1_from_hash(int nid);
+#if LIBWOLFSSL_VERSION_HEX >= 0x05007004
+int wp_hash_copy(wc_HashAlg* src, wc_HashAlg* dst);
+#else
 int wp_hash_copy(wc_HashAlg* src, wc_HashAlg* dst, enum wc_HashType hashType);
+#endif
 
 int wp_cipher_from_params(const OSSL_PARAM params[], int* cipher,
     const char** cipherName);

--- a/scripts/utils-general.sh
+++ b/scripts/utils-general.sh
@@ -26,3 +26,19 @@ if [ "$UTILS_GENERAL_LOADED" != "yes" ]; then # only set once
 
     export UTILS_GENERAL_LOADED=yes
 fi
+
+check_folder_age() {
+    folderA=$1
+    folderB=$2
+    folderA_age=$(find "$folderA" -type f -printf '%T@' | sort -n | tail -n 1)
+    folderB_age=$(find "$folderB" -type f -printf '%T@' | sort -n | tail -n 1)
+
+    if awk "BEGIN {exit !($folderA_age > $folderB_age)}"; then
+        echo 1
+    elif awk "BEGIN {exit !($folderA_age < $folderB_age)}"; then
+        echo -1
+    else
+        echo 0
+    fi
+}
+

--- a/scripts/utils-openssl.sh
+++ b/scripts/utils-openssl.sh
@@ -27,7 +27,7 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 source ${SCRIPT_DIR}/utils-general.sh
 
 OPENSSL_GIT="https://github.com/openssl/openssl.git"
-OPENSSL_TAG=${OPENSSL_TAG:-"openssl-3.0.0"}
+OPENSSL_TAG=${OPENSSL_TAG:-"openssl-3.2.0"}
 OPENSSL_SOURCE_DIR=${SCRIPT_DIR}/../openssl-source
 OPENSSL_INSTALL_DIR=${SCRIPT_DIR}/../openssl-install
 

--- a/scripts/utils-wolfprovider.sh
+++ b/scripts/utils-wolfprovider.sh
@@ -43,7 +43,7 @@ install_wolfprov() {
     init_wolfssl
     printf "LD_LIBRARY_PATH: $LD_LIBRARY_PATH\n"
 
-    if [ ! -d ${WOLFPROV_INSTALL_DIR} ]; then
+    if [ ! -d ${WOLFPROV_INSTALL_DIR} ] || [ $(check_folder_age "${WOLFPROV_INSTALL_DIR}" "${WOLFSSL_INSTALL_DIR}") -lt 0 ] || [ $(check_folder_age "${WOLFPROV_INSTALL_DIR}" "${OPENSSL_INSTALL_DIR}") -lt 0 ]; then
         printf "\tConfigure wolfProvider ... "
         if [ ! -e "${WOLFPROV_SOURCE_DIR}/configure" ]; then
             ./autogen.sh >>$LOG_FILE 2>&1

--- a/src/wp_ecdsa_sig.c
+++ b/src/wp_ecdsa_sig.c
@@ -256,7 +256,7 @@ static int wp_ecdsa_sign(wp_EcdsaSigCtx *ctx, unsigned char *sig,
         *sigLen = wc_ecc_sig_size(wp_ecc_get_key(ctx->ecc));
     }
     else {
-#ifdef wc_Hashes
+#if LIBWOLFSSL_VERSION_HEX >= 0x05007004
         if ((ctx->hash.type != WC_HASH_TYPE_NONE) &&
             (tbsLen != (size_t)wc_HashGetDigestSize(ctx->hash.type)))
 #else
@@ -423,7 +423,7 @@ static int wp_ecdsa_setup_md(wp_EcdsaSigCtx *ctx, const char *mdName,
     if (mdName != NULL) {
         int rc;
 
-#ifdef wc_Hashes
+#if LIBWOLFSSL_VERSION_HEX >= 0x05007004
         ctx->hash.type = wp_name_to_wc_hash_type(ctx->libCtx, mdName, mdProps);
         if ((ctx->hash.type == WC_HASH_TYPE_NONE) ||
             (ctx->hash.type == WC_HASH_TYPE_MD5))
@@ -435,7 +435,7 @@ static int wp_ecdsa_setup_md(wp_EcdsaSigCtx *ctx, const char *mdName,
         {
             ok = 0;
         }
-#ifdef wc_Hashes
+#if LIBWOLFSSL_VERSION_HEX >= 0x05007004
         if ((ctx->hash.type == WC_HASH_TYPE_SHA) && (op == EVP_PKEY_OP_SIGN))
 #else
         if ((ctx->hashType == WC_HASH_TYPE_SHA) && (op == EVP_PKEY_OP_SIGN))
@@ -445,7 +445,7 @@ static int wp_ecdsa_setup_md(wp_EcdsaSigCtx *ctx, const char *mdName,
         }
 
         if (ok) {
-#ifdef wc_Hashes
+#if LIBWOLFSSL_VERSION_HEX >= 0x05007004
             rc = wc_HashInit_ex(&ctx->hash, ctx->hash.type, NULL, INVALID_DEVID);
 #else
             rc = wc_HashInit_ex(&ctx->hash, ctx->hashType, NULL, INVALID_DEVID);
@@ -505,7 +505,7 @@ static int wp_ecdsa_digest_signverify_update(wp_EcdsaSigCtx *ctx,
 {
     int ok = 1;
     int rc = wc_HashUpdate(&ctx->hash,
-#ifdef wc_Hashes
+#if LIBWOLFSSL_VERSION_HEX >= 0x05007004
             ctx->hash.type,
 #else
             ctx->hashType,
@@ -569,7 +569,7 @@ static int wp_ecdsa_digest_sign_final(wp_EcdsaSigCtx *ctx, unsigned char *sig,
     }
     else if (sig != NULL) {
         int rc = wc_HashFinal(&ctx->hash,
-#ifdef wc_Hashes
+#if LIBWOLFSSL_VERSION_HEX >= 0x05007004
                 ctx->hash.type,
 #else
                 ctx->hashType,
@@ -583,7 +583,7 @@ static int wp_ecdsa_digest_sign_final(wp_EcdsaSigCtx *ctx, unsigned char *sig,
     if (ok) {
         ok = wp_ecdsa_sign(ctx, sig, sigLen, sigSize, digest,
             wc_HashGetDigestSize(
-#ifdef wc_Hashes
+#if LIBWOLFSSL_VERSION_HEX >= 0x05007004
                 ctx->hash.type
 #else
                 ctx->hashType
@@ -642,7 +642,7 @@ static int wp_ecdsa_digest_verify_final(wp_EcdsaSigCtx *ctx, unsigned char *sig,
     }
     else {
         int rc = wc_HashFinal(&ctx->hash,
-#ifdef wc_Hashes
+#if LIBWOLFSSL_VERSION_HEX >= 0x05007004
                 ctx->hash.type,
 #else
                 ctx->hashType,
@@ -655,7 +655,7 @@ static int wp_ecdsa_digest_verify_final(wp_EcdsaSigCtx *ctx, unsigned char *sig,
 
     if (ok) {
         ok = wp_ecdsa_verify(ctx,sig, sigLen, digest,
-#ifdef wc_Hashes
+#if LIBWOLFSSL_VERSION_HEX >= 0x05007004
             wc_HashGetDigestSize(ctx->hash.type)
 #else
             wc_HashGetDigestSize(ctx->hashType)

--- a/src/wp_ecdsa_sig.c
+++ b/src/wp_ecdsa_sig.c
@@ -51,7 +51,7 @@ typedef struct wp_EcdsaSigCtx {
 
     /** wolfSSL hash object. */
     wc_HashAlg hash;
-#ifndef wc_Hashes
+#if LIBWOLFSSL_VERSION_HEX < 0x05007004
     /** Hash algorithm to use on data to be signed. */
     enum wc_HashType hashType;
 #endif
@@ -143,7 +143,7 @@ static wp_EcdsaSigCtx* wp_ecdsa_dupctx(wp_EcdsaSigCtx* srcCtx)
         }
 
         if (ok && (!wp_hash_copy(&srcCtx->hash, &dstCtx->hash
-#ifndef wc_Hashes
+#if LIBWOLFSSL_VERSION_HEX < 0x05007004
                         ,srcCtx->hashType
 #endif
                         ))) {
@@ -154,7 +154,7 @@ static wp_EcdsaSigCtx* wp_ecdsa_dupctx(wp_EcdsaSigCtx* srcCtx)
         }
         if (ok) {
             dstCtx->ecc      = srcCtx->ecc;
-#ifndef wc_Hashes
+#if LIBWOLFSSL_VERSION_HEX < 0x05007004
             dstCtx->hashType = srcCtx->hashType;
 #endif
             dstCtx->op       = srcCtx->op;

--- a/src/wp_ecx_sig.c
+++ b/src/wp_ecx_sig.c
@@ -137,7 +137,7 @@ static wp_EcxSigCtx* wp_ecx_dupctx(wp_EcxSigCtx* srcCtx)
             ok = 0;
         }
 
-#ifdef wc_Hashes
+#if LIBWOLFSSL_VERSION_HEX >= 0x05007004
         if (ok && (!wp_hash_copy(&srcCtx->hash, &dstCtx->hash)))
 #else
         if (ok && (!wp_hash_copy(&srcCtx->hash, &dstCtx->hash, srcCtx->hashType)))

--- a/src/wp_ecx_sig.c
+++ b/src/wp_ecx_sig.c
@@ -50,8 +50,6 @@ typedef struct wp_EcxSigCtx {
 
     /** wolfSSL hash object. */
     wc_HashAlg hash;
-    /** Hash algorithm to use on data to be signed. */
-    enum wc_HashType hashType;
 
     /** Property query string. */
     char* propQuery;
@@ -135,8 +133,7 @@ static wp_EcxSigCtx* wp_ecx_dupctx(wp_EcxSigCtx* srcCtx)
             ok = 0;
         }
 
-        if (ok && (!wp_hash_copy(&srcCtx->hash, &dstCtx->hash,
-                                 srcCtx->hashType))) {
+        if (ok && (!wp_hash_copy(&srcCtx->hash, &dstCtx->hash))) {
             ok = 0;
         }
         if (ok && (!wp_ecx_up_ref(srcCtx->ecx))) {
@@ -144,7 +141,6 @@ static wp_EcxSigCtx* wp_ecx_dupctx(wp_EcxSigCtx* srcCtx)
         }
         if (ok) {
             dstCtx->ecx      = srcCtx->ecx;
-            dstCtx->hashType = srcCtx->hashType;
             dstCtx->op       = srcCtx->op;
             XMEMCPY(dstCtx->mdName, srcCtx->mdName, sizeof(srcCtx->mdName));
         }

--- a/src/wp_ecx_sig.c
+++ b/src/wp_ecx_sig.c
@@ -50,7 +50,7 @@ typedef struct wp_EcxSigCtx {
 
     /** wolfSSL hash object. */
     wc_HashAlg hash;
-#ifndef wc_Hashes
+#if LIBWOLFSSL_VERSION_HEX < 0x05007004
     /** Hash algorithm to use on data to be signed. */
     enum wc_HashType hashType;
 #endif
@@ -150,7 +150,7 @@ static wp_EcxSigCtx* wp_ecx_dupctx(wp_EcxSigCtx* srcCtx)
         }
         if (ok) {
             dstCtx->ecx      = srcCtx->ecx;
-#ifndef wc_Hashes
+#if LIBWOLFSSL_VERSION_HEX < 0x05007004
             dstCtx->hashType = srcCtx->hashType;
 #endif
             dstCtx->op       = srcCtx->op;

--- a/src/wp_ecx_sig.c
+++ b/src/wp_ecx_sig.c
@@ -50,6 +50,10 @@ typedef struct wp_EcxSigCtx {
 
     /** wolfSSL hash object. */
     wc_HashAlg hash;
+#ifndef wc_Hashes
+    /** Hash algorithm to use on data to be signed. */
+    enum wc_HashType hashType;
+#endif
 
     /** Property query string. */
     char* propQuery;
@@ -133,7 +137,12 @@ static wp_EcxSigCtx* wp_ecx_dupctx(wp_EcxSigCtx* srcCtx)
             ok = 0;
         }
 
-        if (ok && (!wp_hash_copy(&srcCtx->hash, &dstCtx->hash))) {
+#ifdef wc_Hashes
+        if (ok && (!wp_hash_copy(&srcCtx->hash, &dstCtx->hash)))
+#else
+        if (ok && (!wp_hash_copy(&srcCtx->hash, &dstCtx->hash, srcCtx->hashType)))
+#endif
+        {
             ok = 0;
         }
         if (ok && (!wp_ecx_up_ref(srcCtx->ecx))) {
@@ -141,6 +150,9 @@ static wp_EcxSigCtx* wp_ecx_dupctx(wp_EcxSigCtx* srcCtx)
         }
         if (ok) {
             dstCtx->ecx      = srcCtx->ecx;
+#ifndef wc_Hashes
+            dstCtx->hashType = srcCtx->hashType;
+#endif
             dstCtx->op       = srcCtx->op;
             XMEMCPY(dstCtx->mdName, srcCtx->mdName, sizeof(srcCtx->mdName));
         }

--- a/src/wp_internal.c
+++ b/src/wp_internal.c
@@ -248,62 +248,99 @@ int wp_mgf1_from_hash(int nid)
  * @return  1 on success.
  * @return  0 on failure.
  */
-int wp_hash_copy(wc_HashAlg* src, wc_HashAlg* dst)
+int wp_hash_copy(wc_HashAlg* src, wc_HashAlg* dst, enum wc_HashType hashType)
 {
     int ok = 1;
     int rc = 0;
 
-    switch (src->type) {
+#ifdef wc_Hashes
+    switch (src->type)
+#else
+    switch (hashType)
+#endif
+    {
     case WC_HASH_TYPE_MD5:
 #ifdef WP_HAVE_MD5
+#ifdef wc_Hashes
         rc = wc_Md5Copy(&src->alg.md5, &dst->alg.md5);
+#else
+        rc = wc_Md5Copy(&src->md5, &dst->md5);
+#endif
 #else
         ok = 0;
 #endif
         break;
     case WC_HASH_TYPE_SHA:
 #ifdef WP_HAVE_SHA1
+#ifdef wc_Hashes
         rc = wc_ShaCopy(&src->alg.sha, &dst->alg.sha);
+#else
+        rc = wc_ShaCopy(&src->sha, &dst->sha);
+#endif
 #else
         ok = 0;
 #endif
         break;
     case WC_HASH_TYPE_SHA224:
 #ifdef WP_HAVE_SHA224
+#ifdef wc_Hashes
         rc = wc_Sha224Copy(&src->alg.sha224, &dst->alg.sha224);
+#else
+        rc = wc_Sha224Copy(&src->sha224, &dst->sha224);
+#endif
 #else
         ok = 0;
 #endif
         break;
     case WC_HASH_TYPE_SHA256:
 #ifdef WP_HAVE_SHA256
+#ifdef wc_Hashes
         rc = wc_Sha256Copy(&src->alg.sha256, &dst->alg.sha256);
+#else
+        rc = wc_Sha256Copy(&src->sha256, &dst->sha256);
+#endif
 #else
         ok = 0;
 #endif
         break;
     case WC_HASH_TYPE_SHA384:
 #ifdef WP_HAVE_SHA384
+#ifdef wc_Hashes
         rc = wc_Sha384Copy(&src->alg.sha384, &dst->alg.sha384);
+#else
+        rc = wc_Sha384Copy(&src->sha384, &dst->sha384);
+#endif
 #else
         ok = 0;
 #endif
         break;
 #ifdef WP_HAVE_SHA512
     case WC_HASH_TYPE_SHA512:
+#ifdef wc_Hashes
         rc = wc_Sha512Copy(&src->alg.sha512, &dst->alg.sha512);
+#else
+        rc = wc_Sha512Copy(&src->sha512, &dst->sha512);
+#endif
         break;
 #if LIBWOLFSSL_VERSION_HEX >= 0x05000000
 #if !defined(WOLFSSL_NOSHA512_224) && !defined(HAVE_FIPS) && \
         !defined(SELF_TEST)
     case WC_HASH_TYPE_SHA512_224:
+#ifdef wc_Hashes
         rc = wc_Sha512_224Copy(&src->alg.sha512, &dst->alg.sha512);
+#else
+        rc = wc_Sha512_224Copy(&src->sha512, &dst->sha512);
+#endif
         break;
 #endif /* !WOLFSSL_NOSHA512_224 */
 #if !defined(WOLFSSL_NOSHA512_256) && !defined(HAVE_FIPS) && \
         !defined(SELF_TEST)
     case WC_HASH_TYPE_SHA512_256:
+#ifdef wc_Hashes
         rc = wc_Sha512_256Copy(&src->alg.sha512, &dst->alg.sha512);
+#else
+        rc = wc_Sha512_256Copy(&src->sha512, &dst->sha512);
+#endif
         break;
 #endif /* !WOLFSSL_NOSHA512_256 */
 #endif /* LIBWOLFSSL_VERSION_HEX >= 0x05000000 */
@@ -316,16 +353,32 @@ int wp_hash_copy(wc_HashAlg* src, wc_HashAlg* dst)
 #endif /* WP_HAVE_SHA512 */
 #ifdef WP_HAVE_SHA3
     case WC_HASH_TYPE_SHA3_224:
+#ifdef wc_Hashes
         rc = wc_Sha3_224_Copy(&src->alg.sha3, &dst->alg.sha3);
+#else
+        rc = wc_Sha3_224_Copy(&src->sha3, &dst->sha3);
+#endif
         break;
     case WC_HASH_TYPE_SHA3_256:
+#ifdef wc_Hashes
         rc = wc_Sha3_256_Copy(&src->alg.sha3, &dst->alg.sha3);
+#else
+        rc = wc_Sha3_256_Copy(&src->sha3, &dst->sha3);
+#endif
         break;
     case WC_HASH_TYPE_SHA3_384:
+#ifdef wc_Hashes
         rc = wc_Sha3_384_Copy(&src->alg.sha3, &dst->alg.sha3);
+#else
+        rc = wc_Sha3_384_Copy(&src->sha3, &dst->sha3);
+#endif
         break;
     case WC_HASH_TYPE_SHA3_512:
+#ifdef wc_Hashes
         rc = wc_Sha3_512_Copy(&src->alg.sha3, &dst->alg.sha3);
+#else
+        rc = wc_Sha3_512_Copy(&src->sha3, &dst->sha3);
+#endif
         break;
 #else
     case WC_HASH_TYPE_SHA3_224:
@@ -355,8 +408,10 @@ int wp_hash_copy(wc_HashAlg* src, wc_HashAlg* dst)
     }
     if (rc != 0) {
         ok = 0;
+#ifdef wc_Hashes
     } else {
         dst->type = src->type;
+#endif
     }
 
     WOLFPROV_LEAVE(WP_LOG_PROVIDER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);

--- a/src/wp_internal.c
+++ b/src/wp_internal.c
@@ -248,7 +248,11 @@ int wp_mgf1_from_hash(int nid)
  * @return  1 on success.
  * @return  0 on failure.
  */
+#if LIBWOLFSSL_VERSION_HEX >= 0x05007004
+int wp_hash_copy(wc_HashAlg* src, wc_HashAlg* dst)
+#else
 int wp_hash_copy(wc_HashAlg* src, wc_HashAlg* dst, enum wc_HashType hashType)
+#endif
 {
     int ok = 1;
     int rc = 0;

--- a/src/wp_internal.c
+++ b/src/wp_internal.c
@@ -248,62 +248,62 @@ int wp_mgf1_from_hash(int nid)
  * @return  1 on success.
  * @return  0 on failure.
  */
-int wp_hash_copy(wc_HashAlg* src, wc_HashAlg* dst, enum wc_HashType hashType)
+int wp_hash_copy(wc_HashAlg* src, wc_HashAlg* dst)
 {
     int ok = 1;
     int rc = 0;
 
-    switch (hashType) {
+    switch (src->type) {
     case WC_HASH_TYPE_MD5:
 #ifdef WP_HAVE_MD5
-        rc = wc_Md5Copy(&src->md5, &dst->md5);
+        rc = wc_Md5Copy(&src->alg.md5, &dst->alg.md5);
 #else
         ok = 0;
 #endif
         break;
     case WC_HASH_TYPE_SHA:
 #ifdef WP_HAVE_SHA1
-        rc = wc_ShaCopy(&src->sha, &dst->sha);
+        rc = wc_ShaCopy(&src->alg.sha, &dst->alg.sha);
 #else
         ok = 0;
 #endif
         break;
     case WC_HASH_TYPE_SHA224:
 #ifdef WP_HAVE_SHA224
-        rc = wc_Sha224Copy(&src->sha224, &dst->sha224);
+        rc = wc_Sha224Copy(&src->alg.sha224, &dst->alg.sha224);
 #else
         ok = 0;
 #endif
         break;
     case WC_HASH_TYPE_SHA256:
 #ifdef WP_HAVE_SHA256
-        rc = wc_Sha256Copy(&src->sha256, &dst->sha256);
+        rc = wc_Sha256Copy(&src->alg.sha256, &dst->alg.sha256);
 #else
         ok = 0;
 #endif
         break;
     case WC_HASH_TYPE_SHA384:
 #ifdef WP_HAVE_SHA384
-        rc = wc_Sha384Copy(&src->sha384, &dst->sha384);
+        rc = wc_Sha384Copy(&src->alg.sha384, &dst->alg.sha384);
 #else
         ok = 0;
 #endif
         break;
 #ifdef WP_HAVE_SHA512
     case WC_HASH_TYPE_SHA512:
-        rc = wc_Sha512Copy(&src->sha512, &dst->sha512);
+        rc = wc_Sha512Copy(&src->alg.sha512, &dst->alg.sha512);
         break;
 #if LIBWOLFSSL_VERSION_HEX >= 0x05000000
 #if !defined(WOLFSSL_NOSHA512_224) && !defined(HAVE_FIPS) && \
         !defined(SELF_TEST)
     case WC_HASH_TYPE_SHA512_224:
-        rc = wc_Sha512_224Copy(&src->sha512, &dst->sha512);
+        rc = wc_Sha512_224Copy(&src->alg.sha512, &dst->alg.sha512);
         break;
 #endif /* !WOLFSSL_NOSHA512_224 */
 #if !defined(WOLFSSL_NOSHA512_256) && !defined(HAVE_FIPS) && \
         !defined(SELF_TEST)
     case WC_HASH_TYPE_SHA512_256:
-        rc = wc_Sha512_256Copy(&src->sha512, &dst->sha512);
+        rc = wc_Sha512_256Copy(&src->alg.sha512, &dst->alg.sha512);
         break;
 #endif /* !WOLFSSL_NOSHA512_256 */
 #endif /* LIBWOLFSSL_VERSION_HEX >= 0x05000000 */
@@ -316,16 +316,16 @@ int wp_hash_copy(wc_HashAlg* src, wc_HashAlg* dst, enum wc_HashType hashType)
 #endif /* WP_HAVE_SHA512 */
 #ifdef WP_HAVE_SHA3
     case WC_HASH_TYPE_SHA3_224:
-        rc = wc_Sha3_224_Copy(&src->sha3, &dst->sha3);
+        rc = wc_Sha3_224_Copy(&src->alg.sha3, &dst->alg.sha3);
         break;
     case WC_HASH_TYPE_SHA3_256:
-        rc = wc_Sha3_256_Copy(&src->sha3, &dst->sha3);
+        rc = wc_Sha3_256_Copy(&src->alg.sha3, &dst->alg.sha3);
         break;
     case WC_HASH_TYPE_SHA3_384:
-        rc = wc_Sha3_384_Copy(&src->sha3, &dst->sha3);
+        rc = wc_Sha3_384_Copy(&src->alg.sha3, &dst->alg.sha3);
         break;
     case WC_HASH_TYPE_SHA3_512:
-        rc = wc_Sha3_512_Copy(&src->sha3, &dst->sha3);
+        rc = wc_Sha3_512_Copy(&src->alg.sha3, &dst->alg.sha3);
         break;
 #else
     case WC_HASH_TYPE_SHA3_224:
@@ -355,6 +355,8 @@ int wp_hash_copy(wc_HashAlg* src, wc_HashAlg* dst, enum wc_HashType hashType)
     }
     if (rc != 0) {
         ok = 0;
+    } else {
+        dst->type = src->type;
     }
 
     WOLFPROV_LEAVE(WP_LOG_PROVIDER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);

--- a/src/wp_internal.c
+++ b/src/wp_internal.c
@@ -253,7 +253,7 @@ int wp_hash_copy(wc_HashAlg* src, wc_HashAlg* dst, enum wc_HashType hashType)
     int ok = 1;
     int rc = 0;
 
-#ifdef wc_Hashes
+#if LIBWOLFSSL_VERSION_HEX >= 0x05007004
     switch (src->type)
 #else
     switch (hashType)
@@ -261,7 +261,7 @@ int wp_hash_copy(wc_HashAlg* src, wc_HashAlg* dst, enum wc_HashType hashType)
     {
     case WC_HASH_TYPE_MD5:
 #ifdef WP_HAVE_MD5
-#ifdef wc_Hashes
+#if LIBWOLFSSL_VERSION_HEX >= 0x05007004
         rc = wc_Md5Copy(&src->alg.md5, &dst->alg.md5);
 #else
         rc = wc_Md5Copy(&src->md5, &dst->md5);
@@ -272,7 +272,7 @@ int wp_hash_copy(wc_HashAlg* src, wc_HashAlg* dst, enum wc_HashType hashType)
         break;
     case WC_HASH_TYPE_SHA:
 #ifdef WP_HAVE_SHA1
-#ifdef wc_Hashes
+#if LIBWOLFSSL_VERSION_HEX >= 0x05007004
         rc = wc_ShaCopy(&src->alg.sha, &dst->alg.sha);
 #else
         rc = wc_ShaCopy(&src->sha, &dst->sha);
@@ -283,7 +283,7 @@ int wp_hash_copy(wc_HashAlg* src, wc_HashAlg* dst, enum wc_HashType hashType)
         break;
     case WC_HASH_TYPE_SHA224:
 #ifdef WP_HAVE_SHA224
-#ifdef wc_Hashes
+#if LIBWOLFSSL_VERSION_HEX >= 0x05007004
         rc = wc_Sha224Copy(&src->alg.sha224, &dst->alg.sha224);
 #else
         rc = wc_Sha224Copy(&src->sha224, &dst->sha224);
@@ -294,7 +294,7 @@ int wp_hash_copy(wc_HashAlg* src, wc_HashAlg* dst, enum wc_HashType hashType)
         break;
     case WC_HASH_TYPE_SHA256:
 #ifdef WP_HAVE_SHA256
-#ifdef wc_Hashes
+#if LIBWOLFSSL_VERSION_HEX >= 0x05007004
         rc = wc_Sha256Copy(&src->alg.sha256, &dst->alg.sha256);
 #else
         rc = wc_Sha256Copy(&src->sha256, &dst->sha256);
@@ -305,7 +305,7 @@ int wp_hash_copy(wc_HashAlg* src, wc_HashAlg* dst, enum wc_HashType hashType)
         break;
     case WC_HASH_TYPE_SHA384:
 #ifdef WP_HAVE_SHA384
-#ifdef wc_Hashes
+#if LIBWOLFSSL_VERSION_HEX >= 0x05007004
         rc = wc_Sha384Copy(&src->alg.sha384, &dst->alg.sha384);
 #else
         rc = wc_Sha384Copy(&src->sha384, &dst->sha384);
@@ -316,7 +316,7 @@ int wp_hash_copy(wc_HashAlg* src, wc_HashAlg* dst, enum wc_HashType hashType)
         break;
 #ifdef WP_HAVE_SHA512
     case WC_HASH_TYPE_SHA512:
-#ifdef wc_Hashes
+#if LIBWOLFSSL_VERSION_HEX >= 0x05007004
         rc = wc_Sha512Copy(&src->alg.sha512, &dst->alg.sha512);
 #else
         rc = wc_Sha512Copy(&src->sha512, &dst->sha512);
@@ -326,7 +326,7 @@ int wp_hash_copy(wc_HashAlg* src, wc_HashAlg* dst, enum wc_HashType hashType)
 #if !defined(WOLFSSL_NOSHA512_224) && !defined(HAVE_FIPS) && \
         !defined(SELF_TEST)
     case WC_HASH_TYPE_SHA512_224:
-#ifdef wc_Hashes
+#if LIBWOLFSSL_VERSION_HEX >= 0x05007004
         rc = wc_Sha512_224Copy(&src->alg.sha512, &dst->alg.sha512);
 #else
         rc = wc_Sha512_224Copy(&src->sha512, &dst->sha512);
@@ -336,7 +336,7 @@ int wp_hash_copy(wc_HashAlg* src, wc_HashAlg* dst, enum wc_HashType hashType)
 #if !defined(WOLFSSL_NOSHA512_256) && !defined(HAVE_FIPS) && \
         !defined(SELF_TEST)
     case WC_HASH_TYPE_SHA512_256:
-#ifdef wc_Hashes
+#if LIBWOLFSSL_VERSION_HEX >= 0x05007004
         rc = wc_Sha512_256Copy(&src->alg.sha512, &dst->alg.sha512);
 #else
         rc = wc_Sha512_256Copy(&src->sha512, &dst->sha512);
@@ -353,28 +353,28 @@ int wp_hash_copy(wc_HashAlg* src, wc_HashAlg* dst, enum wc_HashType hashType)
 #endif /* WP_HAVE_SHA512 */
 #ifdef WP_HAVE_SHA3
     case WC_HASH_TYPE_SHA3_224:
-#ifdef wc_Hashes
+#if LIBWOLFSSL_VERSION_HEX >= 0x05007004
         rc = wc_Sha3_224_Copy(&src->alg.sha3, &dst->alg.sha3);
 #else
         rc = wc_Sha3_224_Copy(&src->sha3, &dst->sha3);
 #endif
         break;
     case WC_HASH_TYPE_SHA3_256:
-#ifdef wc_Hashes
+#if LIBWOLFSSL_VERSION_HEX >= 0x05007004
         rc = wc_Sha3_256_Copy(&src->alg.sha3, &dst->alg.sha3);
 #else
         rc = wc_Sha3_256_Copy(&src->sha3, &dst->sha3);
 #endif
         break;
     case WC_HASH_TYPE_SHA3_384:
-#ifdef wc_Hashes
+#if LIBWOLFSSL_VERSION_HEX >= 0x05007004
         rc = wc_Sha3_384_Copy(&src->alg.sha3, &dst->alg.sha3);
 #else
         rc = wc_Sha3_384_Copy(&src->sha3, &dst->sha3);
 #endif
         break;
     case WC_HASH_TYPE_SHA3_512:
-#ifdef wc_Hashes
+#if LIBWOLFSSL_VERSION_HEX >= 0x05007004
         rc = wc_Sha3_512_Copy(&src->alg.sha3, &dst->alg.sha3);
 #else
         rc = wc_Sha3_512_Copy(&src->sha3, &dst->sha3);
@@ -408,7 +408,7 @@ int wp_hash_copy(wc_HashAlg* src, wc_HashAlg* dst, enum wc_HashType hashType)
     }
     if (rc != 0) {
         ok = 0;
-#ifdef wc_Hashes
+#if LIBWOLFSSL_VERSION_HEX >= 0x05007004
     } else {
         dst->type = src->type;
 #endif

--- a/src/wp_rsa_sig.c
+++ b/src/wp_rsa_sig.c
@@ -138,7 +138,7 @@ static int wp_rsa_setup_md(wp_RsaSigCtx* ctx, const char* mdName,
             (hashType == WC_HASH_TYPE_MD5)) {
             ok = 0;
         }
-#ifdef wc_Hashes
+#if LIBWOLFSSL_VERSION_HEX >= 0x05007004
         if (ok && (ctx->hash.type != WC_HASH_TYPE_NONE) &&
             (hashType != ctx->hash.type))
 #else
@@ -156,7 +156,7 @@ static int wp_rsa_setup_md(wp_RsaSigCtx* ctx, const char* mdName,
         (void)op;
 #endif
         if (ok) {
-#ifdef wc_Hashes
+#if LIBWOLFSSL_VERSION_HEX >= 0x05007004
             ctx->hash.type = hashType;
 #else
             ctx->hashType = hashType;
@@ -164,7 +164,7 @@ static int wp_rsa_setup_md(wp_RsaSigCtx* ctx, const char* mdName,
         }
 
         if (ok) {
-#ifdef wc_Hashes
+#if LIBWOLFSSL_VERSION_HEX >= 0x05007004
             rc = wc_HashInit_ex(&ctx->hash, ctx->hash.type, NULL, INVALID_DEVID);
 #else
             rc = wc_HashInit_ex(&ctx->hash, ctx->hashType, NULL, INVALID_DEVID);
@@ -311,7 +311,7 @@ static wp_RsaSigCtx* wp_rsa_ctx_dup(wp_RsaSigCtx* srcCtx)
             ok = 0;
         }
 
-#ifdef wc_Hashes
+#if LIBWOLFSSL_VERSION_HEX >= 0x05007004
         if (ok && (srcCtx->hash.type != WC_HASH_TYPE_NONE) &&
             (!wp_hash_copy(&srcCtx->hash, &dstCtx->hash)))
 #else
@@ -402,7 +402,7 @@ static int wp_rsa_check_pss_salt_len(wp_RsaSigCtx* ctx)
     int maxSaltLen;
     int bits = wp_rsa_get_bits(ctx->rsa);
 
-#ifdef wc_Hashes
+#if LIBWOLFSSL_VERSION_HEX >= 0x05007004
     maxSaltLen = ((bits + 7) / 8) - wc_HashGetDigestSize(ctx->hash.type) - 2;
 #else
     maxSaltLen = ((bits + 7) / 8) - wc_HashGetDigestSize(ctx->hashType) - 2;
@@ -546,13 +546,13 @@ static int wp_rsa_sign_pkcs1(wp_RsaSigCtx* ctx, unsigned char* sig,
     unsigned char* encodedDigest = NULL;
     int encodedDigestLen = 0;
 
-#ifdef wc_Hashes
+#if LIBWOLFSSL_VERSION_HEX >= 0x05007004
     if (ctx->hash.type != WC_HASH_TYPE_NONE)
 #else
     if (ctx->hashType != WC_HASH_TYPE_NONE)
 #endif
     {
-#ifdef wc_Hashes
+#if LIBWOLFSSL_VERSION_HEX >= 0x05007004
         if (tbsLen != (size_t)wc_HashGetDigestSize(ctx->hash.type))
 #else
         if (tbsLen != (size_t)wc_HashGetDigestSize(ctx->hashType))
@@ -567,7 +567,7 @@ static int wp_rsa_sign_pkcs1(wp_RsaSigCtx* ctx, unsigned char* sig,
             }
         }
         if (ok) {
-#ifdef wc_Hashes
+#if LIBWOLFSSL_VERSION_HEX >= 0x05007004
             encodedDigestLen = wc_EncodeSignature(encodedDigest, tbs,
                 (word32)tbsLen, wc_HashGetOID(ctx->hash.type));
 #else
@@ -623,7 +623,7 @@ static int wp_rsa_sign_pss(wp_RsaSigCtx* ctx, unsigned char* sig,
     int ok = 1;
     int rc;
     int saltLen = wp_pss_salt_len_to_wc(ctx->saltLen,
-#ifdef wc_Hashes
+#if LIBWOLFSSL_VERSION_HEX >= 0x05007004
         ctx->hash.type,
 #else
         ctx->hashType,
@@ -632,7 +632,7 @@ static int wp_rsa_sign_pss(wp_RsaSigCtx* ctx, unsigned char* sig,
 
     PRIVATE_KEY_UNLOCK();
     rc = wc_RsaPSS_Sign_ex(tbs, (word32)tbsLen, sig, (word32)sigSize,
-#ifdef wc_Hashes
+#if LIBWOLFSSL_VERSION_HEX >= 0x05007004
         ctx->hash.type,
 #else
         ctx->hashType,
@@ -802,7 +802,7 @@ static int wp_rsa_verify_pkcs1(wp_RsaSigCtx* ctx, const unsigned char* sig,
         if (ok) {
             encodedDigestLen = wc_EncodeSignature(encodedDigest, tbs,
                 (word32)tbsLen, wc_HashGetOID(
-#ifdef wc_Hashes
+#if LIBWOLFSSL_VERSION_HEX >= 0x05007004
                     ctx->hash.type
 #else
                     ctx->hashType
@@ -848,7 +848,7 @@ static int wp_rsa_verify_pss(wp_RsaSigCtx* ctx, const unsigned char* sig,
     int rc;
     int saltLen;
 
-#ifdef wc_Hashes
+#if LIBWOLFSSL_VERSION_HEX >= 0x05007004
     if (ctx->hash.type == WC_HASH_TYPE_NONE)
 #else
     if (ctx->hashType == WC_HASH_TYPE_NONE)
@@ -858,7 +858,7 @@ static int wp_rsa_verify_pss(wp_RsaSigCtx* ctx, const unsigned char* sig,
     }
     if (ok) {
         saltLen = wp_pss_salt_len_to_wc(ctx->saltLen,
-#ifdef wc_Hashes
+#if LIBWOLFSSL_VERSION_HEX >= 0x05007004
                 ctx->hash.type,
 #else
                 ctx->hashType,
@@ -867,7 +867,7 @@ static int wp_rsa_verify_pss(wp_RsaSigCtx* ctx, const unsigned char* sig,
 
         rc = wc_RsaPSS_Verify_ex((byte*)sig, (word32)sigLen, decryptedSig,
             (word32)sigLen,
-#ifdef wc_Hashes
+#if LIBWOLFSSL_VERSION_HEX >= 0x05007004
             ctx->hash.type,
 #else
             ctx->hashType,
@@ -880,7 +880,7 @@ static int wp_rsa_verify_pss(wp_RsaSigCtx* ctx, const unsigned char* sig,
     }
     if (ok) {
         rc = wc_RsaPSS_CheckPadding_ex(tbs, (word32)tbsLen, decryptedSig, rc,
-#ifdef wc_Hashes
+#if LIBWOLFSSL_VERSION_HEX >= 0x05007004
             ctx->hash.type,
 #else
             ctx->hashType,
@@ -1071,7 +1071,7 @@ static int wp_rsa_digest_signverify_update(wp_RsaSigCtx* ctx,
 {
     int ok = 1;
     int rc = wc_HashUpdate(&ctx->hash,
-#ifdef wc_Hashes
+#if LIBWOLFSSL_VERSION_HEX >= 0x05007004
             ctx->hash.type,
 #else
             ctx->hashType,
@@ -1135,7 +1135,7 @@ static int wp_rsa_digest_sign_final(wp_RsaSigCtx* ctx, unsigned char* sig,
     }
     else if (sig != NULL) {
         int rc = wc_HashFinal(&ctx->hash,
-#ifdef wc_Hashes
+#if LIBWOLFSSL_VERSION_HEX >= 0x05007004
                 ctx->hash.type,
 #else
                 ctx->hashType,
@@ -1149,7 +1149,7 @@ static int wp_rsa_digest_sign_final(wp_RsaSigCtx* ctx, unsigned char* sig,
     if (ok) {
         ok = wp_rsa_sign(ctx, sig, sigLen, sigSize, digest,
             wc_HashGetDigestSize(
-#ifdef wc_Hashes
+#if LIBWOLFSSL_VERSION_HEX >= 0x05007004
                 ctx->hash.type
 #else
                 ctx->hashType
@@ -1208,7 +1208,7 @@ static int wp_rsa_digest_verify_final(wp_RsaSigCtx* ctx, unsigned char* sig,
     }
     else {
         int rc = wc_HashFinal(&ctx->hash,
-#ifdef wc_Hashes
+#if LIBWOLFSSL_VERSION_HEX >= 0x05007004
                 ctx->hash.type,
 #else
                 ctx->hashType,
@@ -1222,7 +1222,7 @@ static int wp_rsa_digest_verify_final(wp_RsaSigCtx* ctx, unsigned char* sig,
     if (ok) {
         ok = wp_rsa_verify(ctx,sig, sigLen, digest,
             wc_HashGetDigestSize(
-#ifdef wc_Hashes
+#if LIBWOLFSSL_VERSION_HEX >= 0x05007004
                 ctx->hash.type
 #else
                 ctx->hashType
@@ -1502,7 +1502,7 @@ static int wp_rsa_set_pad_mode(wp_RsaSigCtx* ctx, const OSSL_PARAM* p)
             }
         }
         else if (padMode == RSA_NO_PADDING) {
-#ifdef wc_Hashes
+#if LIBWOLFSSL_VERSION_HEX >= 0x05007004
             if (ctx->hash.type != WC_HASH_TYPE_NONE)
 #else
             if (ctx->hashType != WC_HASH_TYPE_NONE)

--- a/src/wp_rsa_sig.c
+++ b/src/wp_rsa_sig.c
@@ -80,6 +80,10 @@ typedef struct wp_RsaSigCtx {
 
     /** wolfSSL hash object. */
     wc_HashAlg hash;
+#ifndef wc_Hashes
+    /** Hash algorithm to use on data to be signed. */
+    enum wc_HashType hashType;
+#endif
     /** Length of salt to use when padding mode is PSS. */
     int saltLen;
     /** Minimum salt length when padding mode is PSS based on RSA key. */
@@ -134,8 +138,14 @@ static int wp_rsa_setup_md(wp_RsaSigCtx* ctx, const char* mdName,
             (hashType == WC_HASH_TYPE_MD5)) {
             ok = 0;
         }
+#ifdef wc_Hashes
         if (ok && (ctx->hash.type != WC_HASH_TYPE_NONE) &&
-            (hashType != ctx->hash.type)) {
+            (hashType != ctx->hash.type))
+#else
+        if (ok && (ctx->hashType != WC_HASH_TYPE_NONE) &&
+            (hashType != ctx->hashType))
+#endif
+        {
             ok = 0;
         }
 #ifdef HAVE_FIPS
@@ -146,11 +156,19 @@ static int wp_rsa_setup_md(wp_RsaSigCtx* ctx, const char* mdName,
         (void)op;
 #endif
         if (ok) {
+#ifdef wc_Hashes
             ctx->hash.type = hashType;
+#else
+            ctx->hashType = hashType;
+#endif
         }
 
         if (ok) {
+#ifdef wc_Hashes
             rc = wc_HashInit_ex(&ctx->hash, ctx->hash.type, NULL, INVALID_DEVID);
+#else
+            rc = wc_HashInit_ex(&ctx->hash, ctx->hashType, NULL, INVALID_DEVID);
+#endif
             if (rc != 0) {
                 ok = 0;
             }
@@ -293,8 +311,14 @@ static wp_RsaSigCtx* wp_rsa_ctx_dup(wp_RsaSigCtx* srcCtx)
             ok = 0;
         }
 
+#ifdef wc_Hashes
         if (ok && (srcCtx->hash.type != WC_HASH_TYPE_NONE) &&
-            (!wp_hash_copy(&srcCtx->hash, &dstCtx->hash))) {
+            (!wp_hash_copy(&srcCtx->hash, &dstCtx->hash)))
+#else
+        if (ok && (srcCtx->hashType != WC_HASH_TYPE_NONE) &&
+            (!wp_hash_copy(&srcCtx->hash, &dstCtx->hash,srcCtx->hashType)))
+#endif
+        {
             ok = 0;
         }
         if (ok && (!wp_rsa_up_ref(srcCtx->rsa))) {
@@ -302,6 +326,9 @@ static wp_RsaSigCtx* wp_rsa_ctx_dup(wp_RsaSigCtx* srcCtx)
         }
         if (ok) {
             dstCtx->rsa      = srcCtx->rsa;
+#ifndef wc_Hashes
+            dstCtx->hashType = srcCtx->hashType;
+#endif
             dstCtx->mgf      = srcCtx->mgf;
             dstCtx->mgfSet   = srcCtx->mgfSet;
             dstCtx->padMode  = srcCtx->padMode;
@@ -375,7 +402,11 @@ static int wp_rsa_check_pss_salt_len(wp_RsaSigCtx* ctx)
     int maxSaltLen;
     int bits = wp_rsa_get_bits(ctx->rsa);
 
+#ifdef wc_Hashes
     maxSaltLen = ((bits + 7) / 8) - wc_HashGetDigestSize(ctx->hash.type) - 2;
+#else
+    maxSaltLen = ((bits + 7) / 8) - wc_HashGetDigestSize(ctx->hashType) - 2;
+#endif
     if (((bits - 1) & 0x07) == 0) {
         maxSaltLen--;
     }
@@ -515,8 +546,18 @@ static int wp_rsa_sign_pkcs1(wp_RsaSigCtx* ctx, unsigned char* sig,
     unsigned char* encodedDigest = NULL;
     int encodedDigestLen = 0;
 
-    if (ctx->hash.type != WC_HASH_TYPE_NONE) {
-        if (tbsLen != (size_t)wc_HashGetDigestSize(ctx->hash.type)) {
+#ifdef wc_Hashes
+    if (ctx->hash.type != WC_HASH_TYPE_NONE)
+#else
+    if (ctx->hashType != WC_HASH_TYPE_NONE)
+#endif
+    {
+#ifdef wc_Hashes
+        if (tbsLen != (size_t)wc_HashGetDigestSize(ctx->hash.type))
+#else
+        if (tbsLen != (size_t)wc_HashGetDigestSize(ctx->hashType))
+#endif
+        {
             ok = 0;
         }
         if (ok) {
@@ -526,8 +567,13 @@ static int wp_rsa_sign_pkcs1(wp_RsaSigCtx* ctx, unsigned char* sig,
             }
         }
         if (ok) {
+#ifdef wc_Hashes
             encodedDigestLen = wc_EncodeSignature(encodedDigest, tbs,
                 (word32)tbsLen, wc_HashGetOID(ctx->hash.type));
+#else
+            encodedDigestLen = wc_EncodeSignature(encodedDigest, tbs,
+                (word32)tbsLen, wc_HashGetOID(ctx->hashType));
+#endif
             if (encodedDigestLen <= 0) {
                 ok = 0;
             }
@@ -576,12 +622,22 @@ static int wp_rsa_sign_pss(wp_RsaSigCtx* ctx, unsigned char* sig,
 {
     int ok = 1;
     int rc;
-    int saltLen = wp_pss_salt_len_to_wc(ctx->saltLen, ctx->hash.type,
+    int saltLen = wp_pss_salt_len_to_wc(ctx->saltLen,
+#ifdef wc_Hashes
+        ctx->hash.type,
+#else
+        ctx->hashType,
+#endif
         wp_rsa_get_key(ctx->rsa), EVP_PKEY_OP_SIGN);
 
     PRIVATE_KEY_UNLOCK();
     rc = wc_RsaPSS_Sign_ex(tbs, (word32)tbsLen, sig, (word32)sigSize,
-        ctx->hash.type, ctx->mgf, saltLen, wp_rsa_get_key(ctx->rsa),
+#ifdef wc_Hashes
+        ctx->hash.type,
+#else
+        ctx->hashType,
+#endif
+        ctx->mgf, saltLen, wp_rsa_get_key(ctx->rsa),
         &ctx->rng);
     PRIVATE_KEY_LOCK();
     if (rc < 0) {
@@ -745,7 +801,13 @@ static int wp_rsa_verify_pkcs1(wp_RsaSigCtx* ctx, const unsigned char* sig,
         }
         if (ok) {
             encodedDigestLen = wc_EncodeSignature(encodedDigest, tbs,
-                (word32)tbsLen, wc_HashGetOID(ctx->hash.type));
+                (word32)tbsLen, wc_HashGetOID(
+#ifdef wc_Hashes
+                    ctx->hash.type
+#else
+                    ctx->hashType
+#endif
+                    ));
             if (encodedDigestLen <= 0) {
                 ok = 0;
             }
@@ -786,15 +848,31 @@ static int wp_rsa_verify_pss(wp_RsaSigCtx* ctx, const unsigned char* sig,
     int rc;
     int saltLen;
 
-    if (ctx->hash.type == WC_HASH_TYPE_NONE) {
+#ifdef wc_Hashes
+    if (ctx->hash.type == WC_HASH_TYPE_NONE)
+#else
+    if (ctx->hashType == WC_HASH_TYPE_NONE)
+#endif
+    {
         ok = wp_rsa_setup_md(ctx, WP_RSA_DEFAULT_MD, NULL, EVP_PKEY_OP_VERIFY);
     }
     if (ok) {
-        saltLen = wp_pss_salt_len_to_wc(ctx->saltLen, ctx->hash.type,
+        saltLen = wp_pss_salt_len_to_wc(ctx->saltLen,
+#ifdef wc_Hashes
+                ctx->hash.type,
+#else
+                ctx->hashType,
+#endif
             wp_rsa_get_key(ctx->rsa), EVP_PKEY_OP_VERIFY);
 
         rc = wc_RsaPSS_Verify_ex((byte*)sig, (word32)sigLen, decryptedSig,
-            (word32)sigLen, ctx->hash.type, ctx->mgf, saltLen,
+            (word32)sigLen,
+#ifdef wc_Hashes
+            ctx->hash.type,
+#else
+            ctx->hashType,
+#endif
+            ctx->mgf, saltLen,
             wp_rsa_get_key(ctx->rsa));
         if (rc < 0) {
             ok = 0;
@@ -802,7 +880,12 @@ static int wp_rsa_verify_pss(wp_RsaSigCtx* ctx, const unsigned char* sig,
     }
     if (ok) {
         rc = wc_RsaPSS_CheckPadding_ex(tbs, (word32)tbsLen, decryptedSig, rc,
-            ctx->hash.type, saltLen, 0);
+#ifdef wc_Hashes
+            ctx->hash.type,
+#else
+            ctx->hashType,
+#endif
+            saltLen, 0);
         if (rc != 0) {
             ok = 0;
         }
@@ -987,7 +1070,13 @@ static int wp_rsa_digest_signverify_update(wp_RsaSigCtx* ctx,
     const unsigned char* data, size_t dataLen)
 {
     int ok = 1;
-    int rc = wc_HashUpdate(&ctx->hash, ctx->hash.type, data, (word32)dataLen);
+    int rc = wc_HashUpdate(&ctx->hash,
+#ifdef wc_Hashes
+            ctx->hash.type,
+#else
+            ctx->hashType,
+#endif
+            data, (word32)dataLen);
     if (rc != 0) {
         ok = 0;
     }
@@ -1045,7 +1134,13 @@ static int wp_rsa_digest_sign_final(wp_RsaSigCtx* ctx, unsigned char* sig,
         ok = 0;
     }
     else if (sig != NULL) {
-        int rc = wc_HashFinal(&ctx->hash, ctx->hash.type, digest);
+        int rc = wc_HashFinal(&ctx->hash,
+#ifdef wc_Hashes
+                ctx->hash.type,
+#else
+                ctx->hashType,
+#endif
+                digest);
         if (rc != 0) {
             ok = 0;
         }
@@ -1053,7 +1148,13 @@ static int wp_rsa_digest_sign_final(wp_RsaSigCtx* ctx, unsigned char* sig,
 
     if (ok) {
         ok = wp_rsa_sign(ctx, sig, sigLen, sigSize, digest,
-            wc_HashGetDigestSize(ctx->hash.type));
+            wc_HashGetDigestSize(
+#ifdef wc_Hashes
+                ctx->hash.type
+#else
+                ctx->hashType
+#endif
+            ));
     }
 
     WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
@@ -1106,7 +1207,13 @@ static int wp_rsa_digest_verify_final(wp_RsaSigCtx* ctx, unsigned char* sig,
         ok = 0;
     }
     else {
-        int rc = wc_HashFinal(&ctx->hash, ctx->hash.type, digest);
+        int rc = wc_HashFinal(&ctx->hash,
+#ifdef wc_Hashes
+                ctx->hash.type,
+#else
+                ctx->hashType,
+#endif
+                digest);
         if (rc != 0) {
             ok = 0;
         }
@@ -1114,7 +1221,13 @@ static int wp_rsa_digest_verify_final(wp_RsaSigCtx* ctx, unsigned char* sig,
 
     if (ok) {
         ok = wp_rsa_verify(ctx,sig, sigLen, digest,
-            wc_HashGetDigestSize(ctx->hash.type));
+            wc_HashGetDigestSize(
+#ifdef wc_Hashes
+                ctx->hash.type
+#else
+                ctx->hashType
+#endif
+            ));
     }
 
     WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
@@ -1389,7 +1502,12 @@ static int wp_rsa_set_pad_mode(wp_RsaSigCtx* ctx, const OSSL_PARAM* p)
             }
         }
         else if (padMode == RSA_NO_PADDING) {
-            if (ctx->hash.type != WC_HASH_TYPE_NONE) {
+#ifdef wc_Hashes
+            if (ctx->hash.type != WC_HASH_TYPE_NONE)
+#else
+            if (ctx->hashType != WC_HASH_TYPE_NONE)
+#endif
+            {
                 ok = 0;
             }
         }

--- a/src/wp_rsa_sig.c
+++ b/src/wp_rsa_sig.c
@@ -80,7 +80,7 @@ typedef struct wp_RsaSigCtx {
 
     /** wolfSSL hash object. */
     wc_HashAlg hash;
-#ifndef wc_Hashes
+#if LIBWOLFSSL_VERSION_HEX < 0x05007004
     /** Hash algorithm to use on data to be signed. */
     enum wc_HashType hashType;
 #endif
@@ -326,7 +326,7 @@ static wp_RsaSigCtx* wp_rsa_ctx_dup(wp_RsaSigCtx* srcCtx)
         }
         if (ok) {
             dstCtx->rsa      = srcCtx->rsa;
-#ifndef wc_Hashes
+#if LIBWOLFSSL_VERSION_HEX < 0x05007004
             dstCtx->hashType = srcCtx->hashType;
 #endif
             dstCtx->mgf      = srcCtx->mgf;


### PR DESCRIPTION
New 'wc_HashAlg' structure now wraps the type into the structure as well as the union of the hash data structure. This caused some problems with the way wolfProvider was using it.