### PR TITLE
Fix RSA get params to set params instead of reading from empty params

### DIFF
--- a/src/wp_rsa_kmgmt.c
+++ b/src/wp_rsa_kmgmt.c
@@ -747,8 +747,11 @@ static int wp_rsa_get_params_key_data(wp_Rsa* rsa,  OSSL_PARAM params[])
             size_t oLen;
             mp_int* mp = (mp_int*)(((byte*)&rsa->key) + wp_rsa_offset[i]);
             oLen = mp_unsigned_bin_size(mp);
-            if ((p->data != NULL) && (!wp_mp_read_unsigned_bin_le(mp, p->data,
-                    p->data_size))) {
+            if (oLen > p->data_size) {
+                ok = 0;
+            }
+            if (ok && (p->data != NULL) &&
+                      (!wp_mp_to_unsigned_bin_le(mp, p->data, oLen))) {
                 ok = 0;
             }
             p->return_size = oLen;

--- a/test/unit.c
+++ b/test/unit.c
@@ -160,6 +160,7 @@ TEST_CASE test_case[] = {
     TEST_DECL(test_rsa_enc_dec_oaep, NULL),
     TEST_DECL(test_rsa_pkey_keygen, NULL),
     TEST_DECL(test_rsa_pkey_invalid_key_size, NULL),
+    TEST_DECL(test_rsa_get_params, NULL),
     TEST_DECL(test_rsa_load_key, NULL),
     TEST_DECL(test_rsa_load_cert, NULL),
 #endif /* WP_HAVE_RSA */

--- a/test/unit.h
+++ b/test/unit.h
@@ -236,6 +236,7 @@ int test_rsa_enc_dec_pkcs1(void *data);
 int test_rsa_enc_dec_oaep(void *data);
 int test_rsa_pkey_keygen(void *data);
 int test_rsa_pkey_invalid_key_size(void *data);
+int test_rsa_get_params(void *data);
 
 int test_rsa_load_key(void* data);
 int test_rsa_load_cert(void* data);


### PR DESCRIPTION
Fix RSA get params to properly set params from internal mp_* values instead of incorrectly attempting to read from incoming params to be set. 