### PR TITLE
Inject `WOLFPROV_FORCE_FAIL=1` after we build provider

### DIFF
--- a/.github/scripts/check-workflow-result.sh
+++ b/.github/scripts/check-workflow-result.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-if [ $# -lt 2 ]; then
+if [ $# -lt 1 ]; then
     echo "Usage: $0 <test_result> [WOLFPROV_FORCE_FAIL] [TEST_SUITE]"
     exit 1
 fi
@@ -11,7 +11,12 @@ TEST_RESULT="$1"
 WOLFPROV_FORCE_FAIL="${2:-}"
 TEST_SUITE="${3:-}"
 
-if [ "$WOLFPROV_FORCE_FAIL" = "1" ]; then
+# If force fail is empty treat second arg as test suite
+if [ -z "$WOLFPROV_FORCE_FAIL" ]; then
+    TEST_SUITE="${2:-}"
+fi
+
+if [ "$WOLFPROV_FORCE_FAIL" = "WOLFPROV_FORCE_FAIL=1" ]; then
     if [ "$TEST_SUITE" = "curl" ]; then
         # --- curl-specific logic ---
         if [ -f "tests/test.log" ]; then
@@ -67,21 +72,6 @@ if [ "$WOLFPROV_FORCE_FAIL" = "1" ]; then
             exit 0
         else
             echo "FAIL: Actual failed tests do not match expected."
-            exit 1
-        fi
-    elif [ "$TEST_SUITE" = "simple" ]; then
-        # --- simple test suite specific logic ---
-        if [ -f "test-suite.log" ]; then
-            # For simple tests, we expect all tests to fail when force fail is enabled
-            if [ $TEST_RESULT -eq 0 ]; then
-                echo "Simple tests unexpectedly succeeded with force fail enabled"
-                exit 1
-            else
-                echo "Simple tests failed as expected with force fail enabled"
-                exit 0
-            fi
-        else
-            echo "Error: test-suite.log not found"
             exit 1
         fi
     else

--- a/.github/workflows/curl.yml
+++ b/.github/workflows/curl.yml
@@ -73,7 +73,7 @@ jobs:
       matrix:
         curl_ref: [ 'master', 'curl-8_4_0' ]
         wolfssl_ref: [ 'master', 'v5.7.4-stable' ]
-        force_fail: [ 1, 0 ] # ['WOLFPROV_FORCE_FAIL=1', '']
+        force_fail: ['WOLFPROV_FORCE_FAIL=1', '']
     steps:
       - name: Checkout wolfProvider
         uses: actions/checkout@v4
@@ -118,7 +118,7 @@ jobs:
 
       - name: Generate certificates for curl master force-fail tests
         run: |
-          if [ "${{ matrix.force_fail }}" = "1" ] &&
+          if [ "${{ matrix.force_fail }}" = "WOLFPROV_FORCE_FAIL=1" ] &&
              [ "${{ matrix.curl_ref }}" = "master" ]; then
             cd curl/tests/certs
             make test-ca.cacert
@@ -132,7 +132,7 @@ jobs:
           export OPENSSL_CONF=$GITHUB_WORKSPACE/provider.conf
           export OPENSSL_MODULES=$GITHUB_WORKSPACE/wolfprov-install/lib
           export PKG_CONFIG_PATH=$GITHUB_WORKSPACE/openssl-install/lib64/pkgconfig
-          export WOLFPROV_FORCE_FAIL=${{ matrix.force_fail }}
+          export ${{ matrix.force_fail }}
           export CURL_REF=${{ matrix.curl_ref }}
 
           # Run tests and save output to test.log

--- a/.github/workflows/simple.yml
+++ b/.github/workflows/simple.yml
@@ -24,7 +24,7 @@ jobs:
           - 'OPENSSL_TAG=master'
           - 'WOLFSSL_TAG=master'
           - 'OPENSSL_TAG=master WOLFSSL_TAG=master'
-        force_fail: [ 1, 0 ] # ['WOLFPROV_FORCE_FAIL=1', '']
+        force_fail: ['WOLFPROV_FORCE_FAIL=1', '']
 
     steps:
       - name: Checkout wolfProvider
@@ -61,13 +61,11 @@ jobs:
       - name: Build wolfProvider
         if: steps.wolfprov-${{ matrix.build_ref }}-cache.hit != 'true'
         run: |
-          ${{ matrix.build_ref.openssl }} ${{ matrix.build_ref.wolfssl }} WOLFPROV_FORCE_FAIL=${{ matrix.force_fail }} ./scripts/build-wolfprovider.sh || BUILD_RESULT=$?
-          $GITHUB_WORKSPACE/.github/scripts/check-workflow-result.sh $BUILD_RESULT ${{ matrix.force_fail }} simple
+          ${{ matrix.build_ref.openssl }} ${{ matrix.build_ref.wolfssl }} ./scripts/build-wolfprovider.sh
 
       - name: Run simple tests
         run: |
-          WOLFPROV_FORCE_FAIL=${{ matrix.force_fail }} ./scripts/cmd_test/do-cmd-tests.sh || TEST_RESULT=$?
-          $GITHUB_WORKSPACE/.github/scripts/check-workflow-result.sh $TEST_RESULT ${{ matrix.force_fail }} simple
+          ./scripts/cmd_test/do-cmd-tests.sh ${{ matrix.force_fail }}
 
       - name: Print test logs
         if: always()

--- a/scripts/cmd_test/do-cmd-tests.sh
+++ b/scripts/cmd_test/do-cmd-tests.sh
@@ -20,6 +20,12 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
 
+# Get the force fail parameter
+FORCE_FAIL=0
+if [ "$1" = "WOLFPROV_FORCE_FAIL=1" ]; then
+    FORCE_FAIL=1
+fi
+
 # Get the directory where this script is located
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 REPO_ROOT="$( cd "${SCRIPT_DIR}/../.." &> /dev/null && pwd )"
@@ -51,30 +57,30 @@ echo "Using wolfSSL version: ${WOLFSSL_TAG}"
 
 # Run the hash comparison test
 echo -e "\n=== Running Hash Comparison Test ==="
-"${REPO_ROOT}/scripts/cmd_test/hash-cmd-test.sh"
+"${REPO_ROOT}/scripts/cmd_test/hash-cmd-test.sh" "$1"
 HASH_RESULT=$?
 
 # Run the AES comparison test
 echo -e "\n=== Running AES Comparison Test ==="
-"${REPO_ROOT}/scripts/cmd_test/aes-cmd-test.sh"
+"${REPO_ROOT}/scripts/cmd_test/aes-cmd-test.sh" "$1"
 AES_RESULT=$?
 
 # Run the RSA key generation test
 echo -e "\n=== Running RSA Key Generation Test ==="
-"${REPO_ROOT}/scripts/cmd_test/rsa-cmd-test.sh"
+"${REPO_ROOT}/scripts/cmd_test/rsa-cmd-test.sh" "$1"
 RSA_RESULT=$?
 
 # Run the ECC key generation test
 echo -e "\n=== Running ECC Key Generation Test ==="
-"${REPO_ROOT}/scripts/cmd_test/ecc-cmd-test.sh"
+"${REPO_ROOT}/scripts/cmd_test/ecc-cmd-test.sh" "$1"
 ECC_RESULT=$?
 
 # Check results
 if [ $HASH_RESULT -eq 0 ] && [ $AES_RESULT -eq 0 ] && [ $RSA_RESULT -eq 0 ] && [ $ECC_RESULT -eq 0 ]; then
-    echo -e "\n=== All Command-Line Tests Passed ==="
+    echo -e "\n=== All Command-Line Tests Passed $1 ==="
     exit 0
 else
-    echo -e "\n=== Command-Line Tests Failed ==="
+    echo -e "\n=== Command-Line Tests Failed $1 ==="
     echo "Hash Test Result: $HASH_RESULT (0=success)"
     echo "AES Test Result: $AES_RESULT (0=success)"
     echo "RSA Test Result: $RSA_RESULT (0=success)"


### PR DESCRIPTION
# Description

- Changes force_fail ref for `simple.yml` and `curl.yml` so it is consistent and has `WOLFPROV_FORCE_FAIL=1` as arg. This ensures clarity when testing the ref instead of just seeing `1` it is `WOLFPROV_FORCE_FAIL=1` now.
- Adds a WPFF argument to `scripts/cmd_test/do-cmd-tests.sh` which can be set when called to set WPFF after we build in the rsa, ecc, hash, and aes scripts so we can see the failure results better. 
- Test now pass if WPFF is enabled and all of the test fail. If one test passes we mark as a fail and report. This ensures that if any changes occur with coverage with WPFF or default we will see it. 