### PR TITLE
Only restore ed key clamping if key was imported

### DIFF
--- a/src/wp_ecx_kmgmt.c
+++ b/src/wp_ecx_kmgmt.c
@@ -168,6 +168,8 @@ struct wp_Ecx {
     unsigned int hasPub:1;
     /** Private key available. */
     unsigned int hasPriv:1;
+    /* Private key was imported and has been clamped */
+    unsigned int clamped:1;
 };
 
 /**
@@ -877,6 +879,7 @@ static int wp_ecx_import(wp_Ecx* ecx, int selection, const OSSL_PARAM params[])
             if (ok) {
                 ecx->hasPriv = 1;
                 ecx->hasPub = 1;
+                ecx->clamped = 1;
             }
         }
     }
@@ -1020,8 +1023,10 @@ static int wp_ecx_export_keypair(wp_Ecx* ecx, OSSL_PARAM* params, int* pIdx,
         outLen = ecx->data->len;
         rc = (*ecx->data->exportPriv)((void*)&ecx->key, data + *idx, &outLen);
         if (ok) {
-            data[*idx + 0         ] = ecx->unclamped[0];
-            data[*idx + outLen - 1] = ecx->unclamped[1];
+            if (ecx->clamped) {
+                data[*idx + 0         ] = ecx->unclamped[0];
+                data[*idx + outLen - 1] = ecx->unclamped[1];
+            }
             wp_param_set_octet_string_ptr(&params[i++],
                 OSSL_PKEY_PARAM_PRIV_KEY, data + *idx, outLen);
         }


### PR DESCRIPTION
Libssh2 generates and then exports a curve25519 private key. If we generated the key, we are incorrectly clamping the private key with zero values on export. Fix to only clamp if key was imported. 