### PR TITLE
Compute ECC public key on keypair export

### DIFF
--- a/src/wp_ecc_kmgmt.c
+++ b/src/wp_ecc_kmgmt.c
@@ -699,9 +699,21 @@ static int wp_ecc_get_params_enc_pub_key(wp_Ecc* ecc, OSSL_PARAM params[],
             outLen = 1 + 2 * ((ecc->bits + 7) / 8);
         }
         else {
-            rc = wc_ecc_export_x963_ex(&ecc->key, p->data, &outLen, 0);
-            if (rc != 0) {
-               ok = 0;
+            if (ecc->key.type == ECC_PRIVATEKEY_ONLY) {
+#ifdef ECC_TIMING_RESISTANT
+                rc = wc_ecc_make_pub_ex(&ecc->key, NULL, &ecc->rng);
+#else
+                rc = wc_ecc_make_pub_ex(&ecc->key, NULL, NULL);
+#endif
+                if (rc != 0){
+                    ok = 0;
+                }
+            }
+            if (ok) {
+                rc = wc_ecc_export_x963_ex(&ecc->key, p->data, &outLen, 0);
+                if (rc != 0) {
+                   ok = 0;
+                }
             }
         }
         p->return_size = outLen;

--- a/src/wp_ecc_kmgmt.c
+++ b/src/wp_ecc_kmgmt.c
@@ -1355,10 +1355,23 @@ static int wp_ecc_export_keypair(wp_Ecc* ecc, OSSL_PARAM* params, int* pIdx,
     int i = *pIdx;
     word32 outLen;
 
+    if (ecc->key.type == ECC_PRIVATEKEY_ONLY){
+#ifdef ECC_TIMING_RESISTANT
+        rc = wc_ecc_make_pub_ex(&ecc->key, NULL, &ecc->rng);
+#else
+        rc = wc_ecc_make_pub_ex(&ecc->key, NULL, NULL);
+#endif
+        if (rc != 0){
+            ok = 0;
+        }
+    }
+
     outLen = WP_ECC_PUBLIC_KEY_SIZE(ecc);
-    rc = wc_ecc_export_x963_ex(&ecc->key, data + *idx, &outLen, 0);
-    if (rc != 0) {
-        ok = 0;
+    if (ok) {
+        rc = wc_ecc_export_x963_ex(&ecc->key, data + *idx, &outLen, 0);
+        if (rc != 0) {
+            ok = 0;
+        }
     }
     if (ok) {
         wp_param_set_octet_string_ptr(&params[i++], OSSL_PKEY_PARAM_PUB_KEY,

--- a/test/unit.c
+++ b/test/unit.c
@@ -269,6 +269,8 @@ TEST_CASE test_case[] = {
     TEST_DECL(test_ec_load_cert, NULL),
 #endif /* WP_HAVE_ECDSA */
 
+    TEST_DECL(test_ec_decode, NULL),
+
 #ifdef WP_HAVE_PBE
     TEST_DECL(test_pbe, NULL),
 #endif

--- a/test/unit.h
+++ b/test/unit.h
@@ -366,6 +366,7 @@ int test_ec_load_key(void* data);
 int test_ec_load_cert(void* data);
 #endif /* WP_HAVE_ECDSA */
 
+int test_ec_decode(void* data);
 #endif /* WP_HAVE_ECC */
 
 #ifdef WP_HAVE_PBE


### PR DESCRIPTION
Compute public key for a decoded private key (private key type: ECC_PRIVATEKEY_ONLY) when exporting the key pair.