### PR TITLE
openldap.yml - CI github workflow

### DIFF
--- a/.github/workflows/openldap.yml
+++ b/.github/workflows/openldap.yml
@@ -1,0 +1,141 @@
+name: OpenLDAP Tests
+
+# START OF COMMON SECTION
+on:
+  push:
+    branches: [ 'master', 'main', 'release/**' ]
+  pull_request:
+    branches: [ '*' ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+# END OF COMMON SECTION
+
+jobs:
+  build_wolfprovider:
+    name: Build wolfProvider
+    runs-on: ubuntu-22.04
+    timeout-minutes: 20
+    strategy:
+      matrix:
+        wolfssl_ref: [ 'master', 'v5.7.4-stable' ]
+    steps:
+      - name: Checkout wolfProvider
+        uses: actions/checkout@v4
+
+      # Check if this version of wolfssl/wolfprovider has already been built,
+      # mark to cache these items on post if we do end up building
+      - name: Checking wolfSSL/wolfProvider in cache
+        uses: actions/cache@v4
+        id: wolfprov-cache
+        with:
+          path: |
+            wolfssl-source
+            wolfssl-install
+            wolfprov-install
+            provider.conf
+
+          key: wolfprov-${{ matrix.wolfssl_ref }}-${{ github.sha }}
+          lookup-only: true
+
+      # If wolfssl/wolfprovider have not yet been built, pull ossl from cache
+      - name: Checking OpenSSL in cache
+        if: steps.wolfprov-cache.outputs.cache-hit != 'true'
+        uses: actions/cache@v4
+        id: openssl-cache
+        with:
+          path: |
+            openssl-source
+            openssl-install
+
+          key: ossl-depends
+          fail-on-cache-miss: false
+
+      # If not yet built this version, build it now
+      - name: Build wolfProvider
+        if: steps.wolfprov-cache.outputs.cache-hit != 'true'
+        run: |
+          WOLFSSL_TAG=${{ matrix.wolfssl_ref }} ./scripts/build-wolfprovider.sh
+
+      - name: Print errors
+        if: ${{ failure() }}
+        run: |
+          if [ -f test-suite.log ] ; then
+            cat test-suite.log
+          fi
+
+  test_openldap:
+    runs-on: ubuntu-22.04
+    needs: build_wolfprovider
+    # This should be a safe limit for the tests to run.
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # List of releases to test
+          - osp_ref: 2.5.13
+            git_ref: OPENLDAP_REL_ENG_2_5_13
+          - osp_ref: 2.6.7
+            git_ref: OPENLDAP_REL_ENG_2_6_7
+        wolfssl_ref: [ 'master', 'v5.7.4-stable' ]
+    steps:
+      - name: Retrieving OpenSSL from cache
+        uses: actions/cache/restore@v4
+        id: openssl-cache
+        with:
+          path: |
+            openssl-source
+            openssl-install
+
+          key: ossl-depends
+          fail-on-cache-miss: false
+
+      - name: Retrieving wolfSSL/wolfProvider from cache
+        uses: actions/cache/restore@v4
+        id: wolfprov-cache
+        with:
+          path: |
+            wolfssl-source
+            wolfssl-install
+            wolfprov-install
+            provider.conf
+
+          key: wolfprov-${{ matrix.wolfssl_ref }}-${{ github.sha }}
+          fail-on-cache-miss: true
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libsasl2-dev
+
+      - name: Checkout openldap
+        uses: actions/checkout@v4
+        with:
+          repository: openldap/openldap
+          path: openldap
+          ref: ${{ matrix.git_ref }}
+
+      - name: Build and test OpenLDAP with wolfProvider
+        working-directory: openldap
+        run: |
+          # Setup environment for wolfProvider
+          export LD_LIBRARY_PATH=$GITHUB_WORKSPACE/wolfssl-install/lib:$GITHUB_WORKSPACE/openssl-install/lib64
+          export OPENSSL_CONF=$GITHUB_WORKSPACE/provider.conf
+          export OPENSSL_MODULES=$GITHUB_WORKSPACE/wolfprov-install/lib
+
+          # Generate configure script
+          rm -f aclocal.m4
+          autoreconf -ivf
+
+          # Configure with OpenSSL
+          ./configure --with-tls=openssl --disable-bdb --disable-hdb \
+            CFLAGS="-I$GITHUB_WORKSPACE/openssl-install/include \
+              -L$GITHUB_WORKSPACE/openssl-install/lib64" \
+            LDFLAGS="-Wl,-rpath,$GITHUB_WORKSPACE/openssl-install/lib64"
+
+          # Build OpenLDAP
+          make -j depend
+          make -j
+          make -j check


### PR DESCRIPTION
# Description

This PR adds a CI workflow to test OpenLDAP with wolfProvider integration. It builds OpenLDAP against selected wolfSSL versions (`master`, `v5.7.4-stable`) using wolfProvider as the OpenSSL provider. The workflow tests multiple OpenLDAP release branches (`2.5.13`, `2.6.7`) and uses caching to speed up repeated builds. Dependencies are installed, and the build is verified via `make check`.

- verified with `WOLFPROV_FORCE_FAIL=1`