### PR TITLE
Add `WOLFPROV_FORCE_FAIL=1` option to curl.yml test

### DIFF
--- a/.github/scripts/check-workflow-result.sh
+++ b/.github/scripts/check-workflow-result.sh
@@ -3,14 +3,13 @@
 set -e
 
 if [ $# -lt 2 ]; then
-    echo "Usage: $0 <build_result> <test_result> [WOLFPROV_FORCE_FAIL] [TEST_SUITE]"
+    echo "Usage: $0 <test_result> [WOLFPROV_FORCE_FAIL] [TEST_SUITE]"
     exit 1
 fi
 
-BUILD_RESULT="$1"
-TEST_RESULT="$2"
-WOLFPROV_FORCE_FAIL="${3:-}"
-TEST_SUITE="${4:-}"
+TEST_RESULT="$1"
+WOLFPROV_FORCE_FAIL="${2:-}"
+TEST_SUITE="${3:-}"
 
 if [ "$WOLFPROV_FORCE_FAIL" = "1" ]; then
     if [ "$TEST_SUITE" = "curl" ]; then
@@ -74,7 +73,7 @@ if [ "$WOLFPROV_FORCE_FAIL" = "1" ]; then
         # --- simple test suite specific logic ---
         if [ -f "test-suite.log" ]; then
             # For simple tests, we expect all tests to fail when force fail is enabled
-            if [ $BUILD_RESULT -eq 0 ] || [ $TEST_RESULT -eq 0 ]; then
+            if [ $TEST_RESULT -eq 0 ]; then
                 echo "Simple tests unexpectedly succeeded with force fail enabled"
                 exit 1
             else
@@ -87,20 +86,16 @@ if [ "$WOLFPROV_FORCE_FAIL" = "1" ]; then
         fi
     else
         # --- generic force-fail logic for other suites ---
-        if [ $BUILD_RESULT -eq 0 ] || [ $TEST_RESULT -eq 0 ]; then
-            echo "Build/Test unexpectedly succeeded with force fail enabled"
+        if [ $TEST_RESULT -eq 0 ]; then
+            echo "Test unexpectedly succeeded with force fail enabled"
             exit 1 # failure was not seen when expected
         else
-            echo "Build/Test failed as expected with force fail enabled"
+            echo "Test failed as expected with force fail enabled"
             exit 0 # expected failure occurred
         fi
     fi
-elif [ $BUILD_RESULT -ne 0 ] || [ $TEST_RESULT -ne 0 ]; then
-    if [ $BUILD_RESULT -eq 2 ]; then
-        echo "Build/test setup failed unexpectedly"
-    else
-        echo "Tests failed unexpectedly"
-    fi
+elif [ $TEST_RESULT -ne 0 ]; then
+    echo "Tests failed unexpectedly"
     exit 1
 else
     echo "Tests passed successfully"

--- a/.github/scripts/check-workflow-result.sh
+++ b/.github/scripts/check-workflow-result.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+
+set -e
+
+if [ $# -lt 1 ]; then
+    echo "Usage: $0 <test_result> [WOLFPROV_FORCE_FAIL] [TEST_SUITE]"
+    exit 1
+fi
+
+TEST_RESULT="$1"
+WOLFPROV_FORCE_FAIL="${2:-}"
+TEST_SUITE="${3:-}"
+
+if [ "$WOLFPROV_FORCE_FAIL" = "1" ]; then
+    if [ "$TEST_SUITE" = "curl" ]; then
+        # --- curl-specific logic ---
+        if [ -f "tests/test.log" ]; then
+            # Extract and clean the failed test list from the log
+            ACTUAL_FAILS=$(grep -a '^TESTFAIL: These test cases failed:' tests/test.log | sed 's/.*failed: //')
+        else
+            echo "Error: tests/test.log not found"
+            exit 1
+        fi
+
+        # Get curl version from the workflow ref
+        CURL_VERSION="${CURL_REF:-}"
+
+        # Define expected failures based on curl version
+        case "$CURL_VERSION" in
+            "curl-8_4_0")
+                EXPECTED_FAILS="9 31 39 41 44 46 61 64 65 70 71 72 73 88 153 154 158 163 166 167 168 169 170 171 173 186 206 245 246 258 259 273 277 327 335 388 420 444 540 551 552 554 565 579 584 643 645 646 647 648 649 650 651 652 653 654 666 667 668 669 670 671 672 673 977 1001 1002 1030 1053 1060 1061 1071 1072 1079 1095 1105 1133 1136 1151 1155 1158 1160 1161 1186 1187 1189 1190 1191 1192 1193 1194 1195 1196 1198 1199 1229 1284 1285 1286 1293 1315 1404 1412 1415 1418 1437 1568 1903 1905 1916 1917 1964 2024 2026 2027 2028 2030 2058 2059 2060 2061 2062 2063 2064 2065 2066 2067 2068 2069 2073 2076 2200 2201 2202 2203 2204 3017 3018"
+                ;;
+            "master")
+                # TODO: Replace with actual master branch expected failures
+                EXPECTED_FAILS="9 31 39 41 44 46 61 64 65 70 71 72 73 88 153 154 158 163 166 167 168 169 170 171 173 186 206 245 246 258 259 273 277 327 335 388 420 444 483 540 551 552 554 565 579 584 643 645 646 647 648 649 650 651 652 653 654 666 667 668 669 670 671 672 673 695 977 1001 1002 1030 1053 1060 1061 1071 1072 1079 1095 1105 1133 1136 1151 1155 1158 1160 1161 1186 1187 1189 1190 1191 1192 1193 1194 1195 1196 1198 1199 1229 1284 1285 1286 1293 1315 1404 1412 1415 1418 1437 1476 1568 1608 1610 1615 1654 1660 1903 1905 1916 1917 1964 2024 2026 2027 2028 2030 2058 2059 2060 2061 2062 2063 2064 2065 2066 2067 2068 2069 2073 2076 2200 2201 2202 2203 2204 3017 3018"
+                ;;
+            *)
+                echo "Error: Unknown curl version: $CURL_VERSION"
+                exit 1
+                ;;
+        esac
+
+        # Create temporary files for sorted lists
+        TEMP_DIR=$(mktemp -d)
+        ACTUAL_SORTED="${TEMP_DIR}/actual_sorted.txt"
+        EXPECTED_SORTED="${TEMP_DIR}/expected_sorted.txt"
+
+        # Sort both lists, one per line
+        echo "$ACTUAL_FAILS" | tr ' ' '\n' | sort -n > "$ACTUAL_SORTED"
+        echo "$EXPECTED_FAILS" | tr ' ' '\n' | sort -n > "$EXPECTED_SORTED"
+
+        # Find missing in actual (in expected but not in actual)
+        MISSING=$(comm -23 "$EXPECTED_SORTED" "$ACTUAL_SORTED" | tr '\n' ' ')
+        # Find extra in actual (in actual but not in expected)
+        EXTRA=$(comm -13 "$EXPECTED_SORTED" "$ACTUAL_SORTED" | tr '\n' ' ')
+
+        # Clean up temporary files
+        rm -rf "$TEMP_DIR"
+
+        echo "Test(s) that should have failed: $MISSING"
+        echo "Test(s) that shouldn't have failed: $EXTRA"
+
+        # Check if they match by comparing the original sorted files
+        if [ "$ACTUAL_FAILS" = "$EXPECTED_FAILS" ]; then
+            echo "PASS: Actual failed tests match expected."
+            exit 0
+        else
+            echo "FAIL: Actual failed tests do not match expected."
+            exit 1
+        fi
+    else
+        # --- generic force-fail logic for other suites ---
+        if [ "$TEST_RESULT" -ne 0 ]; then
+            echo "Tests failed as expected with force fail enabled (suite: $TEST_SUITE)"
+            exit 0
+        else
+            echo "Tests unexpectedly succeeded with force fail enabled (suite: $TEST_SUITE)"
+            exit 1
+        fi
+    fi
+elif [ "$TEST_RESULT" -ne 0 ]; then
+    if [ "$TEST_RESULT" -eq 2 ]; then
+        echo "Build/test setup failed unexpectedly"
+    else
+        echo "Tests failed unexpectedly"
+    fi
+    exit 1
+else
+    echo "Tests passed successfully"
+    exit 0
+fi

--- a/.github/scripts/check-workflow-result.sh
+++ b/.github/scripts/check-workflow-result.sh
@@ -31,7 +31,6 @@ if [ "$WOLFPROV_FORCE_FAIL" = "1" ]; then
                 EXPECTED_FAILS="9 31 39 41 44 46 61 64 65 70 71 72 73 88 153 154 158 163 166 167 168 169 170 171 173 186 206 245 246 258 259 273 277 327 335 388 420 444 540 551 552 554 565 579 584 643 645 646 647 648 649 650 651 652 653 654 666 667 668 669 670 671 672 673 977 1001 1002 1030 1053 1060 1061 1071 1072 1079 1095 1105 1133 1136 1151 1155 1158 1160 1161 1186 1187 1189 1190 1191 1192 1193 1194 1195 1196 1198 1199 1229 1284 1285 1286 1293 1315 1404 1412 1415 1418 1437 1568 1903 1905 1916 1917 1964 2024 2026 2027 2028 2030 2058 2059 2060 2061 2062 2063 2064 2065 2066 2067 2068 2069 2073 2076 2200 2201 2202 2203 2204 3017 3018"
                 ;;
             "master")
-                # TODO: Replace with actual master branch expected failures
                 EXPECTED_FAILS="9 31 39 41 44 46 61 64 65 70 71 72 73 88 153 154 158 163 166 167 168 169 170 171 173 186 206 245 246 258 259 273 277 327 335 388 420 444 483 540 551 552 554 565 579 584 643 645 646 647 648 649 650 651 652 653 654 666 667 668 669 670 671 672 673 695 977 1001 1002 1030 1053 1060 1061 1071 1072 1079 1095 1105 1133 1136 1151 1155 1158 1160 1161 1186 1187 1189 1190 1191 1192 1193 1194 1195 1196 1198 1199 1229 1284 1285 1286 1293 1315 1404 1412 1415 1418 1437 1476 1568 1608 1610 1615 1654 1660 1903 1905 1916 1917 1964 2024 2026 2027 2028 2030 2058 2059 2060 2061 2062 2063 2064 2065 2066 2067 2068 2069 2073 2076 2200 2201 2202 2203 2204 3017 3018"
                 ;;
             *)
@@ -45,9 +44,12 @@ if [ "$WOLFPROV_FORCE_FAIL" = "1" ]; then
         ACTUAL_SORTED="${TEMP_DIR}/actual_sorted.txt"
         EXPECTED_SORTED="${TEMP_DIR}/expected_sorted.txt"
 
-        # Sort both lists, one per line
-        echo "$ACTUAL_FAILS" | tr ' ' '\n' | sort -n > "$ACTUAL_SORTED"
-        echo "$EXPECTED_FAILS" | tr ' ' '\n' | sort -n > "$EXPECTED_SORTED"
+        # Clean and sort both lists and remove empty lines
+        echo "$ACTUAL_FAILS" | tr ' ' '\n' | grep -v '^$' | sort -n > "$ACTUAL_SORTED"
+        echo "$EXPECTED_FAILS" | tr ' ' '\n' | grep -v '^$' | sort -n > "$EXPECTED_SORTED"
+
+        echo "DEBUG: Sorted actual fails: $(tr '\n' ' ' < "$ACTUAL_SORTED")"
+        echo "DEBUG: Sorted expected fails: $(tr '\n' ' ' < "$EXPECTED_SORTED")"
 
         # Find missing in actual (in expected but not in actual)
         MISSING=$(comm -23 "$EXPECTED_SORTED" "$ACTUAL_SORTED" | tr '\n' ' ')
@@ -60,8 +62,7 @@ if [ "$WOLFPROV_FORCE_FAIL" = "1" ]; then
         echo "Test(s) that should have failed: $MISSING"
         echo "Test(s) that shouldn't have failed: $EXTRA"
 
-        # Check if they match by comparing the original sorted files
-        if [ "$ACTUAL_FAILS" = "$EXPECTED_FAILS" ]; then
+        if [ -z "$MISSING" ] && [ -z "$EXTRA" ]; then
             echo "PASS: Actual failed tests match expected."
             exit 0
         else

--- a/.github/workflows/curl.yml
+++ b/.github/workflows/curl.yml
@@ -74,6 +74,9 @@ jobs:
         curl_ref: [ 'master', 'curl-8_4_0' ]
         wolfssl_ref: [ 'master', 'v5.7.4-stable' ]
     steps:
+      - name: Checkout wolfProvider
+        uses: actions/checkout@v4
+
       - name: Retrieving OpenSSL from cache
         uses: actions/cache/restore@v4
         id: openssl-cache
@@ -109,13 +112,37 @@ jobs:
           repository: curl/curl
           path: curl
           ref: ${{ matrix.curl_ref }}
-          configure: --with-openssl=$GITHUB_WORKSPACE/openssl-install/
+          configure: --with-openssl
           check: false
 
-      - name: Test curl with wolfProvider
+      - name: Test curl with wolfProvider - default
         working-directory: curl
         run: |
+          # Set environment variables for default
           export LD_LIBRARY_PATH=$GITHUB_WORKSPACE/wolfssl-install/lib:$GITHUB_WORKSPACE/openssl-install/lib64
           export OPENSSL_CONF=$GITHUB_WORKSPACE/provider.conf
           export OPENSSL_MODULES=$GITHUB_WORKSPACE/wolfprov-install/lib
-          make -j $(nproc) test-ci
+          export PKG_CONFIG_PATH=$GITHUB_WORKSPACE/openssl-install/lib64/pkgconfig
+
+          # Run tests
+          make -j$(nproc) test-ci || true
+          TEST_RESULT=$?
+          $GITHUB_WORKSPACE/.github/scripts/check-workflow-result.sh $TEST_RESULT 0 curl
+
+      # Test WPFF after default so certs get generated
+      - name: Test curl with wolfProvider - force fail
+        working-directory: curl
+        run: |
+          # Set environment variables for force fail
+          export LD_LIBRARY_PATH=$GITHUB_WORKSPACE/wolfssl-install/lib:$GITHUB_WORKSPACE/openssl-install/lib64
+          export OPENSSL_CONF=$GITHUB_WORKSPACE/provider.conf
+          export OPENSSL_MODULES=$GITHUB_WORKSPACE/wolfprov-install/lib
+          export PKG_CONFIG_PATH=$GITHUB_WORKSPACE/openssl-install/lib64/pkgconfig
+          export WOLFPROV_FORCE_FAIL=1
+          export CURL_REF=${{ matrix.curl_ref }}
+
+          # Run tests and save output to test.log
+          mkdir -p tests
+          make -j$(nproc) test-ci 2>&1 | tee tests/test.log || true
+          TEST_RESULT=$?
+          $GITHUB_WORKSPACE/.github/scripts/check-workflow-result.sh $TEST_RESULT 1 curl

--- a/.github/workflows/curl.yml
+++ b/.github/workflows/curl.yml
@@ -116,9 +116,9 @@ jobs:
           configure: --with-openssl
           check: false
 
-      - name: Generate certificates for force-fail tests
+      - name: Generate certificates for curl master force-fail tests
         run: |
-          if [ "${{ matrix.force_fail }}" = "1" ]; then
+          if [ "${{ matrix.force_fail }}" = "1" ] && [ "${{ matrix.curl_ref }}" = "master" ]; then
             cd curl/tests/certs
             make test-ca.cacert
             cd ../..
@@ -135,7 +135,8 @@ jobs:
           export WOLFPROV_FORCE_FAIL=${{ matrix.force_fail }}
           export CURL_REF=${{ matrix.curl_ref }}
 
-          # Run tests
-          make -j$(nproc) test-ci || true
+          # Run tests and save output to test.log
+          mkdir -p tests
+          make -j$(nproc) test-ci 2>&1 | tee tests/test.log || true
           TEST_RESULT=$?
           $GITHUB_WORKSPACE/.github/scripts/check-workflow-result.sh $TEST_RESULT ${{ matrix.force_fail }} curl

--- a/.github/workflows/curl.yml
+++ b/.github/workflows/curl.yml
@@ -73,6 +73,7 @@ jobs:
       matrix:
         curl_ref: [ 'master', 'curl-8_4_0' ]
         wolfssl_ref: [ 'master', 'v5.7.4-stable' ]
+        force_fail: [ 1, 0 ]
     steps:
       - name: Checkout wolfProvider
         uses: actions/checkout@v4
@@ -115,34 +116,26 @@ jobs:
           configure: --with-openssl
           check: false
 
-      - name: Test curl with wolfProvider - default
+      - name: Generate certificates for force-fail tests
+        run: |
+          if [ "${{ matrix.force_fail }}" = "1" ]; then
+            cd curl/tests/certs
+            make test-ca.cacert
+            cd ../..
+          fi
+
+      - name: Test curl with wolfProvider
         working-directory: curl
         run: |
-          # Set environment variables for default
+          # Set environment variables
           export LD_LIBRARY_PATH=$GITHUB_WORKSPACE/wolfssl-install/lib:$GITHUB_WORKSPACE/openssl-install/lib64
           export OPENSSL_CONF=$GITHUB_WORKSPACE/provider.conf
           export OPENSSL_MODULES=$GITHUB_WORKSPACE/wolfprov-install/lib
           export PKG_CONFIG_PATH=$GITHUB_WORKSPACE/openssl-install/lib64/pkgconfig
+          export WOLFPROV_FORCE_FAIL=${{ matrix.force_fail }}
+          export CURL_REF=${{ matrix.curl_ref }}
 
           # Run tests
           make -j$(nproc) test-ci || true
           TEST_RESULT=$?
-          $GITHUB_WORKSPACE/.github/scripts/check-workflow-result.sh $TEST_RESULT 0 curl
-
-      # Test WPFF after default so certs get generated
-      - name: Test curl with wolfProvider - force fail
-        working-directory: curl
-        run: |
-          # Set environment variables for force fail
-          export LD_LIBRARY_PATH=$GITHUB_WORKSPACE/wolfssl-install/lib:$GITHUB_WORKSPACE/openssl-install/lib64
-          export OPENSSL_CONF=$GITHUB_WORKSPACE/provider.conf
-          export OPENSSL_MODULES=$GITHUB_WORKSPACE/wolfprov-install/lib
-          export PKG_CONFIG_PATH=$GITHUB_WORKSPACE/openssl-install/lib64/pkgconfig
-          export WOLFPROV_FORCE_FAIL=1
-          export CURL_REF=${{ matrix.curl_ref }}
-
-          # Run tests and save output to test.log
-          mkdir -p tests
-          make -j$(nproc) test-ci 2>&1 | tee tests/test.log || true
-          TEST_RESULT=$?
-          $GITHUB_WORKSPACE/.github/scripts/check-workflow-result.sh $TEST_RESULT 1 curl
+          $GITHUB_WORKSPACE/.github/scripts/check-workflow-result.sh $TEST_RESULT ${{ matrix.force_fail }} curl

--- a/.github/workflows/curl.yml
+++ b/.github/workflows/curl.yml
@@ -73,7 +73,7 @@ jobs:
       matrix:
         curl_ref: [ 'master', 'curl-8_4_0' ]
         wolfssl_ref: [ 'master', 'v5.7.4-stable' ]
-        force_fail: [ 1, 0 ]
+        force_fail: [ 1, 0 ] # ['WOLFPROV_FORCE_FAIL=1', '']
     steps:
       - name: Checkout wolfProvider
         uses: actions/checkout@v4
@@ -118,12 +118,12 @@ jobs:
 
       - name: Generate certificates for curl master force-fail tests
         run: |
-          if [ "${{ matrix.force_fail }}" = "1" ] && [ "${{ matrix.curl_ref }}" = "master" ]; then
+          if [ "${{ matrix.force_fail }}" = "1" ] &&
+             [ "${{ matrix.curl_ref }}" = "master" ]; then
             cd curl/tests/certs
             make test-ca.cacert
             cd ../..
           fi
-
       - name: Test curl with wolfProvider
         working-directory: curl
         run: |

--- a/.github/workflows/simple.yml
+++ b/.github/workflows/simple.yml
@@ -3,8 +3,7 @@ name: Simple Tests
 # START OF COMMON SECTION
 on:
   push:
-    branches: [ '*' ]
-#    branches: [ 'master', 'main', 'release/**' ]
+    branches: [ 'master', 'main', 'release/**' ]
   pull_request:
     branches: [ '*' ]
 
@@ -14,48 +13,61 @@ concurrency:
 # END OF COMMON SECTION
 
 jobs:
-  make_check:
-    runs-on: ubuntu-latest
+  simple_test:
+    name: Simple Test
+    runs-on: ubuntu-22.04
     timeout-minutes: 20
-
     strategy:
       matrix:
-        config:
+        build_ref:
           - ''
           - 'OPENSSL_TAG=master'
           - 'WOLFSSL_TAG=master'
           - 'OPENSSL_TAG=master WOLFSSL_TAG=master'
-        force_fail:
-          - ''
-          - 'WOLFPROV_FORCE_FAIL=1'
+        force_fail: [ 1, 0 ] # ['WOLFPROV_FORCE_FAIL=1', '']
 
     steps:
-      - uses: actions/checkout@v4
-        name: Checkout repository
+      - name: Checkout wolfProvider
+        uses: actions/checkout@v4
 
-      - name: Run build and tests
+      # Check if this version of wolfssl/wolfprovider has already been built,
+      # mark to cache these items on post if we do end up building
+      - name: Checking wolfSSL/wolfProvider in cache
+        uses: actions/cache@v4
+        id: wolfprov-cache
+        with:
+          path: |
+            wolfssl-source
+            wolfssl-install
+            wolfprov-install
+            provider.conf
+
+          key: wolfprov-${{ matrix.build_ref }}-${{ github.sha }}
+          lookup-only: true
+
+      # If wolfssl/wolfprovider have not yet been built, pull ossl from cache
+      - name: Checking OpenSSL in cache
+        if: steps.wolfprov-${{ matrix.build_ref }}-cache.hit != 'true'
+        uses: actions/cache@v4
+        id: openssl-cache
+        with:
+          path: |
+            openssl-source
+            openssl-install
+
+          key: ossl-depends
+
+      # If not yet built this version, build it now
+      - name: Build wolfProvider
+        if: steps.wolfprov-${{ matrix.build_ref }}-cache.hit != 'true'
         run: |
-          # Build first with matrix config
-          ${{ matrix.config }} ${{ matrix.force_fail }} ./scripts/build-wolfprovider.sh || BUILD_RESULT=$?
+          ${{ matrix.build_ref.openssl }} ${{ matrix.build_ref.wolfssl }} WOLFPROV_FORCE_FAIL=${{ matrix.force_fail }} ./scripts/build-wolfprovider.sh || BUILD_RESULT=$?
+          $GITHUB_WORKSPACE/.github/scripts/check-workflow-result.sh $BUILD_RESULT ${{ matrix.force_fail }} simple
 
-          # Run all tests regardless of build result
-          ${{ matrix.force_fail }} ./scripts/cmd_test/do-cmd-tests.sh || TEST_RESULT=$?
-
-          # For force_fail, we expect failures (return 1)
-          if [ -n "${{ matrix.force_fail }}" ]; then
-            if [ $BUILD_RESULT -eq 0 ] || [ $TEST_RESULT -eq 0 ]; then
-              echo "Build/Test unexpectedly succeeded with force fail enabled"
-              exit 1 # failure was not seen when expected
-            else
-              echo "Build/Test failed as expected with force fail enabled"
-              exit 0 # expected failure occurred
-            fi
-          else
-            # Normal case - expect success
-            if [ $BUILD_RESULT -ne 0 ] || [ $TEST_RESULT -ne 0 ]; then
-              exit 1 # unexpected failure
-            fi
-          fi
+      - name: Run simple tests
+        run: |
+          WOLFPROV_FORCE_FAIL=${{ matrix.force_fail }} ./scripts/cmd_test/do-cmd-tests.sh || TEST_RESULT=$?
+          $GITHUB_WORKSPACE/.github/scripts/check-workflow-result.sh $TEST_RESULT ${{ matrix.force_fail }} simple
 
       - name: Print test logs
         if: always()
@@ -63,4 +75,3 @@ jobs:
           if [ -f test-suite.log ] ; then
             cat test-suite.log
           fi
-


### PR DESCRIPTION
# Description

- Builds `curl.yml` github workflow with `WOLFPROV_FORCE_FAIL=1` through matrix ref. Checks possible scenarios fail/pass scenarios and continues/exits if unexpected a based on ref. 
- Builds `simple.yml` with cache restore method and WPFF ref matrix for faster build times
- Added new `check-workflow-results.sh` that is needed to test the different scenarios with WPFF enabled. For curl test it will return the expected failures vs actual failures with WPFF enabled. 