### PR TITLE
Fix wolfprovider ECC get priv key handling

### DIFF
--- a/src/wp_ecc_kmgmt.c
+++ b/src/wp_ecc_kmgmt.c
@@ -818,7 +818,7 @@ static int wp_ecc_get_params(wp_Ecc* ecc, OSSL_PARAM params[])
 #else
             &(ecc->key.k),
 #endif
-            1))) {
+            ecc->hasPriv))) {
         ok = 0;
     }
     /* Private key. */


### PR DESCRIPTION
Fix wolfprovider ECC handling to appropriately fail when attempting to get private key value from a public key. This flow is used in bind9. 