### PR TITLE
Temporary test fix due to changing behavior in openssl master

### DIFF
--- a/test/test_hkdf.c
+++ b/test/test_hkdf.c
@@ -91,6 +91,8 @@ static int test_hkdf_calc(OSSL_LIB_CTX* libCtx, unsigned char *key, int keyLen,
     return err;
 }
 
+#if OPENSSL_VERSION_NUMBER <= 0x30400000L
+
 static int test_hkdf_double_set_salt(OSSL_LIB_CTX* libCtx, unsigned char *key,
     int keyLen, const EVP_MD *md, int mode)
 {
@@ -165,6 +167,8 @@ static int test_hkdf_double_set_salt(OSSL_LIB_CTX* libCtx, unsigned char *key,
     return err;
 }
 
+#endif
+
 static int test_hkdf_md(const EVP_MD *md, int mode)
 {
     int err = 0;
@@ -194,6 +198,8 @@ static int test_hkdf_md(const EVP_MD *md, int mode)
         err = 1;
     }
 
+#if OPENSSL_VERSION_NUMBER <= 0x30400000L
+
     memset(oKey, 0, sizeof(oKey));
     memset(wKey, 0, sizeof(wKey));
 
@@ -217,6 +223,8 @@ static int test_hkdf_md(const EVP_MD *md, int mode)
         PRINT_BUFFER("wolfSSL key", wKey, sizeof(wKey));
         err = 1;
     }
+
+#endif
 
     return err;
 }


### PR DESCRIPTION
This PR for openssl https://github.com/openssl/openssl/pull/27305 went into master, changing expected return codes. Only run tests for older versions until this can be worked out with the openssl maintainers.