### PR TITLE
Github workflow testing support with `WOLFPROV_FORCE_FAIL=1`

### DIFF
--- a/.github/scripts/check-workflow-result.sh
+++ b/.github/scripts/check-workflow-result.sh
@@ -1,4 +1,23 @@
 #!/bin/bash
+# check-workflow-result.sh
+#
+# Copyright (C) 2006-2024 wolfSSL Inc.
+#
+# This file is part of wolfProvider.
+#
+# wolfProvider is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# wolfProvider is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
 
 set -e
 
@@ -11,14 +30,17 @@ TEST_RESULT="$1"
 WOLFPROV_FORCE_FAIL="${2:-}"
 TEST_SUITE="${3:-}"
 
+# Ensure TEST_RESULT is treated as a number
+TEST_RESULT=$((TEST_RESULT + 0))
+
 # If force fail is empty treat second arg as test suite
 if [ -z "$WOLFPROV_FORCE_FAIL" ]; then
     TEST_SUITE="${2:-}"
 fi
 
 if [ "$WOLFPROV_FORCE_FAIL" = "WOLFPROV_FORCE_FAIL=1" ]; then
+    # ----- CURL -----
     if [ "$TEST_SUITE" = "curl" ]; then
-        # --- curl-specific logic ---
         if [ -f "tests/test.log" ]; then
             # Extract and clean the failed test list from the log
             ACTUAL_FAILS=$(grep -a '^TESTFAIL: These test cases failed:' tests/test.log | sed 's/.*failed: //')
@@ -74,13 +96,128 @@ if [ "$WOLFPROV_FORCE_FAIL" = "WOLFPROV_FORCE_FAIL=1" ]; then
             echo "FAIL: Actual failed tests do not match expected."
             exit 1
         fi
+    # ----- OPENVPN -----
+    elif [ "$TEST_SUITE" = "openvpn" ]; then
+        if [ -f "openvpn-test.log" ]; then
+            # Extract failed tests from the log
+            ACTUAL_FAILS=$(grep -a '^FAIL: ' openvpn-test.log | sed 's/^FAIL: //' | sort)
+
+            # Define expected failures
+            EXPECTED_FAILS="auth_token_testdriver crypto_testdriver pkt_testdriver tls_crypt_testdriver"
+            
+            # Create temporary files for sorted lists
+            TEMP_DIR=$(mktemp -d)
+            ACTUAL_SORTED="${TEMP_DIR}/actual_sorted.txt"
+            EXPECTED_SORTED="${TEMP_DIR}/expected_sorted.txt"
+            
+            # Clean and sort both lists
+            echo "$ACTUAL_FAILS" | tr ' ' '\n' | grep -v '^$' | sort > "$ACTUAL_SORTED"
+            echo "$EXPECTED_FAILS" | tr ' ' '\n' | grep -v '^$' | sort > "$EXPECTED_SORTED"
+            
+            echo "DEBUG: Actual failed tests: $(tr '\n' ' ' < "$ACTUAL_SORTED")"
+            echo "DEBUG: Expected failed tests: $(tr '\n' ' ' < "$EXPECTED_SORTED")"
+            
+            # Find missing in actual (in expected but not in actual)
+            MISSING=$(comm -23 "$EXPECTED_SORTED" "$ACTUAL_SORTED" | tr '\n' ' ')
+            # Find extra in actual (in actual but not in expected)
+            EXTRA=$(comm -13 "$EXPECTED_SORTED" "$ACTUAL_SORTED" | tr '\n' ' ')
+            
+            # Clean up temporary files
+            rm -rf "$TEMP_DIR"
+            
+            echo "Test(s) that should have failed: $MISSING"
+            echo "Test(s) that shouldn't have failed: $EXTRA"
+            
+            if [ -z "$MISSING" ] && [ -z "$EXTRA" ]; then
+                echo "PASS: Actual failed tests match expected."
+                exit 0
+            else
+                echo "FAIL: Actual failed tests do not match expected."
+                exit 1
+            fi
+        else
+            echo "Error: openvpn-test.log not found"
+            exit 1
+        fi
+    # ----- SSSD -----
+    elif [ "$TEST_SUITE" = "sssd" ]; then
+        if [ -f "sssd-test.log" ]; then
+            # Extract failed tests from the log
+            ACTUAL_FAILS=$(grep -a '^FAIL: ' sssd-test.log | sed 's/^FAIL: //' | sort)
+            
+            # Define expected failures
+            EXPECTED_FAILS="src/tests/pysss-test.py3.sh pam-srv-tests ssh-srv-tests test_cert_utils sss_certmap_test sysdb-tests crypto-tests"
+            
+            # Create temporary files for sorted lists
+            TEMP_DIR=$(mktemp -d)
+            ACTUAL_SORTED="${TEMP_DIR}/actual_sorted.txt"
+            EXPECTED_SORTED="${TEMP_DIR}/expected_sorted.txt"
+            
+            # Clean and sort both lists
+            echo "$ACTUAL_FAILS" | tr ' ' '\n' | grep -v '^$' | sort > "$ACTUAL_SORTED"
+            echo "$EXPECTED_FAILS" | tr ' ' '\n' | grep -v '^$' | sort > "$EXPECTED_SORTED"
+            
+            echo "DEBUG: Actual failed tests: $(tr '\n' ' ' < "$ACTUAL_SORTED")"
+            echo "DEBUG: Expected failed tests: $(tr '\n' ' ' < "$EXPECTED_SORTED")"
+            
+            # Find missing in actual (in expected but not in actual)
+            MISSING=$(comm -23 "$EXPECTED_SORTED" "$ACTUAL_SORTED" | tr '\n' ' ')
+            # Find extra in actual (in actual but not in expected)
+            EXTRA=$(comm -13 "$EXPECTED_SORTED" "$ACTUAL_SORTED" | tr '\n' ' ')
+            
+            # Clean up temporary files
+            rm -rf "$TEMP_DIR"
+            
+            echo "Test(s) that should have failed: $MISSING"
+            echo "Test(s) that shouldn't have failed: $EXTRA"
+            
+            if [ -z "$MISSING" ] && [ -z "$EXTRA" ]; then
+                echo "PASS: Actual failed tests match expected."
+                exit 0
+            else
+                echo "FAIL: Actual failed tests do not match expected."
+                exit 1
+            fi
+        else
+            echo "Error: sssd-test.log not found"
+            exit 1
+        fi
+    # ----- NGINX -----
+    elif [ "$TEST_SUITE" = "nginx" ]; then
+        if [ -f "nginx-test.log" ]; then
+            # Check if the test result shows FAIL
+            if grep -q "Result: FAIL" nginx-test.log; then
+                echo "PASS: nginx tests failed as expected with force fail enabled"
+                exit 0
+            else
+                echo "FAIL: nginx tests unexpectedly succeeded with force fail enabled"
+                exit 1
+            fi
+        else
+            echo "Error: nginx-test.log not found"
+            exit 1
+        fi
+    # ----- STUNNEL -----
+    elif [ "$TEST_SUITE" = "stunnel" ]; then
+        if [ -f "$GITHUB_WORKSPACE/tests/stunnel-test.log" ]; then
+            # Check for expected error patterns
+            if grep -q "failed: 41" "$GITHUB_WORKSPACE/tests/stunnel-test.log"; then
+                echo "PASS: stunnel tests failed as expected with force fail enabled"
+                exit 0
+            else
+                echo "FAIL: stunnel tests unexpectedly succeeded with force fail enabled"
+                exit 1
+            fi
+        else
+            echo "Error: stunnel-test.log not found"
+            exit 1
+        fi
     else
-        # --- generic force-fail logic for other suites ---
         if [ $TEST_RESULT -eq 0 ]; then
-            echo "Test unexpectedly succeeded with force fail enabled"
+            echo "$TEST_SUITE tests unexpectedly succeeded with force fail enabled"
             exit 1 # failure was not seen when expected
         else
-            echo "Test failed as expected with force fail enabled"
+            echo "$TEST_SUITE tests failed as expected with force fail enabled"
             exit 0 # expected failure occurred
         fi
     fi

--- a/.github/workflows/curl.yml
+++ b/.github/workflows/curl.yml
@@ -20,6 +20,7 @@ jobs:
     strategy:
       matrix:
         wolfssl_ref: [ 'master', 'v5.7.4-stable' ]
+        openssl_ref: [ 'openssl-3.2.0' ]
     steps:
       - name: Checkout wolfProvider
         uses: actions/checkout@v4
@@ -49,7 +50,7 @@ jobs:
             openssl-source
             openssl-install
 
-          key: ossl-depends
+          key: ossl-depends-${{ matrix.openssl_ref }}
 
       # If not yet built this version, build it now
       - name: Build wolfProvider
@@ -73,7 +74,11 @@ jobs:
       matrix:
         curl_ref: [ 'master', 'curl-8_4_0' ]
         wolfssl_ref: [ 'master', 'v5.7.4-stable' ]
+        openssl_ref: [ 'openssl-3.2.0' ]
         force_fail: ['WOLFPROV_FORCE_FAIL=1', '']
+        exclude:
+          - curl_ref: 'master'
+            force_fail: 'WOLFPROV_FORCE_FAIL=1'
     steps:
       - name: Checkout wolfProvider
         uses: actions/checkout@v4
@@ -86,7 +91,7 @@ jobs:
             openssl-source
             openssl-install
 
-          key: ossl-depends
+          key: ossl-depends-${{ matrix.openssl_ref }}
           fail-on-cache-miss: true
 
       - name: Retrieving wolfSSL/wolfProvider from cache

--- a/.github/workflows/grpc.yml
+++ b/.github/workflows/grpc.yml
@@ -20,6 +20,7 @@ jobs:
     strategy:
       matrix:
         wolfssl_ref: [ 'master', 'v5.7.4-stable' ]
+        openssl_ref: [ 'openssl-3.2.0' ]
     steps:
       - name: Checkout wolfProvider
         uses: actions/checkout@v4
@@ -49,7 +50,7 @@ jobs:
             openssl-source
             openssl-install
 
-          key: ossl-depends
+          key: ossl-depends-${{ matrix.openssl_ref }}
           fail-on-cache-miss: false
 
       # If not yet built this version, build it now
@@ -74,7 +75,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - ref: v1.60.0
+          - grpc_ref: [ 'master', 'v1.60.0' ]
             tests: >-
               bad_ssl_alpn_test bad_ssl_cert_test client_ssl_test
               crl_ssl_transport_security_test server_ssl_test
@@ -82,7 +83,14 @@ jobs:
               test_core_security_ssl_credentials_test test_cpp_end2end_ssl_credentials_test
               h2_ssl_cert_test h2_ssl_session_reuse_test
         wolfssl_ref: [ 'master', 'v5.7.4-stable' ]
+        openssl_ref: [ 'openssl-3.2.0' ]
+        exclude:
+          - grpc_ref: 'master'
+            force_fail: 'WOLFPROV_FORCE_FAIL=1'
     steps:
+      - name: Checkout wolfProvider
+        uses: actions/checkout@v4
+
       - name: Confirm IPv4 and IPv6 support
         run: |
           ip addr list lo | grep 'inet '
@@ -96,7 +104,7 @@ jobs:
             openssl-source
             openssl-install
 
-          key: ossl-depends
+          key: ossl-depends-${{ matrix.openssl_ref }}
           fail-on-cache-miss: false
 
       - name: Retrieving wolfSSL/wolfProvider from cache
@@ -127,7 +135,7 @@ jobs:
         with:
           repository: grpc/grpc
           path: grpc
-          ref: ${{ matrix.ref }}
+          ref: ${{ matrix.grpc_ref }}
 
       - name: Build grpc with wolfProvider
         working-directory: ./grpc

--- a/.github/workflows/ipmitool.yml
+++ b/.github/workflows/ipmitool.yml
@@ -20,6 +20,7 @@ jobs:
     strategy:
       matrix:
         wolfssl_ref: [ 'master', 'v5.7.4-stable' ]
+        openssl_ref: [ 'openssl-3.2.0' ]
     steps:
       - name: Checkout wolfProvider
         uses: actions/checkout@v4
@@ -49,7 +50,7 @@ jobs:
             openssl-source
             openssl-install
 
-          key: ossl-depends
+          key: ossl-depends-${{ matrix.openssl_ref }}
           fail-on-cache-miss: false
 
       # If not yet built this version, build it now
@@ -73,8 +74,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        git_ref: [ c3939dac2c060651361fc71516806f9ab8c38901 ]
+        ipmitool_ref: [ 'master', 'c3939dac2c060651361fc71516806f9ab8c38901' ]
         wolfssl_ref: [ 'master', 'v5.7.4-stable' ]
+        openssl_ref: [ 'openssl-3.2.0' ]
+        exclude:
+          - ipmitool_ref: 'master'
+            force_fail: 'WOLFPROV_FORCE_FAIL=1'
     steps:
       - name: Retrieving OpenSSL from cache
         uses: actions/cache/restore@v4
@@ -84,7 +89,7 @@ jobs:
             openssl-source
             openssl-install
 
-          key: ossl-depends
+          key: ossl-depends-${{ matrix.openssl_ref }}
           fail-on-cache-miss: false
 
       - name: Retrieving wolfSSL/wolfProvider from cache
@@ -110,9 +115,8 @@ jobs:
         uses: wolfSSL/actions-build-autotools-project@v1
         with:
           repository: ipmitool/ipmitool
-          ref: ${{ matrix.git_ref }}
+          ref: ${{ matrix.ipmitool_ref }}
           path: ipmitool
-          configure: --with-openssl=$GITHUB_WORKSPACE/openssl-install
           check: false
 
       - name: Confirm built with OpenSSL and test with wolfProvider

--- a/.github/workflows/multi-compiler.yml
+++ b/.github/workflows/multi-compiler.yml
@@ -111,4 +111,3 @@ jobs:
           if [ -f config.log ]; then
             cat config.log
           fi
-

--- a/.github/workflows/nginx.yml
+++ b/.github/workflows/nginx.yml
@@ -20,6 +20,7 @@ jobs:
     strategy:
       matrix:
         wolfssl_ref: [ 'master', 'v5.7.4-stable' ]
+        openssl_ref: [ 'openssl-3.2.0' ]
     steps:
       - name: Checkout wolfProvider
         uses: actions/checkout@v4
@@ -49,7 +50,7 @@ jobs:
             openssl-source
             openssl-install
 
-          key: ossl-depends
+          key: ossl-depends-${{ matrix.openssl_ref }}
 
       # If not yet built this version, build it now
       - name: Build wolfProvider
@@ -73,7 +74,15 @@ jobs:
       matrix:
         nginx_ref: [ 'master', 'release-1.27.4' ]
         wolfssl_ref: [ 'master', 'v5.7.4-stable' ]
+        openssl_ref: [ 'openssl-3.2.0' ]
+        force_fail: [ 'WOLFPROV_FORCE_FAIL=1', '']
+        exclude:
+          - nginx_ref: 'master'
+            force_fail: 'WOLFPROV_FORCE_FAIL=1'
     steps:
+      - name: Checkout wolfProvider
+        uses: actions/checkout@v4
+
       - name: Retrieving OpenSSL from cache
         uses: actions/cache/restore@v4
         id: openssl-cache
@@ -82,7 +91,7 @@ jobs:
             openssl-source
             openssl-install
 
-          key: ossl-depends
+          key: ossl-depends-${{ matrix.openssl_ref }}
           fail-on-cache-miss: true
 
       - name: Retrieving wolfSSL/wolfProvider from cache
@@ -125,7 +134,13 @@ jobs:
       - name: Run nginx-tests with wolfProvider
         working-directory: nginx-tests
         run: |
+          # Set environment variables
           export LD_LIBRARY_PATH=$GITHUB_WORKSPACE/wolfssl-install/lib:$GITHUB_WORKSPACE/openssl-install/lib64
           export OPENSSL_CONF=$GITHUB_WORKSPACE/provider.conf
           export OPENSSL_MODULES=$GITHUB_WORKSPACE/wolfprov-install/lib
-          TEST_NGINX_VERBOSE=y TEST_NGINX_CATLOG=y TEST_NGINX_BINARY=../nginx/objs/nginx prove -v .
+          export ${{ matrix.force_fail }}
+
+          # Run tests and save result
+          TEST_NGINX_VERBOSE=y TEST_NGINX_CATLOG=y TEST_NGINX_BINARY=../nginx/objs/nginx prove -v . 2>&1 | tee nginx-test.log || true
+          TEST_RESULT=$?
+          $GITHUB_WORKSPACE/.github/scripts/check-workflow-result.sh $TEST_RESULT ${{ matrix.force_fail }} nginx

--- a/.github/workflows/openldap.yml
+++ b/.github/workflows/openldap.yml
@@ -20,6 +20,7 @@ jobs:
     strategy:
       matrix:
         wolfssl_ref: [ 'master', 'v5.7.4-stable' ]
+        openssl_ref: [ 'openssl-3.2.0' ]
     steps:
       - name: Checkout wolfProvider
         uses: actions/checkout@v4
@@ -49,7 +50,7 @@ jobs:
             openssl-source
             openssl-install
 
-          key: ossl-depends
+          key: ossl-depends-${{ matrix.openssl_ref }}
           fail-on-cache-miss: false
 
       # If not yet built this version, build it now
@@ -73,13 +74,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          # List of releases to test
-          - osp_ref: 2.5.13
-            git_ref: OPENLDAP_REL_ENG_2_5_13
-          - osp_ref: 2.6.7
-            git_ref: OPENLDAP_REL_ENG_2_6_7
+        openldap_ref: [ 'master', 'OPENLDAP_REL_ENG_2_5_13', 'OPENLDAP_REL_ENG_2_6_7' ]
         wolfssl_ref: [ 'master', 'v5.7.4-stable' ]
+        openssl_ref: [ 'openssl-3.2.0' ]
     steps:
       - name: Retrieving OpenSSL from cache
         uses: actions/cache/restore@v4
@@ -89,7 +86,7 @@ jobs:
             openssl-source
             openssl-install
 
-          key: ossl-depends
+          key: ossl-depends-${{ matrix.openssl_ref }}
           fail-on-cache-miss: false
 
       - name: Retrieving wolfSSL/wolfProvider from cache
@@ -115,7 +112,7 @@ jobs:
         with:
           repository: openldap/openldap
           path: openldap
-          ref: ${{ matrix.git_ref }}
+          ref: ${{ matrix.openldap_ref }}
 
       - name: Build and test OpenLDAP with wolfProvider
         working-directory: openldap

--- a/.github/workflows/openvpn.yml
+++ b/.github/workflows/openvpn.yml
@@ -20,6 +20,7 @@ jobs:
     strategy:
       matrix:
         wolfssl_ref: [ 'master', 'v5.7.4-stable' ]
+        openssl_ref: [ 'openssl-3.2.0' ]
     steps:
       - name: Checkout wolfProvider
         uses: actions/checkout@v4
@@ -49,7 +50,7 @@ jobs:
             openssl-source
             openssl-install
 
-          key: ossl-depends
+          key: ossl-depends-${{ matrix.openssl_ref }}
 
       # If not yet built this version, build it now
       - name: Build wolfProvider
@@ -71,9 +72,17 @@ jobs:
     timeout-minutes: 20
     strategy:
       matrix:
-        openvpn_ref: [ 'master' ]
+        openvpn_ref: [ 'master', 'v2.6.7' ]
         wolfssl_ref: [ 'master', 'v5.7.4-stable' ]
+        openssl_ref: [ 'openssl-3.2.0' ]
+        force_fail: ['WOLFPROV_FORCE_FAIL=1', '']
+        exclude:
+          - openvpn_ref: 'master'
+            force_fail: 'WOLFPROV_FORCE_FAIL=1'
     steps:
+      - name: Checkout wolfProvider
+        uses: actions/checkout@v4
+
       - name: Retrieving OpenSSL from cache
         uses: actions/cache/restore@v4
         id: openssl-cache
@@ -82,7 +91,7 @@ jobs:
             openssl-source
             openssl-install
 
-          key: ossl-depends
+          key: ossl-depends-${{ matrix.openssl_ref }}
           fail-on-cache-miss: true
 
       - name: Retrieving wolfSSL/wolfProvider from cache
@@ -117,7 +126,13 @@ jobs:
       - name: Test OpenVPN with wolfProvider
         working-directory: openvpn
         run: |
+          # Set environment variables
           export LD_LIBRARY_PATH=$GITHUB_WORKSPACE/wolfssl-install/lib:$GITHUB_WORKSPACE/openssl-install/lib64
           export OPENSSL_CONF=$GITHUB_WORKSPACE/provider.conf
           export OPENSSL_MODULES=$GITHUB_WORKSPACE/wolfprov-install/lib
-          make check
+          export ${{ matrix.force_fail }}
+
+          # Run tests and save result
+          make check 2>&1 | tee openvpn-test.log || true
+          TEST_RESULT=$?
+          $GITHUB_WORKSPACE/.github/scripts/check-workflow-result.sh $TEST_RESULT ${{ matrix.force_fail }} openvpn

--- a/.github/workflows/simple.yml
+++ b/.github/workflows/simple.yml
@@ -24,6 +24,7 @@ jobs:
           - 'OPENSSL_TAG=master'
           - 'WOLFSSL_TAG=master'
           - 'OPENSSL_TAG=master WOLFSSL_TAG=master'
+        openssl_ref: [ 'openssl-3.2.0' ]
         force_fail: ['WOLFPROV_FORCE_FAIL=1', '']
 
     steps:
@@ -55,7 +56,7 @@ jobs:
             openssl-source
             openssl-install
 
-          key: ossl-depends
+          key: ossl-depends-${{ matrix.openssl_ref }}
 
       # If not yet built this version, build it now
       - name: Build wolfProvider

--- a/.github/workflows/socat.yml
+++ b/.github/workflows/socat.yml
@@ -20,6 +20,7 @@ jobs:
     strategy:
       matrix:
         wolfssl_ref: [ 'master', 'v5.7.4-stable' ]
+        openssl_ref: [ 'openssl-3.2.0' ]
     steps:
       - name: Checkout wolfProvider
         uses: actions/checkout@v4
@@ -49,7 +50,7 @@ jobs:
             openssl-source
             openssl-install
 
-          key: ossl-depends
+          key: ossl-depends-${{ matrix.openssl_ref }}
 
       # If not yet built this version, build it now
       - name: Build wolfProvider
@@ -72,6 +73,7 @@ jobs:
     strategy:
       matrix:
         wolfssl_ref: [ 'master', 'v5.7.4-stable' ]
+        openssl_ref: [ 'openssl-3.2.0' ]
     steps:
       - name: Retrieving OpenSSL from cache
         uses: actions/cache/restore@v4
@@ -81,7 +83,7 @@ jobs:
             openssl-source
             openssl-install
 
-          key: ossl-depends
+          key: ossl-depends-${{ matrix.openssl_ref }}
           fail-on-cache-miss: true
 
       - name: Retrieving wolfSSL/wolfProvider from cache

--- a/.github/workflows/sssd.yml
+++ b/.github/workflows/sssd.yml
@@ -23,13 +23,47 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sssd_ref: [ 2.9.1 ]
+        sssd_ref: [ 'master', '2.9.1' ]
         wolfssl_ref: [ 'master', 'v5.7.4-stable' ]
+        openssl_ref: [ 'openssl-3.2.0' ]
+        force_fail: ['WOLFPROV_FORCE_FAIL=1', '']
+        exclude:
+          - sssd_ref: 'master'
+            force_fail: 'WOLFPROV_FORCE_FAIL=1'
     steps:
       - name: Checkout wolfProvider
         uses: actions/checkout@v4
 
+      # Check if this version of wolfssl/wolfprovider has already been built,
+      # mark to cache these items on post if we do end up building
+      - name: Checking wolfSSL/wolfProvider in cache
+        uses: actions/cache@v4
+        id: wolfprov-cache
+        with:
+          path: |
+            wolfssl-source
+            wolfssl-install
+            wolfprov-install
+            provider.conf
+
+          key: wolfprov-${{ matrix.wolfssl_ref }}-${{ github.sha }}
+          lookup-only: true
+
+      # If wolfssl/wolfprovider have not yet been built, pull ossl from cache
+      - name: Checking OpenSSL in cache
+        if: steps.wolfprov-${{ matrix.wolfssl_ref }}-cache.hit != 'true'
+        uses: actions/cache@v4
+        id: openssl-cache
+        with:
+          path: |
+            openssl-source
+            openssl-install
+
+          key: ossl-depends-${{ matrix.openssl_ref }}
+
+      # If not yet built this version, build it now
       - name: Build wolfProvider
+        if: steps.wolfprov-${{ matrix.wolfssl_ref }}-cache.hit != 'true'
         run: |
           WOLFSSL_TAG=${{ matrix.wolfssl_ref }} ./scripts/build-wolfprovider.sh
 
@@ -39,7 +73,7 @@ jobs:
           export DEBIAN_FRONTEND=noninteractive
           apt-get update
           apt-get install -y build-essential autoconf libldb-dev \
-          libldb2 python3-ldb bc
+          libldb2 python3-ldb bc libcap-dev libutf8proc-dev
 
       - name: Setup env
         run: |
@@ -49,13 +83,29 @@ jobs:
           ln -s samba-4.0/ldb_module.h /usr/include/ldb_module.h
           ln -s samba-4.0/ldb_version.h /usr/include/ldb_version.h
 
-      - name: Build sssd with wolfProvider
-        uses: wolfSSL/actions-build-autotools-project@v1
-        with:
-          repository: SSSD/sssd
-          ref: ${{ matrix.sssd_ref }}
-          path: sssd
-          configure: >-
-            --without-samba --disable-cifs-idmap-plugin
-            --without-nfsv4-idmapd-plugin --with-oidc-child=no
-          check: true
+      - name: Build and test sssd with wolfProvider
+        run: |
+          # Clone SSSD
+          git clone https://github.com/SSSD/sssd.git
+          cd sssd
+          git checkout ${{ matrix.sssd_ref }}
+
+          # Configure and build SSSD with wolfProvider
+          autoreconf -ivf
+          ./configure --without-samba --disable-cifs-idmap-plugin \
+          --without-nfsv4-idmapd-plugin --with-oidc-child=no
+          make -j
+
+      - name: Run tests
+        working-directory: sssd
+        run: |
+          # Set environment variables
+          export LD_LIBRARY_PATH=$GITHUB_WORKSPACE/wolfssl-install/lib:$GITHUB_WORKSPACE/openssl-install/lib64
+          export OPENSSL_CONF=$GITHUB_WORKSPACE/provider.conf
+          export OPENSSL_MODULES=$GITHUB_WORKSPACE/wolfprov-install/lib
+          export ${{ matrix.force_fail }}
+
+          # Run tests and save result
+          make check 2>&1 | tee sssd-test.log || true
+          TEST_RESULT=$?
+          $GITHUB_WORKSPACE/.github/scripts/check-workflow-result.sh $TEST_RESULT ${{ matrix.force_fail }} sssd

--- a/.github/workflows/stunnel.yml
+++ b/.github/workflows/stunnel.yml
@@ -20,6 +20,7 @@ jobs:
     strategy:
       matrix:
         wolfssl_ref: [ 'master', 'v5.7.4-stable' ]
+        openssl_ref: [ 'openssl-3.3.0' ]
     steps:
       - name: Checkout wolfProvider
         uses: actions/checkout@v4
@@ -49,13 +50,13 @@ jobs:
             openssl-source
             openssl-install
 
-          key: ossl-depends
+          key: ossl-depends-${{ matrix.openssl_ref }}
 
       # If not yet built this version, build it now
       - name: Build wolfProvider
         if: steps.wolfprov-${{ matrix.wolfssl_ref }}-cache.hit != 'true'
         run: |
-          WOLFSSL_TAG=${{ matrix.wolfssl_ref }} ./scripts/build-wolfprovider.sh
+          OPENSSL_TAG=${{ matrix.openssl_ref }} WOLFSSL_TAG=${{ matrix.wolfssl_ref }} ./scripts/build-wolfprovider.sh
 
       - name: Print errors
         if: ${{ failure() }}
@@ -71,9 +72,17 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        stunnel_ref: [ 5.67 ]
+        stunnel_ref: [ 'master', 'stunnel-5.67' ]
         wolfssl_ref: [ 'master', 'v5.7.4-stable' ]
+        openssl_ref: [ 'openssl-3.3.0' ]
+        force_fail: ['WOLFPROV_FORCE_FAIL=1', '']
+        exclude:
+          - stunnel_ref: 'master'
+            force_fail: 'WOLFPROV_FORCE_FAIL=1'
     steps:
+      - name: Checkout wolfProvider
+        uses: actions/checkout@v4
+
       - name: Retrieving OpenSSL from cache
         uses: actions/cache/restore@v4
         id: openssl-cache
@@ -82,7 +91,7 @@ jobs:
             openssl-source
             openssl-install
 
-          key: ossl-depends
+          key: ossl-depends-${{ matrix.openssl_ref }}
           fail-on-cache-miss: true
 
       - name: Retrieving wolfSSL/wolfProvider from cache
@@ -105,23 +114,39 @@ jobs:
           libtool pkg-config libwrap0-dev autoconf-archive \
           autotools-dev m4
 
-      - name: Build stunnel
-        uses: wolfSSL/actions-build-autotools-project@v1
+      - name: Checkout OSP
+        uses: actions/checkout@v4
         with:
-          repository: mtrojnar/stunnel
-          ref: stunnel-${{ matrix.stunnel_ref }}
-          path: stunnel
-          configure: --with-ssl=$GITHUB_WORKSPACE/openssl-install/
-          check: true
+          repository: wolfssl/osp
+          path: osp
+
+      - name: Build Stunnel
+        run: |
+          git clone https://github.com/mtrojnar/stunnel.git
+          cd stunnel
+          git checkout ${{ matrix.stunnel_ref }}
+          if [ ${{ matrix.force_fail }} != '' ]; then
+            patch -p1 < $GITHUB_WORKSPACE/osp/wolfProvider/stunnel/stunnel-WPFF-5.67-wolfprov.patch
+          fi
+          autoreconf -ivf
+          ./configure --with-ssl=$GITHUB_WORKSPACE/openssl-install/
+          make -j
 
       - name: Verify stunnel with wolfProvider
         working-directory: ./stunnel
         run: |
-          # Setup environment for wolfProvider
+          # Setup environment variables
           export LD_LIBRARY_PATH=$GITHUB_WORKSPACE/wolfssl-install/lib:$GITHUB_WORKSPACE/openssl-install/lib64
           export OPENSSL_CONF=$GITHUB_WORKSPACE/provider.conf
           export OPENSSL_MODULES=$GITHUB_WORKSPACE/wolfprov-install/lib
+          export ${{ matrix.force_fail }}
 
           # Verify stunnel
           ldd src/stunnel | grep -E '(libssl|libcrypto)'
           ./src/stunnel -version
+
+          # Run tests and capture output
+          mkdir -p $GITHUB_WORKSPACE/tests
+          make check 2>&1 | tee $GITHUB_WORKSPACE/tests/stunnel-test.log || true
+          TEST_RESULT=$?
+          $GITHUB_WORKSPACE/.github/scripts/check-workflow-result.sh $TEST_RESULT ${{ matrix.force_fail }} stunnel


### PR DESCRIPTION
# Description

- Adds support for WPFF matrix refs for `sssd.yml`, `nginx.yml`, `openvpn.yml`, `curl.yml`, `simple.yml`, and `stunnel.yml`
- Updated `check-workflow-result.sh` to pass in sssd, stunnel, nginx, curl, and openvpn as test_suite
- Injects the WPFF right before we do make check and preserves original workflow functionality. 
- Expanded `sssd.yml` test so we can inject the WPFF ref after we make and before make check
- use `ossl-depends-${{ matrix.openssl_ref }}` so we can supply different openssl refs without breaking all the other builds when caching and retrieving. 
- Only test master with default build if WPFF we just neg test stable version 