### PR TITLE
Fix ECC issue where y component was incorrectly overwritten

### DIFF
--- a/src/wp_ecc_kmgmt.c
+++ b/src/wp_ecc_kmgmt.c
@@ -528,7 +528,7 @@ static int wp_ecc_set_params_x_y(wp_Ecc *ecc, const OSSL_PARAM params[])
             ecc->key.pubkey.y))) {
         ok = 0;
     }
-    if (ok && mp_iszero(ecc->key.pubkey.x)) {
+    if (ok && mp_iszero(ecc->key.pubkey.y)) {
         ok = 0;
     }
     if (ok) {
@@ -591,10 +591,38 @@ static int wp_ecc_set_params(wp_Ecc *ecc, const OSSL_PARAM params[])
     const OSSL_PARAM *p;
 
     if (params != NULL) {
-        if (!wp_ecc_set_params_x_y(ecc, params)) {
-            if (!wp_ecc_set_params_enc_pub_key(ecc, params,
-                    OSSL_PKEY_PARAM_ENCODED_PUBLIC_KEY)) {
-                ok = 0;
+        if (!wp_ecc_set_params_enc_pub_key(ecc, params,
+                OSSL_PKEY_PARAM_ENCODED_PUBLIC_KEY)) {
+            ok = 0;
+        }
+        if (ok) {
+            p = OSSL_PARAM_locate_const(params,
+                OSSL_PKEY_PARAM_EC_PUB_X);
+            if (p != NULL) {
+                if (!wp_params_get_mp(params, OSSL_PKEY_PARAM_EC_PUB_X,
+                        ecc->key.pubkey.x)) {
+                    ok = 0;
+                }
+                if (ok && mp_iszero(ecc->key.pubkey.x)) {
+                    ok = 0;
+                }
+                if (ok) {
+                    ecc->key.type = ECC_PUBLICKEY;
+                    ecc->hasPub = 1;
+                }
+            }
+        }
+        if (ok) {
+            p = OSSL_PARAM_locate_const(params,
+                OSSL_PKEY_PARAM_EC_PUB_Y);
+            if (p != NULL) {
+                if (!wp_params_get_mp(params, OSSL_PKEY_PARAM_EC_PUB_Y,
+                        ecc->key.pubkey.y)) {
+                    ok = 0;
+                }
+                if (ok && mp_iszero(ecc->key.pubkey.y)) {
+                    ok = 0;
+                }
             }
         }
         if (ok) {

--- a/src/wp_ecdsa_sig.c
+++ b/src/wp_ecdsa_sig.c
@@ -187,7 +187,7 @@ static int wp_ecdsa_signverify_init(wp_EcdsaSigCtx *ctx, wp_Ecc* ecc,
 
     if (ctx->ecc != ecc) {
         wp_ecc_free(ctx->ecc);
-        if (!wp_ecc_up_ref(ecc)) {
+        if (ecc != NULL && !wp_ecc_up_ref(ecc)) {
             ok = 0;
         }
     }

--- a/src/wp_rsa_kmgmt.c
+++ b/src/wp_rsa_kmgmt.c
@@ -1950,37 +1950,6 @@ static int wp_rsa_determine_type(wp_Rsa* rsa, unsigned char* data, word32 len)
 }
 
 /**
- * Decode the SubjectPublicInfo DER encoded RSA key into the RSA key object.
- *
- * @param [in, out] rsa   RSA key object.
- * @param [in]      data  DER encoding.
- * @param [in]      len   Length, in bytes, of DER encoding.
- * @return  1 on success.
- * @return  0 on failure.
- */
-static int wp_rsa_decode_spki(wp_Rsa* rsa, unsigned char* data, word32 len)
-{
-    int ok = 1;
-    int rc;
-    word32 idx = 0;
-
-    rc = wc_RsaPublicKeyDecode(data, &idx, &rsa->key, len);
-    if (rc != 0) {
-        ok = 0;
-    }
-    if (ok && !wp_rsa_determine_type(rsa, data, len)) {
-        ok = 0;
-    }
-    if (ok) {
-        rsa->bits = wc_RsaEncryptSize(&rsa->key) * 8;
-        rsa->hasPub = 1;
-    }
-
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
-    return ok;
-}
-
-/**
  * Get the PSS parameters from the DER encoded RSA-PSS parameters.
  *
  * TODO: rework to use tables of DER encodings.
@@ -2114,6 +2083,44 @@ static int wp_rsa_pss_get_params(wp_Rsa* rsa, unsigned char* data, word32 len)
         rsa->pssDefSet = 1;
     }
 
+    return ok;
+}
+
+/**
+ * Decode the SubjectPublicInfo DER encoded RSA key into the RSA key object.
+ *
+ * @param [in, out] rsa   RSA key object.
+ * @param [in]      data  DER encoding.
+ * @param [in]      len   Length, in bytes, of DER encoding.
+ * @return  1 on success.
+ * @return  0 on failure.
+ */
+static int wp_rsa_decode_spki(wp_Rsa* rsa, unsigned char* data, word32 len)
+{
+    int ok = 1;
+    int rc;
+    word32 idx = 0;
+
+    rc = wc_RsaPublicKeyDecode(data, &idx, &rsa->key, len);
+    if (rc != 0) {
+        ok = 0;
+    }
+    if (ok && !wp_rsa_determine_type(rsa, data, len)) {
+        ok = 0;
+    }
+    if (ok && (rsa->type == RSA_FLAG_TYPE_RSASSAPSS)) {
+        /* We need to check for pss params to allow a rejection for non-pkcs8
+         * keys. If we dont reject then the keytype gets set to RSA-PSS
+         * which is wrong. For non-pkcs8 fail here for PSS decoder
+         * and let the base RSA pick it up instead */
+        ok = wp_rsa_pss_get_params(rsa, data, len);
+    }
+    if (ok) {
+        rsa->bits = wc_RsaEncryptSize(&rsa->key) * 8;
+        rsa->hasPub = 1;
+    }
+
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 


### PR DESCRIPTION
Fix issue found when encoding where wp_ecc_set_params_x_y() incorrectly overwrites a previously decoded value for the public y component. 

Test case involves pkcs11-tool interop testing with openssl, will be brought in with pending OpenSC CI for wolfProvider.