### PR TITLE
Fix Refs in `simple.yml`

### DIFF
--- a/.github/workflows/simple.yml
+++ b/.github/workflows/simple.yml
@@ -19,12 +19,8 @@ jobs:
     timeout-minutes: 20
     strategy:
       matrix:
-        build_ref:
-          - ''
-          - 'OPENSSL_TAG=master'
-          - 'WOLFSSL_TAG=master'
-          - 'OPENSSL_TAG=master WOLFSSL_TAG=master'
-        openssl_ref: [ 'openssl-3.5.0' ]
+        openssl_ref: [ 'master', 'openssl-3.5.0' ]
+        wolfssl_ref: [ 'master', 'v5.8.0-stable' ]
         force_fail: ['WOLFPROV_FORCE_FAIL=1', '']
 
     steps:
@@ -43,12 +39,12 @@ jobs:
             wolfprov-install
             provider.conf
 
-          key: wolfprov-${{ matrix.build_ref }}-${{ github.sha }}
+          key: wolfprov-${{ matrix.wolfssl_ref }}-${{ github.sha }}
           lookup-only: true
 
       # If wolfssl/wolfprovider have not yet been built, pull ossl from cache
       - name: Checking OpenSSL in cache
-        if: steps.wolfprov-${{ matrix.build_ref }}-cache.hit != 'true'
+        if: steps.wolfprov-${{ matrix.wolfssl_ref }}-cache.hit != 'true'
         uses: actions/cache@v4
         id: openssl-cache
         with:
@@ -61,9 +57,9 @@ jobs:
 
       # If not yet built this version, build it now
       - name: Build wolfProvider
-        if: steps.wolfprov-${{ matrix.build_ref }}-cache.hit != 'true'
+        if: steps.wolfprov-${{ matrix.wolfssl_ref }}-cache.hit != 'true'
         run: |
-          ${{ matrix.build_ref.openssl }} ${{ matrix.build_ref.wolfssl }} ./scripts/build-wolfprovider.sh
+          OPENSSL_TAG=${{ matrix.openssl_ref }} WOLFSSL_TAG=${{ matrix.wolfssl_ref }} ./scripts/build-wolfprovider.sh
 
       - name: Run simple tests
         run: |


### PR DESCRIPTION
# Description

Updates the refs so that we actually test all possibilities. Caught that it was only testing default (3.2.0 and 5.7.4) when we should be testing both masters. Added refs for latest version as well. 