### PR TITLE
openssh.yml - Github CI Workflow

### DIFF
--- a/.github/scripts/check-workflow-result.sh
+++ b/.github/scripts/check-workflow-result.sh
@@ -212,6 +212,21 @@ if [ "$WOLFPROV_FORCE_FAIL" = "WOLFPROV_FORCE_FAIL=1" ]; then
             echo "Error: stunnel-test.log not found"
             exit 1
         fi
+    # ----- OPENSSH -----
+    elif [ "$TEST_SUITE" = "openssh" ]; then
+        if [ -f "openssh-test.log" ]; then
+            # Check for expected PRNGD socket error and exit code 255
+            if grep -q "Couldn't connect to PRNGD socket" openssh-test.log && grep -q "Error 255" openssh-test.log; then
+                echo "PASS: OpenSSH tests failed as expected with PRNGD socket error"
+                exit 0
+            else
+                echo "FAIL: OpenSSH tests did not fail as expected"
+                exit 1
+            fi
+        else
+            echo "Error: openssh-test.log not found"
+            exit 1
+        fi
     else
         if [ $TEST_RESULT -eq 0 ]; then
             echo "$TEST_SUITE tests unexpectedly succeeded with force fail enabled"

--- a/.github/workflows/openssh.yml
+++ b/.github/workflows/openssh.yml
@@ -19,8 +19,8 @@ jobs:
     timeout-minutes: 20
     strategy:
       matrix:
-        wolfssl_ref: [ 'master', 'v5.7.4-stable' ]
-        openssl_ref: [ 'openssl-3.2.0' ]
+        wolfssl_ref: [ 'master', 'v5.8.0-stable' ]
+        openssl_ref: [ 'openssl-3.5.0' ]
     steps:
       - name: Checkout wolfProvider
         uses: actions/checkout@v4
@@ -56,7 +56,7 @@ jobs:
       - name: Build wolfProvider
         if: steps.wolfprov-${{ matrix.wolfssl_ref }}-cache.hit != 'true'
         run: |
-          WOLFSSL_TAG=${{ matrix.wolfssl_ref }} ./scripts/build-wolfprovider.sh
+          OPENSSL_TAG=${{ matrix.openssl_ref }} WOLFSSL_TAG=${{ matrix.wolfssl_ref }} ./scripts/build-wolfprovider.sh
 
       - name: Print errors
         if: ${{ failure() }}
@@ -72,8 +72,8 @@ jobs:
     timeout-minutes: 20
     strategy:
       matrix:
-        wolfssl_ref: [ 'master', 'v5.7.4-stable' ]
-        openssl_ref: [ 'openssl-3.2.0' ]
+        wolfssl_ref: [ 'master', 'v5.8.0-stable' ]
+        openssl_ref: [ 'openssl-3.5.0' ]
         openssh_ref: [ 'master', 'V_10_0_P2', 'V_9_9_P1' ]
         force_fail: [ 'WOLFPROV_FORCE_FAIL=1', '' ]
         exclude:

--- a/.github/workflows/openssh.yml
+++ b/.github/workflows/openssh.yml
@@ -1,0 +1,149 @@
+name: openssh Tests
+
+# START OF COMMON SECTION
+on:
+  push:
+    branches: [ 'master', 'main', 'release/**' ]
+  pull_request:
+    branches: [ '*' ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+# END OF COMMON SECTION
+
+jobs:
+  build_wolfprovider:
+    name: Build wolfProvider
+    runs-on: ubuntu-22.04
+    timeout-minutes: 20
+    strategy:
+      matrix:
+        wolfssl_ref: [ 'master', 'v5.7.4-stable' ]
+        openssl_ref: [ 'openssl-3.2.0' ]
+    steps:
+      - name: Checkout wolfProvider
+        uses: actions/checkout@v4
+
+      # Check if this version of wolfssl/wolfprovider has already been built,
+      # mark to cache these items on post if we do end up building
+      - name: Checking wolfSSL/wolfProvider in cache
+        uses: actions/cache@v4
+        id: wolfprov-cache
+        with:
+          path: |
+            wolfssl-source
+            wolfssl-install
+            wolfprov-install
+            provider.conf
+
+          key: wolfprov-${{ matrix.wolfssl_ref }}-${{ github.sha }}
+          lookup-only: true
+
+      # If wolfssl/wolfprovider have not yet been built, pull ossl from cache
+      - name: Checking OpenSSL in cache
+        if: steps.wolfprov-${{ matrix.wolfssl_ref }}-cache.hit != 'true'
+        uses: actions/cache@v4
+        id: openssl-cache
+        with:
+          path: |
+            openssl-source
+            openssl-install
+
+          key: ossl-depends-${{ matrix.openssl_ref }}
+
+      # If not yet built this version, build it now
+      - name: Build wolfProvider
+        if: steps.wolfprov-${{ matrix.wolfssl_ref }}-cache.hit != 'true'
+        run: |
+          WOLFSSL_TAG=${{ matrix.wolfssl_ref }} ./scripts/build-wolfprovider.sh
+
+      - name: Print errors
+        if: ${{ failure() }}
+        run: |
+          if [ -f test-suite.log ] ; then
+            cat test-suite.log
+          fi
+
+  test_openssh:
+    runs-on: ubuntu-22.04
+    needs: build_wolfprovider
+    # This should be a safe limit for the tests to run.
+    timeout-minutes: 20
+    strategy:
+      matrix:
+        wolfssl_ref: [ 'master', 'v5.7.4-stable' ]
+        openssl_ref: [ 'openssl-3.2.0' ]
+        openssh_ref: [ 'master', 'V_10_0_P2', 'V_9_9_P1' ]
+        force_fail: [ 'WOLFPROV_FORCE_FAIL=1', '' ]
+        exclude:
+          - openssh_ref: 'master'
+            force_fail: 'WOLFPROV_FORCE_FAIL=1'
+    steps:
+      - name: Checkout wolfProvider
+        uses: actions/checkout@v4
+
+      - name: Retrieving OpenSSL from cache
+        uses: actions/cache/restore@v4
+        id: openssl-cache
+        with:
+          path: |
+            openssl-source
+            openssl-install
+
+          key: ossl-depends-${{ matrix.openssl_ref }}
+          fail-on-cache-miss: true
+
+      - name: Retrieving wolfSSL/wolfProvider from cache
+        uses: actions/cache/restore@v4
+        id: wolfprov-cache
+        with:
+          path: |
+            wolfssl-source
+            wolfssl-install
+            wolfprov-install
+            provider.conf
+
+          key: wolfprov-${{ matrix.wolfssl_ref }}-${{ github.sha }}
+          fail-on-cache-miss: true
+
+      - name: Checkout OSP
+        uses: actions/checkout@v4
+        with:
+          repository: wolfssl/osp
+          path: osp
+
+      - name: Checkout openssh
+        uses: actions/checkout@v4
+        with:
+          repository: openssh/openssh-portable
+          path: openssh-portable
+          ref: ${{ matrix.openssh_ref }}
+
+      - name: Build and Test openssh-portable
+        working-directory: openssh-portable
+        run: |
+          # Set environment variables
+          export LD_LIBRARY_PATH=$GITHUB_WORKSPACE/wolfssl-install/lib:$GITHUB_WORKSPACE/openssl-install/lib64
+          export OPENSSL_CONF=$GITHUB_WORKSPACE/provider.conf
+          export OPENSSL_MODULES=$GITHUB_WORKSPACE/wolfprov-install/lib
+
+          # Apply the patch for the correct version of OpenSSH
+          if [ "${{ matrix.openssh_ref }}" != "master" ]; then
+            patch -p1 < $GITHUB_WORKSPACE/osp/wolfProvider/openssh/openssh-${{ matrix.openssh_ref }}-wolfprov.patch
+          else
+            # for master we need to supply the latest release version
+            patch -p1 < $GITHUB_WORKSPACE/osp/wolfProvider/openssh/openssh-V_10_0_P2-wolfprov.patch
+          fi
+
+          autoreconf -ivf
+          ./configure --with-ssl-dir=$GITHUB_WORKSPACE/openssl-install \
+                     --with-rpath=-Wl,-rpath=$GITHUB_WORKSPACE/openssl-install/lib64 \
+                     --with-prngd-socket=/tmp/prngd
+          make -j
+
+          # Run all the tests except (t-exec) as it takes too long
+          export ${{ matrix.force_fail }}
+          make file-tests interop-tests extra-tests unit 2>&1 | tee openssh-test.log || true
+          TEST_RESULT=$?
+          $GITHUB_WORKSPACE/.github/scripts/check-workflow-result.sh $TEST_RESULT ${{ matrix.force_fail }} openssh


### PR DESCRIPTION
# Description

This PR adds a new GitHub Actions workflow to build and test `wolfProvider` with OpenSSH.
It builds against multiple versions of wolfSSL, OpenSSL, and OpenSSH using a matrix strategy with caching to speed up CI.

* Tests `wolfProvider` with `openssh-portable` (V\_9\_9, V\_10\_0\_P2, master)
* Supports failure injection via `WOLFPROV_FORCE_FAIL=1`
* Skips long-running `t-exec` tests for efficiency
* Tests with newest ossl `openssl-3.5.0` and `v5.8.0-stable`