### PR TITLE
AES-GCM: performance fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ Add `--enable-pwdbased` to the configure command above if PKCS#12 is used in Ope
 
 Add to CPPFLAGS `-DHAVE_FFDHE_6144 -DHAVE_FFDHE_8192 -DFP_MAX_BITS=16384` to enable predefined 6144-bit and 8192-bit DH parameters.
 
+Add to `--enable-hmac-copy` if performing HMAC repeatedly with the same key to improve performance. (Available with wolfSSL 5.7.8+.)
+
 Add `--enable-sp=yes,asm' '--enable-sp-math-all'` to use SP Integer maths. Replace `-DFP_MAX_BITS=16384` with -DSP_INT_BITS=8192` when used.
 
 Remove `-DWOLFSSL_PSS_LONG_SALT -DWOLFSSL_PSS_SALT_LEN_DISCOVER` and add `--enable-fips=v2` to the configure command above if building from a FIPS v2 bundle and not the git repository. Change `--enable-fips=v2` to `--enable-fips=ready` if using a FIPS Ready bundle.


### PR DESCRIPTION
Don't look for known strings in parameter list's keys - instead compare each parameters key with known strings.
Note that HMAC performance can be improved with new wolfSSL configuration option.