### PR TITLE
CI github workflow codespell.yml

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,47 @@
+name: Codespell test
+
+# START OF COMMON SECTION
+on:
+  push:
+    branches: [ 'master', 'main', 'release/**' ]
+  pull_request:
+    branches: [ '*' ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+# END OF COMMON SECTION
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    steps:
+      - name: Checkout wolfProvider
+        uses: actions/checkout@v4
+
+      - name: Create exclude file if needed
+        run: |
+          if [ ! -f .codespellexcludelines ]; then
+            touch .codespellexcludelines
+          fi
+
+      - name: Run codespell
+        uses: codespell-project/actions-codespell@v2.1
+        with:
+          check_filenames: true
+          check_hidden: true
+          # Add comma separated list of words that occur multiple times that should be ignored (sorted alphabetically, case sensitive)
+          ignore_words_list: adin,addIn,aNULL,brunch,carryIn,chainG,ciph,cLen,cliKs,dout,emac,haveA,inCreated,inOut,inout,larg,LEAPYEAR,Merget,optionA,parm,parms,repid,rIn,userA,ser,siz,te,Te,toLen
+          # The exclude_file contains lines of code that should be ignored. This is useful for individual lines which have non-words that can safely be ignored.
+          exclude_file: '.codespellexcludelines'
+          # To skip files entirely from being processed, add it to the following list:
+          skip: '*.cproject,*.der,*.mtpj,*.pem,*.vcxproj,.git,*.launch,*.scfg,*.revoked,*.txt'
+
+      - name: Print errors
+        if: ${{ failure() }}
+        run: |
+          if [ -f test-suite.log ] ; then
+            cat test-suite.log
+          fi

--- a/IDE/Android/build.sh
+++ b/IDE/Android/build.sh
@@ -37,7 +37,7 @@ if [ ! -e ${WORKSPACE}/openssl-install ]; then
     export OPENSSL_ALL_CIPHERS="-cipher ALL -ciphersuites TLS_AES_256_GCM_SHA384:TLS_AES_128_GCM_SHA256:TLS_AES_128_CCM_SHA256:TLS_AES_128_CCM_8_SHA256"
     git clone https://github.com/openssl/openssl.git --branch=${OPENSSL_BRANCH} ${WORKSPACE}/openssl-source && \
         cd ${WORKSPACE}/openssl-source && \
-        ./Configure android-x86_64 --prefix=${WORKSPACE}/openssl-install && \
+        ./Configure no-sm3 no-sm4 android-x86_64 --prefix=${WORKSPACE}/openssl-install && \
         sed -i 's/-ldl//g' Makefile && \
         sed -i 's/-pie//g' Makefile && \
         make -j && \

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ The quickest method is to use the `scripts/build-wolfprovider.sh` script as foll
 ./scripts/build-wolfprovider.sh
 ```
 
-It will retreive the dependencies and compile them as necessary. To use other than the default (such as different releases) you can set various environment variables prior to calling the script:
+It will retrieve the dependencies and compile them as necessary. To use other than the default (such as different releases) you can set various environment variables prior to calling the script:
 
 ```
 OPENSSL_TAG=openssl-3.2.0 WOLFSSL_TAG=v5.7.2-stable WOLFPROV_DEBUG=1 scripts/build-wolfprovider.sh

--- a/autogen.sh
+++ b/autogen.sh
@@ -2,7 +2,7 @@
 #
 # autogen.sh
 #
-# Create configure and makfile stuff...
+# Create configure and makefile stuff...
 #
 
 autoreconf --install --force --verbose

--- a/include/wolfprovider/internal.h
+++ b/include/wolfprovider/internal.h
@@ -103,7 +103,7 @@
 #define WP_RSA_DEFAULT_SALT_LEN     20
 
 /* These values are taken from ssl.h.
- * Can't include this header as it re-declares OpenSSL types.
+ * Can't include this header as it redeclares OpenSSL types.
  */
 /* Named Groups */
 enum {

--- a/include/wolfprovider/version.h
+++ b/include/wolfprovider/version.h
@@ -27,7 +27,7 @@
 extern "C" {
 #endif
 
-#define LIBWOLFPROV_VERSION_STRING "1.1.0-RC"
+#define LIBWOLFPROV_VERSION_STRING "1.0.2"
 #define LIBWOLFPROV_VERSION_HEX @HEX_VERSION@
 
 #ifdef __cplusplus

--- a/src/wp_aes_aead.c
+++ b/src/wp_aes_aead.c
@@ -67,7 +67,7 @@ typedef struct wp_AeadCtx {
     /** Current state of IV/nonce.  */
     int ivState;
 
-    /** Initialized for encrpytion or decryption. */
+    /** Initialized for encryption or decryption. */
     unsigned int enc:1;
     /** IV/nonce has been generated. */
     unsigned int ivGen:1;
@@ -263,7 +263,7 @@ static int wp_aead_tls_init(wp_AeadCtx* ctx, unsigned char* aad, size_t aadLen)
  *
  * @param [in, out] ctx    AEAD context object.
  * @param [in]      in     More AAD data.
- * @parma [in]      inLen  Length of new AAD data.
+ * @param [in]      inLen  Length of new AAD data.
  * @return  1 on success.
  * @return  0 on failure.
  */
@@ -299,7 +299,7 @@ static int wp_aead_cache_aad(wp_AeadCtx *ctx, const unsigned char *in,
  *
  * @param [in, out] ctx    AEAD context object.
  * @param [in]      in     More AAD data.
- * @parma [in]      inLen  Length of new AAD data.
+ * @param [in]      inLen  Length of new AAD data.
  * @return  1 on success.
  * @return  0 on failure.
  */

--- a/src/wp_aes_block.c
+++ b/src/wp_aes_block.c
@@ -813,7 +813,7 @@ static int wp_aes_block_set_ctx_params(wp_AesBlockCtx *ctx,
  * @param [in, out] ctx      AES block context object.
  * @param [in]      kBits    Number of bits in a valid key.
  * @param [in]      ivBits   Number of bits in a valid IV. 0 indicates no IV.
- * @parma [in]      mode     AES block mode: ECB or CBC.
+ * @param [in]      mode     AES block mode: ECB or CBC.
  * @return  1 on success.
  * @return  0 on failure.
  */

--- a/src/wp_aes_stream.c
+++ b/src/wp_aes_stream.c
@@ -381,7 +381,7 @@ static int wp_aes_stream_doit(wp_AesStreamCtx *ctx, unsigned char *out,
 #ifdef WP_HAVE_AESCFB
     if (ctx->mode == EVP_CIPH_CFB_MODE) {
         int rc;
- 
+
         XMEMCPY(&ctx->aes.reg, ctx->iv, ctx->ivLen);
         if (ctx->enc) {
             rc = wc_AesCfbEncrypt(&ctx->aes, out, in, (word32)inLen);
@@ -578,7 +578,7 @@ static int wp_aes_stream_set_ctx_params(wp_AesStreamCtx *ctx,
  * @param [in, out] ctx      AES stream context object.
  * @param [in]      kBits    Number of bits in a valid key.
  * @param [in]      ivBits   Number of bits in a valid IV. 0 indicates no IV.
- * @parma [in]      mode     AES stream mode: CTR.
+ * @param [in]      mode     AES stream mode: CTR.
  * @return  1 on success.
  * @return  0 on failure.
  */

--- a/src/wp_cmac.c
+++ b/src/wp_cmac.c
@@ -208,7 +208,7 @@ static int wp_cmac_init(wp_CmacCtx* macCtx, const unsigned char* key,
  * Update the MAC state with data.
  *
  * @param [in, out] macCtx   CMAC context object to update.
- * @parma [in]      data     Data to be MACed.
+ * @param [in]      data     Data to be MACed.
  * @param [in]      dataLen  Length of data in bytes.
  * @return  1 on success.
  * @return  0 on failure.

--- a/src/wp_des.c
+++ b/src/wp_des.c
@@ -778,7 +778,7 @@ static int wp_des3_block_set_ctx_params(wp_Des3BlockCtx *ctx,
  * @param [in, out] ctx      DES3 block context object.
  * @param [in]      kBits    Number of bits in a valid key.
  * @param [in]      ivBits   Number of bits in a valid IV. 0 indicates no IV.
- * @parma [in]      mode     DES3 block mode: ECB or CBC.
+ * @param [in]      mode     DES3 block mode: ECB or CBC.
  * @return  1 on success.
  * @return  0 on failure.
  */

--- a/src/wp_dh_exch.c
+++ b/src/wp_dh_exch.c
@@ -306,7 +306,7 @@ static int wp_dh_derive_secret(wp_DhCtx* ctx, unsigned char* secret,
  * Can put the DH secret through a KDF.
  *
  * @param [in]  ctx      DH key exchange context object.
- * @param [out] secert   Buffer to hold secret/key.
+ * @param [out] secret   Buffer to hold secret/key.
  * @param [out] secLen   Length of secret/key data in bytes.
  * @param [in]  secSize  Size of buffer in bytes.
  * @return 1 on success.

--- a/src/wp_dh_kmgmt.c
+++ b/src/wp_dh_kmgmt.c
@@ -560,7 +560,7 @@ static wp_Dh* wp_dh_dup(const wp_Dh *src, int selection)
  * Return the DH key object taken out of the reference.
  *
  * @param [in, out] pDh   Pointer to a DH key object.
- * @parma [in]      size  Size of data structure that is the DH key object.
+ * @param [in]      size  Size of data structure that is the DH key object.
  *                        Unused.
  * @return  NULL when no DH key object at reference.
  * @return  DH key object from reference on success.
@@ -790,8 +790,8 @@ static int wp_dh_has(const wp_Dh* dh, int selection)
 /**
  * Check that two DH key objects match for the components specified.
  *
- * @parma [in] dh1        First DH key object.
- * @parma [in] dh2        Second DH key object.
+ * @param [in] dh1        First DH key object.
+ * @param [in] dh2        Second DH key object.
  * @param [in] selection  Parts of key to match.
  * @return  1 on success.
  * @return  0 on failure.
@@ -2565,7 +2565,7 @@ static int wp_dh_encode(wp_DhEncDecCtx* ctx, OSSL_CORE_BIO *cBio,
  *
  * @param [in] ctx          DH encoder/decoder context object.
  * @param [in] dh           DH key object.
- * @oaram [in] size         Size of key object.
+ * @param [in] size         Size of key object.
  * @param [in] exportCb     Callback to export key.
  * @param [in] exportCbArg  Argument to pass to callback.
  * @return  1 on success.

--- a/src/wp_ecc_kmgmt.c
+++ b/src/wp_ecc_kmgmt.c
@@ -468,7 +468,7 @@ static wp_Ecc* wp_ecc_dup(const wp_Ecc *src, int selection)
  * Return the ECC key object taken out of the reference.
  *
  * @param [in, out] pEcc  Pointer to a ECC key object.
- * @parma [in]      size  Size of data structure that is the ECC key object.
+ * @param [in]      size  Size of data structure that is the ECC key object.
  *                        Unused.
  * @return  NULL when no ECC key object at reference.
  * @return  ECC key object from reference on success.
@@ -852,8 +852,8 @@ static int wp_ecc_has(const wp_Ecc* ecc, int selection)
 /**
  * Check that two ECC key objects match for the components specified.
  *
- * @parma [in] ecc1       First ECC key object.
- * @parma [in] ecc2       Second ECC key object.
+ * @param [in] ecc1       First ECC key object.
+ * @param [in] ecc2       Second ECC key object.
  * @param [in] selection  Parts of key to match.
  * @return  1 on success.
  * @return  0 on failure.
@@ -2633,7 +2633,7 @@ static int wp_ecc_encode(wp_EccEncDecCtx* ctx, OSSL_CORE_BIO *cBio,
  *
  * @param [in] ctx          ECC encoder/decoder context object.
  * @param [in] ecc          ECC key object.
- * @oaram [in] size         Size of key object.
+ * @param [in] size         Size of key object.
  * @param [in] exportCb     Callback to export key.
  * @param [in] exportCbArg  Argument to pass to callback.
  * @return  1 on success.

--- a/src/wp_ecdh_exch.c
+++ b/src/wp_ecdh_exch.c
@@ -290,7 +290,7 @@ static int wp_ecdh_derive_secret(wp_EcdhCtx* ctx, unsigned char* secret,
  * Can put the ECDH secret through a KDF.
  *
  * @param [in]  ctx      ECDH key exchange context object.
- * @param [out] secert   Buffer to hold secret/key.
+ * @param [out] secret   Buffer to hold secret/key.
  * @param [out] secLen   Length of secret/key data in bytes.
  * @param [in]  secSize  Size of buffer in bytes.
  * @return 1 on success.

--- a/src/wp_ecdsa_sig.c
+++ b/src/wp_ecdsa_sig.c
@@ -406,7 +406,7 @@ static int wp_ecdsa_verify_recover(wp_EcdsaSigCtx *ctx, const unsigned char *rou
  *
  * @param [in, out] ctx      ECDSA signature context object.
  * @param [in]      mdName   Name of digest.
- * @param [in]      mdProps  Digest properites.
+ * @param [in]      mdProps  Digest properties.
  * @param [in]      op       Signature operation being performed.
  * @return  1 on success.
  * @return  0 on failure.

--- a/src/wp_ecx_exch.c
+++ b/src/wp_ecx_exch.c
@@ -209,7 +209,7 @@ const unsigned char wp_curve25519_order[] = {
  * Can put the secret through a KDF.
  *
  * @param [in]  ctx      ECX key exchange context object.
- * @param [out] secert   Buffer to hold secret/key.
+ * @param [out] secret   Buffer to hold secret/key.
  * @param [out] secLen   Length of secret/key data in bytes.
  * @param [in]  secSize  Size of buffer in bytes.
  * @return 1 on success.
@@ -295,7 +295,7 @@ const OSSL_DISPATCH wp_x25519_keyexch_functions[] = {
  * Can put the secret through a KDF.
  *
  * @param [in]  ctx      ECX key exchange context object.
- * @param [out] secert   Buffer to hold secret/key.
+ * @param [out] secret   Buffer to hold secret/key.
  * @param [out] secLen   Length of secret/key data in bytes.
  * @param [in]  secSize  Size of buffer in bytes.
  * @return 1 on success.

--- a/src/wp_ecx_kmgmt.c
+++ b/src/wp_ecx_kmgmt.c
@@ -352,7 +352,7 @@ static wp_Ecx* wp_ecx_dup(const wp_Ecx* src, int selection)
  * Return the ECX key object taken out of the reference.
  *
  * @param [in, out] pEcx  Pointer to a ECX key object.
- * @parma [in]      size  Size of data structure that is the ECX key object.
+ * @param [in]      size  Size of data structure that is the ECX key object.
  *                        Unused.
  * @return  NULL when no ECX key object at reference.
  * @return  ECX key object from reference on success.
@@ -610,8 +610,8 @@ static int wp_ecx_has(const wp_Ecx* ecx, int selection)
 /**
  * Check that two ECX key objects' private keys match.
  *
- * @parma [in] ecx1       First ECX key object.
- * @parma [in] ecx2       Second ECX key object.
+ * @param [in] ecx1       First ECX key object.
+ * @param [in] ecx2       Second ECX key object.
  * @return  1 on success.
  * @return  0 on failure.
  */
@@ -655,8 +655,8 @@ static int wp_ecx_match_priv_key(const wp_Ecx* ecx1, const wp_Ecx* ecx2)
 /**
  * Check that two ECX key objects' public keys match.
  *
- * @parma [in] ecx1       First ECX key object.
- * @parma [in] ecx2       Second ECX key object.
+ * @param [in] ecx1       First ECX key object.
+ * @param [in] ecx2       Second ECX key object.
  * @return  1 on success.
  * @return  0 on failure.
  */
@@ -702,8 +702,8 @@ static int wp_ecx_match_pub_key(const wp_Ecx* ecx1, const wp_Ecx* ecx2)
 /**
  * Check that two ECX key objects match for the components specified.
  *
- * @parma [in] ecx1       First ECX key object.
- * @parma [in] ecx2       Second ECX key object.
+ * @param [in] ecx1       First ECX key object.
+ * @param [in] ecx2       Second ECX key object.
  * @param [in] selection  Parts of key to match.
  * @return  1 on success.
  * @return  0 on failure.
@@ -2081,7 +2081,7 @@ static int wp_ecx_encode(wp_EcxEncDecCtx* ctx, OSSL_CORE_BIO *cBio,
  *
  * @param [in] ctx          ECX encoder/decoder context object.
  * @param [in] ecx          ECX key object.
- * @oaram [in] size         Size of key object.
+ * @param [in] size         Size of key object.
  * @param [in] exportCb     Callback to export key.
  * @param [in] exportCbArg  Argument to pass to callback.
  * @return  1 on success.

--- a/src/wp_file_store.c
+++ b/src/wp_file_store.c
@@ -48,7 +48,7 @@ typedef struct wp_FileCtx {
 
     /** Decoder context for processing the contents of the file. */
     OSSL_DECODER_CTX* decCtx;
-    /** Properites query. */
+    /** Properties query. */
     char* propQuery;
     /** Type of data: key, certificate, CRL, ... */
     int type;

--- a/src/wp_gmac.c
+++ b/src/wp_gmac.c
@@ -208,7 +208,7 @@ static int wp_gmac_init(wp_GmacCtx* macCtx, const unsigned char* key,
  * Update the MAC state with data.
  *
  * @param [in, out] macCtx   GMAC context object to update.
- * @parma [in]      data     Data to be MACed.
+ * @param [in]      data     Data to be MACed.
  * @param [in]      dataLen  Length of data in bytes.
  * @return  1 on success.
  * @return  0 on failure.

--- a/src/wp_hkdf.c
+++ b/src/wp_hkdf.c
@@ -380,7 +380,7 @@ static int wp_hkdf_base_set_info(wp_HkdfCtx* ctx, const OSSL_PARAM params[])
     unsigned char* q = ctx->info;
 
     ctx->infoSz = 0;
-    /* Combine all the data in the info parametrs. */
+    /* Combine all the data in the info parameters. */
     while (ok && ((p = OSSL_PARAM_locate_const(params,
             OSSL_KDF_PARAM_INFO)) != NULL)) {
         size_t sz = 0;

--- a/src/wp_hmac.c
+++ b/src/wp_hmac.c
@@ -231,7 +231,7 @@ static int wp_hmac_init(wp_HmacCtx* macCtx, const unsigned char* key,
  * Update the MAC state with data.
  *
  * @param [in, out] macCtx   HMAC context object to update.
- * @parma [in]      data     Data to be MACed.
+ * @param [in]      data     Data to be MACed.
  * @param [in]      dataLen  Length of data in bytes.
  * @return  1 on success.
  * @return  0 on failure.

--- a/src/wp_kdf_exch.c
+++ b/src/wp_kdf_exch.c
@@ -178,7 +178,7 @@ static int wp_kdf_init(wp_KdfCtx* ctx, wp_Kdf* kdf, const OSSL_PARAM params[])
  * Can put the ECDH secret through a KDF.
  *
  * @param [in]  ctx      ECDH key exchange context object.
- * @param [out] secert   Buffer to hold secret/key.
+ * @param [out] secret   Buffer to hold secret/key.
  * @param [out] secLen   Length of secret/key data in bytes.
  * @param [in]  secSize  Size of buffer in bytes.
  * @return 1 on success.
@@ -238,7 +238,7 @@ static const OSSL_PARAM* wp_hkdf_settable_ctx_params(wp_KdfCtx* ctx,
         OSSL_PARAM_octet_string(OSSL_KDF_PARAM_SALT, NULL, 0),
         OSSL_PARAM_octet_string(OSSL_KDF_PARAM_INFO, NULL, 0),
         OSSL_PARAM_END
-    };    
+    };
     return settable_ctx_params;
 }
 
@@ -260,7 +260,7 @@ static const OSSL_PARAM* wp_tls1_prf_settable_ctx_params(wp_KdfCtx* ctx,
         OSSL_PARAM_octet_string(OSSL_KDF_PARAM_SECRET, NULL, 0),
         OSSL_PARAM_octet_string(OSSL_KDF_PARAM_SEED, NULL, 0),
         OSSL_PARAM_END
-    };    
+    };
     return settable_ctx_params;
 }
 

--- a/src/wp_logging.c
+++ b/src/wp_logging.c
@@ -244,7 +244,7 @@ void WOLFPROV_ENTER(int component, const char* msg)
  * Log function used to record function exit. Extended for function name.
  *
  * @param component [IN] Component type, from wolfProv_LogComponents enum.
- * @param func [IN] Name of function that exitting.
+ * @param func [IN] Name of function that exiting.
  * @param msg  [IN] Log message.
  * @param ret  [IN] Value that function will be returning.
  */

--- a/src/wp_mac_kmgmt.c
+++ b/src/wp_mac_kmgmt.c
@@ -265,7 +265,7 @@ static wp_Mac* wp_mac_dup(const wp_Mac *src, int selection)
             }
         }
         dst->keyLen = src->keyLen;
-        /* Copy properites if set. */
+        /* Copy properties if set. */
         if (src->properties != NULL) {
             size_t propLen = XSTRLEN(src->properties) + 1;
             dst->properties = OPENSSL_malloc(propLen);
@@ -319,8 +319,8 @@ static int wp_mac_has(const wp_Mac* mac, int selection)
 /**
  * Check that two MAC key objects match for the components specified.
  *
- * @parma [in] mac1       First ECC key object.
- * @parma [in] mac2       Second ECC key object.
+ * @param [in] mac1       First ECC key object.
+ * @param [in] mac2       Second ECC key object.
  * @param [in] selection  Parts of key to match.
  * @return  1 on success.
  * @return  0 on failure.
@@ -595,7 +595,7 @@ static void wp_mac_gen_cleanup(wp_MacGenCtx *ctx)
  * Return the MAC key object taken out of the reference.
  *
  * @param [in, out] pMac  Pointer to a MAC key object.
- * @parma [in]      size  Size of data structure that is the MAC key object.
+ * @param [in]      size  Size of data structure that is the MAC key object.
  *                        Unused.
  * @return  NULL when no MAC key object at reference.
  * @return  MAC key object from reference on success.

--- a/src/wp_params.c
+++ b/src/wp_params.c
@@ -204,7 +204,7 @@ void wp_param_set_mp_buf(OSSL_PARAM* p, const char* key, unsigned char* num,
  * Copies the name and returns the wolfSSL hash type and length of output.
  *
  * @param [in]  params  Array of parameters.
- * @parma [out] name    Buffer to hold hash name.
+ * @param [out] name    Buffer to hold hash name.
  * @param [in]  libCtx  Library context to lookup name in.
  * @param [out] type    wolfCrypt hash type corresponding to name. May be NULL.
  * @param [out] len     Length of digest output in bytes. May be NULL.

--- a/src/wp_rsa_asym.c
+++ b/src/wp_rsa_asym.c
@@ -32,7 +32,7 @@
 #ifdef WP_HAVE_RSA
 
 /* This define taken from ssl.h.
- * Can't include this header as it re-declares OpenSSL types.
+ * Can't include this header as it redeclares OpenSSL types.
  */
 #define WOLFSSL_MAX_MASTER_KEY_LENGTH   48
 
@@ -475,7 +475,7 @@ static int wp_rsaa_decrypt(wp_RsaAsymCtx* ctx, unsigned char* out,
  *
  * @param [in, out] ctx      RSA asymmetric cipher context object.
  * @param [in]      mdName   Name of digest.
- * @param [in]      mdProps  Digest properites.
+ * @param [in]      mdProps  Digest properties.
  * @return  1 on success.
  * @return  0 on failure.
  */
@@ -517,7 +517,7 @@ static int wp_rsaa_setup_md(wp_RsaAsymCtx* ctx, const char* mdName,
  *
  * @param [in, out] ctx      RSA asymmetric cipher context object.
  * @param [in]      mdName   Name of digest.
- * @param [in]      mdProps  Digest properites.
+ * @param [in]      mdProps  Digest properties.
  * @return  1 on success.
  * @return  0 on failure.
  */

--- a/src/wp_rsa_kem.c
+++ b/src/wp_rsa_kem.c
@@ -269,7 +269,7 @@ static int wp_rsasve_gen_rand_bytes(wp_RsaKemCtx* ctx, unsigned char* out)
 }
 
 /**
- * Generate a secret value and corresponding ciphertext (encapsulte).
+ * Generate a secret value and corresponding ciphertext (encapsulate).
  *
  * NIST.SP.800-56Br2
  * 7.2.1.2 RSASVE Generate Operation (RSASVE.GENERATE).
@@ -372,7 +372,7 @@ static int wp_rsakem_encapsulate(wp_RsaKemCtx* ctx, unsigned char* out,
 }
 
 /**
- * Recover the secret from the encapsualted data (decapsulate).
+ * Recover the secret from the encapsulated data (decapsulate).
  *
  * NIST.SP.800-56Br2
  * 7.2.1.3 RSASVE Recovery Operation (RSASVE.RECOVER).
@@ -381,7 +381,7 @@ static int wp_rsakem_encapsulate(wp_RsaKemCtx* ctx, unsigned char* out,
  * @param [out] out        Buffer to hold secret.
  * @param [out] outLen     Length of secret in bytes.
  * @param [out] in         Buffer holding encapsulated secret.
- * @param [out] secretLen  Length of encapsualted data in bytes.
+ * @param [out] secretLen  Length of encapsulated data in bytes.
  * @return  1 on success.
  * @return  0 on failure.
  */
@@ -438,7 +438,7 @@ static int wp_rsasve_recover(wp_RsaKemCtx* ctx, unsigned char* out,
  * @param [out] out        Buffer to hold secret.
  * @param [out] outLen     Length of secret in bytes.
  * @param [out] in         Buffer holding encapsulated secret.
- * @param [out] secretLen  Length of encapsualted data in bytes.
+ * @param [out] secretLen  Length of encapsulated data in bytes.
  * @return  1 on success.
  * @return  0 on failure.
  */

--- a/src/wp_rsa_kmgmt.c
+++ b/src/wp_rsa_kmgmt.c
@@ -578,7 +578,7 @@ static int wp_rsa_pss_params_set_pss_defaults(wp_RsaPssParams* pss)
  *
  * @param [in, out] pss      RSA PSS parameters object.
  * @param [in]      mdName   Name of digest.
- * @param [in]      mdProps  Digest properites.
+ * @param [in]      mdProps  Digest properties.
  * @param [in]      libCtx   Library context.
  * @return  1 on success.
  * @return  0 on failure.
@@ -603,7 +603,7 @@ static int wp_rsa_pss_params_setup_mgf1_md(wp_RsaPssParams* pss,
  *
  * @param [in, out] pss      RSA PSS parameters object.
  * @param [in]      mdName   Name of digest.
- * @param [in]      mdProps  Digest properites.
+ * @param [in]      mdProps  Digest properties.
  * @param [in]      libCtx   Library context.
  * @return  1 on success.
  * @return  0 on failure.
@@ -710,7 +710,7 @@ static int wp_rsa_pss_params_set_mgf1_digest(wp_RsaPssParams* pss,
  *
  * @param [in, out] pss          RSA PSS parameters object.
  * @param [in, out] defaultsSet  Whether default PSS parameters have been set.
- * @param [in]      params       Array of parameters and valus.
+ * @param [in]      params       Array of parameters and values.
  * @param [in]      libCtx       Library context.
  * @return  1 on success.
  * @return  0 on failure.
@@ -777,7 +777,7 @@ static int wp_rsa_pss_params_set_params(wp_RsaPssParams* pss,
  * Return the RSA key object taken out of the reference.
  *
  * @param [in, out] pRsa  Pointer to a RSA key object.
- * @parma [in]      size  Size of data structure that is the RSA key object.
+ * @param [in]      size  Size of data structure that is the RSA key object.
  *                        Unused.
  * @param [in]      type  Expected RSA type: PKCS#1.5 or PSS.
  * @return  NULL when no RSA key object at reference or not matching type.
@@ -981,8 +981,8 @@ static int wp_rsa_has(const wp_Rsa* rsa, int selection)
 /**
  * Check that two RSA key objects match for the components specified.
  *
- * @parma [in] rsa1       First RSA key object.
- * @parma [in] rsa2       Second RSA key object.
+ * @param [in] rsa1       First RSA key object.
+ * @param [in] rsa2       Second RSA key object.
  * @param [in] selection  Parts of key to match.
  * @return  1 on success.
  * @return  0 on failure.
@@ -1601,7 +1601,7 @@ static const OSSL_PARAM* wp_rsa_gen_settable_params(wp_RsaGenCtx* gctx,
  * Return the RSA key object taken out of the reference.
  *
  * @param [in, out] pRsa  Pointer to a RSA key object.
- * @parma [in]      size  Size of data structure that is the RSA key object.
+ * @param [in]      size  Size of data structure that is the RSA key object.
  *                        Unused.
  * @return  NULL when no RSA key object at reference or not RSA PKCS#1.5 type.
  * @return  RSA key object from reference on success.
@@ -1658,7 +1658,7 @@ static wp_Rsa* wp_rsapss_new(WOLFPROV_CTX* provctx)
  * Return the RSA key object taken out of the reference.
  *
  * @param [in, out] pRsa  Pointer to a RSA key object.
- * @parma [in]      size  Size of data structure that is the RSA key object.
+ * @param [in]      size  Size of data structure that is the RSA key object.
  *                        Unused.
  * @return  NULL when no RSA key object at reference or not RSA PSS type.
  * @return  RSA key object from reference on success.
@@ -3201,7 +3201,7 @@ static int wp_rsa_encode(wp_RsaEncDecCtx* ctx, OSSL_CORE_BIO* cBio,
  *
  * @param [in] ctx          RSA encoder/decoder context object.
  * @param [in] rsa          RSA key object.
- * @oaram [in] size         Size of key object.
+ * @param [in] size         Size of key object.
  * @param [in] exportCb     Callback to export key.
  * @param [in] exportCbArg  Argument to pass to callback.
  * @return  1 on success.

--- a/src/wp_rsa_sig.c
+++ b/src/wp_rsa_sig.c
@@ -109,7 +109,7 @@ static int wp_rsa_set_ctx_params(wp_RsaSigCtx* ctx, const OSSL_PARAM params[]);
  *
  * @param [in, out] ctx      RSA signature context object.
  * @param [in]      mdName   Name of digest.
- * @param [in]      mdProps  Digest properites.
+ * @param [in]      mdProps  Digest properties.
  * @param [in]      op       Signature operation being performed.
  * @return  1 on success.
  * @return  0 on failure.
@@ -198,7 +198,7 @@ static int wp_rsa_setup_md(wp_RsaSigCtx* ctx, const char* mdName,
  *
  * @param [in, out] ctx      RSA signature context object.
  * @param [in]      mdName   Name of digest.
- * @param [in]      mdProps  Digest properites.
+ * @param [in]      mdProps  Digest properties.
  * @return  1 on success.
  * @return  0 on failure.
  */

--- a/src/wp_tls1_prf.c
+++ b/src/wp_tls1_prf.c
@@ -213,7 +213,7 @@ static int wp_kdf_tls1_prf_get_seed(wp_Tls1Prf_Ctx* ctx,
     const OSSL_PARAM *p;
     unsigned char* q = ctx->seed + ctx->seedSz;
 
-    /* Combine all the data in the seed parametrs. */
+    /* Combine all the data in the seed parameters. */
     while (ok && ((p = OSSL_PARAM_locate_const(params,
             OSSL_KDF_PARAM_SEED)) != NULL)) {
         size_t sz = 0;

--- a/test/test_ecc.c
+++ b/test/test_ecc.c
@@ -285,7 +285,7 @@ static int test_eckeygen_name_ex(const char *name, int setEncoding, int expectFa
         err = EVP_PKEY_CTX_ctrl_str(ctx, "ec_paramgen_curve", name) != 1;
     }
     if (err == 0 && setEncoding) {
-        /* For now only testing explictly setting named curve encoding */
+        /* For now only testing explicitly setting named curve encoding */
         err = EVP_PKEY_CTX_ctrl_str(ctx, "ec_param_enc",
                 OSSL_PKEY_EC_ENCODING_GROUP) != 1;
     }


### PR DESCRIPTION
# Description 

This pr adds support for github CI test codespell which tests spelling in wolfProvider.

- added no-sm3 and no-sm4 for prb fail
- fixed spelling errors found by test and suppressed valid errors with `ignore_words_list`
- fixed multiple `param` spelling errors that where not being displayed