### PR TITLE
Fix AES handling to accept NULL/0 input

### DIFF
--- a/src/wp_aes_block.c
+++ b/src/wp_aes_block.c
@@ -693,7 +693,9 @@ static int wp_aes_block_cipher(wp_AesBlockCtx* ctx, unsigned char* out,
     if (ok && (outSize < inLen)) {
         ok = 0;
     }
-    if (ok && !wp_aes_block_doit(ctx, out, in, inLen)) {
+    /* NULL in, NULL out, 0 len is OK */
+    if (ok && (out != NULL && in != NULL && inLen != 0) &&
+            !wp_aes_block_doit(ctx, out, in, inLen)) {
         ok = 0;
     }
     if (ok) {

--- a/src/wp_aes_stream.c
+++ b/src/wp_aes_stream.c
@@ -477,7 +477,9 @@ static int wp_aes_stream_cipher(wp_AesStreamCtx* ctx, unsigned char* out,
     if (ok && (outSize < inLen)) {
         ok = 0;
     }
-    if (ok && (!wp_aes_stream_doit(ctx, out, in, inLen))) {
+    /* NULL in, NULL out, 0 len is OK */
+    if (ok && (in != NULL && out != NULL && inLen != 0) &&
+              (!wp_aes_stream_doit(ctx, out, in, inLen))) {
         ok = 0;
     }
 

--- a/test/unit.c
+++ b/test/unit.c
@@ -129,6 +129,7 @@ TEST_CASE test_case[] = {
     TEST_DECL(test_aes192_cfb_stream, NULL),
     TEST_DECL(test_aes256_cfb_stream, NULL),
 #endif
+    TEST_DECL(test_cipher_null_zero, NULL),
 #ifdef WP_HAVE_AESGCM
     TEST_DECL(test_aes128_gcm, NULL),
     TEST_DECL(test_aes192_gcm, NULL),

--- a/test/unit.h
+++ b/test/unit.h
@@ -174,6 +174,8 @@ int test_aes256_cfb_stream(void *data);
 
 #endif
 
+int test_cipher_null_zero(void *data);
+
 #ifdef WP_HAVE_AESGCM
 
 int test_aes128_gcm(void *data);


### PR DESCRIPTION
Fix block and stream handling for AES to accept NULL in, NULL out, 0 length cipher calls. Test case derived from libssh2 flows.