### PR TITLE
Use different find command for comparing directory ages in script

### DIFF
--- a/scripts/utils-general.sh
+++ b/scripts/utils-general.sh
@@ -30,8 +30,14 @@ fi
 check_folder_age() {
     folderA=$1
     folderB=$2
-    folderA_age=$(find "$folderA" -type f -printf '%T@' | sort -n | tail -n 1)
-    folderB_age=$(find "$folderB" -type f -printf '%T@' | sort -n | tail -n 1)
+
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        folderA_age=$(find "$folderA" -type f -exec stat -f '%Dm' {} \; | sort -n | tail -n 1)
+        folderB_age=$(find "$folderB" -type f -exec stat -f '%Dm' {} \; | sort -n | tail -n 1)
+    else
+        folderA_age=$(find "$folderA" -type f -printf '%T@' | sort -n | tail -n 1)
+        folderB_age=$(find "$folderB" -type f -printf '%T@' | sort -n | tail -n 1)
+    fi
 
     if awk "BEGIN {exit !($folderA_age > $folderB_age)}"; then
         echo 1

--- a/scripts/utils-wolfprovider.sh
+++ b/scripts/utils-wolfprovider.sh
@@ -21,6 +21,7 @@
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 source ${SCRIPT_DIR}/utils-openssl.sh
 source ${SCRIPT_DIR}/utils-wolfssl.sh
+source ${SCRIPT_DIR}/utils-general.sh
 
 WOLFPROV_SOURCE_DIR=${SCRIPT_DIR}/..
 WOLFPROV_INSTALL_DIR=${SCRIPT_DIR}/../wolfprov-install


### PR DESCRIPTION
This change fixes a minor issue on MacOS in the utils script due to a non-GNU version of `find`.

These are the messages I encountered using MacOS 15.3.1 which are removed following this change.

```
find: -printf: unknown primary or operator
find: -printf: unknown primary or operator
awk: syntax error at source line 1
 context is
	BEGIN {exit !( >>>  > <<<  )}
awk: illegal statement at source line 1
awk: syntax error at source line 1
 context is
	BEGIN {exit !( >>>  < <<<  )}
awk: illegal statement at source line 1
find: -printf: unknown primary or operator
find: -printf: unknown primary or operator
awk: syntax error at source line 1
 context is
	BEGIN {exit !( >>>  > <<<  )}
awk: illegal statement at source line 1
awk: syntax error at source line 1
 context is
	BEGIN {exit !( >>>  < <<<  )}
awk: illegal statement at source line 1
	wolfProvider installed in: /Users/paul/Documents/wolfssl/git/wolfProvider/scripts/../wolfprov-install
```