### PR TITLE
Add Cache Key for Openssl Version Cache / Restore

### DIFF
--- a/.github/workflows/curl.yml
+++ b/.github/workflows/curl.yml
@@ -50,7 +50,8 @@ jobs:
             openssl-source
             openssl-install
 
-          key: ossl-depends-${{ matrix.openssl_ref }}
+          key: ossl-depends-${{ matrix.openssl_ref }}-${{ github.sha }}
+          lookup-only: true
 
       # If not yet built this version, build it now
       - name: Build wolfProvider
@@ -91,7 +92,7 @@ jobs:
             openssl-source
             openssl-install
 
-          key: ossl-depends-${{ matrix.openssl_ref }}
+          key: ossl-depends-${{ matrix.openssl_ref }}-${{ github.sha }}
           fail-on-cache-miss: true
 
       - name: Retrieving wolfSSL/wolfProvider from cache

--- a/.github/workflows/grpc.yml
+++ b/.github/workflows/grpc.yml
@@ -50,8 +50,8 @@ jobs:
             openssl-source
             openssl-install
 
-          key: ossl-depends-${{ matrix.openssl_ref }}
-          fail-on-cache-miss: false
+          key: ossl-depends-${{ matrix.openssl_ref }}-${{ github.sha }}
+          lookup-only: true
 
       # If not yet built this version, build it now
       - name: Build wolfProvider
@@ -101,8 +101,8 @@ jobs:
             openssl-source
             openssl-install
 
-          key: ossl-depends-${{ matrix.openssl_ref }}
-          fail-on-cache-miss: false
+          key: ossl-depends-${{ matrix.openssl_ref }}-${{ github.sha }}
+          fail-on-cache-miss: true
 
       - name: Retrieving wolfSSL/wolfProvider from cache
         uses: actions/cache/restore@v4

--- a/.github/workflows/ipmitool.yml
+++ b/.github/workflows/ipmitool.yml
@@ -50,8 +50,8 @@ jobs:
             openssl-source
             openssl-install
 
-          key: ossl-depends-${{ matrix.openssl_ref }}
-          fail-on-cache-miss: false
+          key: ossl-depends-${{ matrix.openssl_ref }}-${{ github.sha }}
+          lookup-only: true
 
       # If not yet built this version, build it now
       - name: Build wolfProvider
@@ -86,8 +86,8 @@ jobs:
             openssl-source
             openssl-install
 
-          key: ossl-depends-${{ matrix.openssl_ref }}
-          fail-on-cache-miss: false
+          key: ossl-depends-${{ matrix.openssl_ref }}-${{ github.sha }}
+          fail-on-cache-miss: true
 
       - name: Retrieving wolfSSL/wolfProvider from cache
         uses: actions/cache/restore@v4

--- a/.github/workflows/nginx.yml
+++ b/.github/workflows/nginx.yml
@@ -50,7 +50,8 @@ jobs:
             openssl-source
             openssl-install
 
-          key: ossl-depends-${{ matrix.openssl_ref }}
+          key: ossl-depends-${{ matrix.openssl_ref }}-${{ github.sha }}
+          lookup-only: true
 
       # If not yet built this version, build it now
       - name: Build wolfProvider
@@ -91,7 +92,7 @@ jobs:
             openssl-source
             openssl-install
 
-          key: ossl-depends-${{ matrix.openssl_ref }}
+          key: ossl-depends-${{ matrix.openssl_ref }}-${{ github.sha }}
           fail-on-cache-miss: true
 
       - name: Retrieving wolfSSL/wolfProvider from cache

--- a/.github/workflows/openldap.yml
+++ b/.github/workflows/openldap.yml
@@ -50,8 +50,8 @@ jobs:
             openssl-source
             openssl-install
 
-          key: ossl-depends-${{ matrix.openssl_ref }}
-          fail-on-cache-miss: false
+          key: ossl-depends-${{ matrix.openssl_ref }}-${{ github.sha }}
+          lookup-only: true
 
       # If not yet built this version, build it now
       - name: Build wolfProvider
@@ -86,8 +86,8 @@ jobs:
             openssl-source
             openssl-install
 
-          key: ossl-depends-${{ matrix.openssl_ref }}
-          fail-on-cache-miss: false
+          key: ossl-depends-${{ matrix.openssl_ref }}-${{ github.sha }}
+          fail-on-cache-miss: true
 
       - name: Retrieving wolfSSL/wolfProvider from cache
         uses: actions/cache/restore@v4

--- a/.github/workflows/openssh.yml
+++ b/.github/workflows/openssh.yml
@@ -50,7 +50,8 @@ jobs:
             openssl-source
             openssl-install
 
-          key: ossl-depends-${{ matrix.openssl_ref }}
+          key: ossl-depends-${{ matrix.openssl_ref }}-${{ github.sha }}
+          lookup-only: true
 
       # If not yet built this version, build it now
       - name: Build wolfProvider
@@ -91,7 +92,7 @@ jobs:
             openssl-source
             openssl-install
 
-          key: ossl-depends-${{ matrix.openssl_ref }}
+          key: ossl-depends-${{ matrix.openssl_ref }}-${{ github.sha }}
           fail-on-cache-miss: true
 
       - name: Retrieving wolfSSL/wolfProvider from cache

--- a/.github/workflows/openvpn.yml
+++ b/.github/workflows/openvpn.yml
@@ -50,7 +50,8 @@ jobs:
             openssl-source
             openssl-install
 
-          key: ossl-depends-${{ matrix.openssl_ref }}
+          key: ossl-depends-${{ matrix.openssl_ref }}-${{ github.sha }}
+          lookup-only: true
 
       # If not yet built this version, build it now
       - name: Build wolfProvider
@@ -91,7 +92,7 @@ jobs:
             openssl-source
             openssl-install
 
-          key: ossl-depends-${{ matrix.openssl_ref }}
+          key: ossl-depends-${{ matrix.openssl_ref }}-${{ github.sha }}
           fail-on-cache-miss: true
 
       - name: Retrieving wolfSSL/wolfProvider from cache

--- a/.github/workflows/simple.yml
+++ b/.github/workflows/simple.yml
@@ -56,7 +56,8 @@ jobs:
             openssl-source
             openssl-install
 
-          key: ossl-depends-${{ matrix.openssl_ref }}
+          key: ossl-depends-${{ matrix.openssl_ref }}-${{ github.sha }}
+          lookup-only: true
 
       # If not yet built this version, build it now
       - name: Build wolfProvider

--- a/.github/workflows/socat.yml
+++ b/.github/workflows/socat.yml
@@ -50,7 +50,8 @@ jobs:
             openssl-source
             openssl-install
 
-          key: ossl-depends-${{ matrix.openssl_ref }}
+          key: ossl-depends-${{ matrix.openssl_ref }}-${{ github.sha }}
+          lookup-only: true
 
       # If not yet built this version, build it now
       - name: Build wolfProvider
@@ -83,7 +84,7 @@ jobs:
             openssl-source
             openssl-install
 
-          key: ossl-depends-${{ matrix.openssl_ref }}
+          key: ossl-depends-${{ matrix.openssl_ref }}-${{ github.sha }}
           fail-on-cache-miss: true
 
       - name: Retrieving wolfSSL/wolfProvider from cache

--- a/.github/workflows/sssd.yml
+++ b/.github/workflows/sssd.yml
@@ -59,7 +59,8 @@ jobs:
             openssl-source
             openssl-install
 
-          key: ossl-depends-${{ matrix.openssl_ref }}
+          key: ossl-depends-${{ matrix.openssl_ref }}-${{ github.sha }}
+          lookup-only: true
 
       # If not yet built this version, build it now
       - name: Build wolfProvider

--- a/.github/workflows/stunnel.yml
+++ b/.github/workflows/stunnel.yml
@@ -50,7 +50,8 @@ jobs:
             openssl-source
             openssl-install
 
-          key: ossl-depends-${{ matrix.openssl_ref }}
+          key: ossl-depends-${{ matrix.openssl_ref }}-${{ github.sha }}
+          lookup-only: true
 
       # If not yet built this version, build it now
       - name: Build wolfProvider
@@ -91,7 +92,7 @@ jobs:
             openssl-source
             openssl-install
 
-          key: ossl-depends-${{ matrix.openssl_ref }}
+          key: ossl-depends-${{ matrix.openssl_ref }}-${{ github.sha }}
           fail-on-cache-miss: true
 
       - name: Retrieving wolfSSL/wolfProvider from cache


### PR DESCRIPTION
# Description

- Fixes version inconsistency error with openssl 
- Uses a cache key like wolfssl so we get a clean build every time we invoke a test workkflow