### PR TITLE
Update Github CI version refs to latest `openssl-3.5.0` and `5.8.0-stable`

### DIFF
--- a/.github/workflows/curl.yml
+++ b/.github/workflows/curl.yml
@@ -19,8 +19,8 @@ jobs:
     timeout-minutes: 20
     strategy:
       matrix:
-        wolfssl_ref: [ 'master', 'v5.7.4-stable' ]
-        openssl_ref: [ 'openssl-3.2.0' ]
+        wolfssl_ref: [ 'master', 'v5.8.0-stable' ]
+        openssl_ref: [ 'openssl-3.5.0' ]
     steps:
       - name: Checkout wolfProvider
         uses: actions/checkout@v4
@@ -56,7 +56,7 @@ jobs:
       - name: Build wolfProvider
         if: steps.wolfprov-${{ matrix.wolfssl_ref }}-cache.hit != 'true'
         run: |
-          WOLFSSL_TAG=${{ matrix.wolfssl_ref }} ./scripts/build-wolfprovider.sh
+          OPENSSL_TAG=${{ matrix.openssl_ref }} WOLFSSL_TAG=${{ matrix.wolfssl_ref }} ./scripts/build-wolfprovider.sh
 
       - name: Print errors
         if: ${{ failure() }}
@@ -73,8 +73,8 @@ jobs:
     strategy:
       matrix:
         curl_ref: [ 'master', 'curl-8_4_0' ]
-        wolfssl_ref: [ 'master', 'v5.7.4-stable' ]
-        openssl_ref: [ 'openssl-3.2.0' ]
+        wolfssl_ref: [ 'master', 'v5.8.0-stable' ]
+        openssl_ref: [ 'openssl-3.5.0' ]
         force_fail: ['WOLFPROV_FORCE_FAIL=1', '']
         exclude:
           - curl_ref: 'master'

--- a/.github/workflows/grpc.yml
+++ b/.github/workflows/grpc.yml
@@ -19,8 +19,8 @@ jobs:
     timeout-minutes: 20
     strategy:
       matrix:
-        wolfssl_ref: [ 'master', 'v5.7.4-stable' ]
-        openssl_ref: [ 'openssl-3.2.0' ]
+        wolfssl_ref: [ 'master', 'v5.8.0-stable' ]
+        openssl_ref: [ 'openssl-3.5.0' ]
     steps:
       - name: Checkout wolfProvider
         uses: actions/checkout@v4
@@ -57,7 +57,7 @@ jobs:
       - name: Build wolfProvider
         if: steps.wolfprov-cache.outputs.cache-hit != 'true'
         run: |
-          WOLFSSL_TAG=${{ matrix.wolfssl_ref }} ./scripts/build-wolfprovider.sh
+          OPENSSL_TAG=${{ matrix.openssl_ref }} WOLFSSL_TAG=${{ matrix.wolfssl_ref }} ./scripts/build-wolfprovider.sh
 
       - name: Print errors
         if: ${{ failure() }}
@@ -82,8 +82,8 @@ jobs:
               ssl_transport_security_test ssl_transport_security_utils_test
               test_core_security_ssl_credentials_test test_cpp_end2end_ssl_credentials_test
               h2_ssl_cert_test h2_ssl_session_reuse_test
-        wolfssl_ref: [ 'master', 'v5.7.4-stable' ]
-        openssl_ref: [ 'openssl-3.2.0' ]
+        wolfssl_ref: [ 'master', 'v5.8.0-stable' ]
+        openssl_ref: [ 'openssl-3.5.0' ]
     steps:
       - name: Checkout wolfProvider
         uses: actions/checkout@v4

--- a/.github/workflows/ipmitool.yml
+++ b/.github/workflows/ipmitool.yml
@@ -19,8 +19,8 @@ jobs:
     timeout-minutes: 20
     strategy:
       matrix:
-        wolfssl_ref: [ 'master', 'v5.7.4-stable' ]
-        openssl_ref: [ 'openssl-3.2.0' ]
+        wolfssl_ref: [ 'master', 'v5.8.0-stable' ]
+        openssl_ref: [ 'openssl-3.5.0' ]
     steps:
       - name: Checkout wolfProvider
         uses: actions/checkout@v4
@@ -57,7 +57,7 @@ jobs:
       - name: Build wolfProvider
         if: steps.wolfprov-cache.outputs.cache-hit != 'true'
         run: |
-          WOLFSSL_TAG=${{ matrix.wolfssl_ref }} ./scripts/build-wolfprovider.sh
+          OPENSSL_TAG=${{ matrix.openssl_ref }} WOLFSSL_TAG=${{ matrix.wolfssl_ref }} ./scripts/build-wolfprovider.sh
 
       - name: Print errors
         if: ${{ failure() }}
@@ -75,8 +75,8 @@ jobs:
       fail-fast: false
       matrix:
         ipmitool_ref: [ 'master', 'c3939dac2c060651361fc71516806f9ab8c38901' ]
-        wolfssl_ref: [ 'master', 'v5.7.4-stable' ]
-        openssl_ref: [ 'openssl-3.2.0' ]
+        wolfssl_ref: [ 'master', 'v5.8.0-stable' ]
+        openssl_ref: [ 'openssl-3.5.0' ]
     steps:
       - name: Retrieving OpenSSL from cache
         uses: actions/cache/restore@v4

--- a/.github/workflows/nginx.yml
+++ b/.github/workflows/nginx.yml
@@ -19,8 +19,8 @@ jobs:
     timeout-minutes: 20
     strategy:
       matrix:
-        wolfssl_ref: [ 'master', 'v5.7.4-stable' ]
-        openssl_ref: [ 'openssl-3.2.0' ]
+        wolfssl_ref: [ 'master', 'v5.8.0-stable' ]
+        openssl_ref: [ 'openssl-3.5.0' ]
     steps:
       - name: Checkout wolfProvider
         uses: actions/checkout@v4
@@ -56,7 +56,7 @@ jobs:
       - name: Build wolfProvider
         if: steps.wolfprov-${{ matrix.wolfssl_ref }}-cache.hit != 'true'
         run: |
-          WOLFSSL_TAG=${{ matrix.wolfssl_ref }} ./scripts/build-wolfprovider.sh
+          OPENSSL_TAG=${{ matrix.openssl_ref }} WOLFSSL_TAG=${{ matrix.wolfssl_ref }} ./scripts/build-wolfprovider.sh
 
       - name: Print errors
         if: ${{ failure() }}
@@ -73,8 +73,8 @@ jobs:
     strategy:
       matrix:
         nginx_ref: [ 'master', 'release-1.27.4' ]
-        wolfssl_ref: [ 'master', 'v5.7.4-stable' ]
-        openssl_ref: [ 'openssl-3.2.0' ]
+        wolfssl_ref: [ 'master', 'v5.8.0-stable' ]
+        openssl_ref: [ 'openssl-3.5.0' ]
         force_fail: [ 'WOLFPROV_FORCE_FAIL=1', '']
         exclude:
           - nginx_ref: 'master'

--- a/.github/workflows/openldap.yml
+++ b/.github/workflows/openldap.yml
@@ -19,8 +19,8 @@ jobs:
     timeout-minutes: 20
     strategy:
       matrix:
-        wolfssl_ref: [ 'master', 'v5.7.4-stable' ]
-        openssl_ref: [ 'openssl-3.2.0' ]
+        wolfssl_ref: [ 'master', 'v5.8.0-stable' ]
+        openssl_ref: [ 'openssl-3.5.0' ]
     steps:
       - name: Checkout wolfProvider
         uses: actions/checkout@v4
@@ -57,7 +57,7 @@ jobs:
       - name: Build wolfProvider
         if: steps.wolfprov-cache.outputs.cache-hit != 'true'
         run: |
-          WOLFSSL_TAG=${{ matrix.wolfssl_ref }} ./scripts/build-wolfprovider.sh
+          OPENSSL_TAG=${{ matrix.openssl_ref }} WOLFSSL_TAG=${{ matrix.wolfssl_ref }} ./scripts/build-wolfprovider.sh
 
       - name: Print errors
         if: ${{ failure() }}
@@ -75,8 +75,8 @@ jobs:
       fail-fast: false
       matrix:
         openldap_ref: [ 'master', 'OPENLDAP_REL_ENG_2_5_13', 'OPENLDAP_REL_ENG_2_6_7' ]
-        wolfssl_ref: [ 'master', 'v5.7.4-stable' ]
-        openssl_ref: [ 'openssl-3.2.0' ]
+        wolfssl_ref: [ 'master', 'v5.8.0-stable' ]
+        openssl_ref: [ 'openssl-3.5.0' ]
     steps:
       - name: Retrieving OpenSSL from cache
         uses: actions/cache/restore@v4

--- a/.github/workflows/openvpn.yml
+++ b/.github/workflows/openvpn.yml
@@ -19,8 +19,8 @@ jobs:
     timeout-minutes: 20
     strategy:
       matrix:
-        wolfssl_ref: [ 'master', 'v5.7.4-stable' ]
-        openssl_ref: [ 'openssl-3.2.0' ]
+        wolfssl_ref: [ 'master', 'v5.8.0-stable' ]
+        openssl_ref: [ 'openssl-3.5.0' ]
     steps:
       - name: Checkout wolfProvider
         uses: actions/checkout@v4
@@ -56,7 +56,7 @@ jobs:
       - name: Build wolfProvider
         if: steps.wolfprov-${{ matrix.wolfssl_ref }}-cache.hit != 'true'
         run: |
-          WOLFSSL_TAG=${{ matrix.wolfssl_ref }} ./scripts/build-wolfprovider.sh
+          OPENSSL_TAG=${{ matrix.openssl_ref }} WOLFSSL_TAG=${{ matrix.wolfssl_ref }} ./scripts/build-wolfprovider.sh
 
       - name: Print errors
         if: ${{ failure() }}
@@ -73,8 +73,8 @@ jobs:
     strategy:
       matrix:
         openvpn_ref: [ 'master', 'v2.6.7' ]
-        wolfssl_ref: [ 'master', 'v5.7.4-stable' ]
-        openssl_ref: [ 'openssl-3.2.0' ]
+        wolfssl_ref: [ 'master', 'v5.8.0-stable' ]
+        openssl_ref: [ 'openssl-3.5.0' ]
         force_fail: ['WOLFPROV_FORCE_FAIL=1', '']
         exclude:
           - openvpn_ref: 'master'

--- a/.github/workflows/simple.yml
+++ b/.github/workflows/simple.yml
@@ -24,7 +24,7 @@ jobs:
           - 'OPENSSL_TAG=master'
           - 'WOLFSSL_TAG=master'
           - 'OPENSSL_TAG=master WOLFSSL_TAG=master'
-        openssl_ref: [ 'openssl-3.2.0' ]
+        openssl_ref: [ 'openssl-3.5.0' ]
         force_fail: ['WOLFPROV_FORCE_FAIL=1', '']
 
     steps:

--- a/.github/workflows/socat.yml
+++ b/.github/workflows/socat.yml
@@ -19,8 +19,8 @@ jobs:
     timeout-minutes: 20
     strategy:
       matrix:
-        wolfssl_ref: [ 'master', 'v5.7.4-stable' ]
-        openssl_ref: [ 'openssl-3.2.0' ]
+        wolfssl_ref: [ 'master', 'v5.8.0-stable' ]
+        openssl_ref: [ 'openssl-3.5.0' ]
     steps:
       - name: Checkout wolfProvider
         uses: actions/checkout@v4
@@ -56,7 +56,7 @@ jobs:
       - name: Build wolfProvider
         if: steps.wolfprov-${{ matrix.wolfssl_ref }}-cache.hit != 'true'
         run: |
-          WOLFSSL_TAG=${{ matrix.wolfssl_ref }} ./scripts/build-wolfprovider.sh
+          OPENSSL_TAG=${{ matrix.openssl_ref }} WOLFSSL_TAG=${{ matrix.wolfssl_ref }} ./scripts/build-wolfprovider.sh
 
       - name: Print errors
         if: ${{ failure() }}
@@ -72,8 +72,8 @@ jobs:
     timeout-minutes: 20
     strategy:
       matrix:
-        wolfssl_ref: [ 'master', 'v5.7.4-stable' ]
-        openssl_ref: [ 'openssl-3.2.0' ]
+        wolfssl_ref: [ 'master', 'v5.8.0-stable' ]
+        openssl_ref: [ 'openssl-3.5.0' ]
     steps:
       - name: Retrieving OpenSSL from cache
         uses: actions/cache/restore@v4

--- a/.github/workflows/sssd.yml
+++ b/.github/workflows/sssd.yml
@@ -24,8 +24,8 @@ jobs:
       fail-fast: false
       matrix:
         sssd_ref: [ 'master', '2.9.1' ]
-        wolfssl_ref: [ 'master', 'v5.7.4-stable' ]
-        openssl_ref: [ 'openssl-3.2.0' ]
+        wolfssl_ref: [ 'master', 'v5.8.0-stable' ]
+        openssl_ref: [ 'openssl-3.5.0' ]
         force_fail: ['WOLFPROV_FORCE_FAIL=1', '']
         exclude:
           - sssd_ref: 'master'
@@ -65,7 +65,7 @@ jobs:
       - name: Build wolfProvider
         if: steps.wolfprov-${{ matrix.wolfssl_ref }}-cache.hit != 'true'
         run: |
-          WOLFSSL_TAG=${{ matrix.wolfssl_ref }} ./scripts/build-wolfprovider.sh
+          OPENSSL_TAG=${{ matrix.openssl_ref }} WOLFSSL_TAG=${{ matrix.wolfssl_ref }} ./scripts/build-wolfprovider.sh
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/stunnel.yml
+++ b/.github/workflows/stunnel.yml
@@ -19,8 +19,8 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        wolfssl_ref: [ 'master', 'v5.7.4-stable' ]
-        openssl_ref: [ 'openssl-3.3.0' ]
+        wolfssl_ref: [ 'master', 'v5.8.0-stable' ]
+        openssl_ref: [ 'openssl-3.5.0' ]
     steps:
       - name: Checkout wolfProvider
         uses: actions/checkout@v4
@@ -73,8 +73,8 @@ jobs:
     strategy:
       matrix:
         stunnel_ref: [ 'master', 'stunnel-5.67' ]
-        wolfssl_ref: [ 'master', 'v5.7.4-stable' ]
-        openssl_ref: [ 'openssl-3.3.0' ]
+        wolfssl_ref: [ 'master', 'v5.8.0-stable' ]
+        openssl_ref: [ 'openssl-3.5.0' ]
         force_fail: ['WOLFPROV_FORCE_FAIL=1', '']
         exclude:
           - stunnel_ref: 'master'


### PR DESCRIPTION
# Description

* Added matrix strategy to all GitHub CI workflows for `wolfssl_ref` and `openssl_ref`
* Enables testing against wolfSSL (`v5.8.0-stable`) and OpenSSL (`openssl-3.5.0`) versions