### PR TITLE
Fix IV handling for AES-CBC on reinit with NULL IV

### DIFF
--- a/src/wp_aes_block.c
+++ b/src/wp_aes_block.c
@@ -319,7 +319,7 @@ static int wp_aes_block_init(wp_AesBlockCtx *ctx, const unsigned char *key,
             ok = 0;
         }
         if (ok) {
-            int rc = wc_AesSetKey(&ctx->aes, key, (word32)ctx->keyLen, iv,
+            int rc = wc_AesSetKey(&ctx->aes, key, (word32)ctx->keyLen, ctx->iv,
                 enc ? AES_ENCRYPTION : AES_DECRYPTION);
             if (rc != 0) {
                 ok = 0;


### PR DESCRIPTION
Fix IV handling for AES-CBC on reinit with NULL IV.

Fixes ZD 18906
