### PR TITLE
Remove override for CI test status

### DIFF
--- a/.github/workflows/curl.yml
+++ b/.github/workflows/curl.yml
@@ -143,6 +143,6 @@ jobs:
 
           # Run tests and save output to test.log
           mkdir -p tests
-          make -j$(nproc) test-ci 2>&1 | tee tests/test.log || true
+          make -j$(nproc) test-ci 2>&1 | tee tests/test.log
           TEST_RESULT=$?
           $GITHUB_WORKSPACE/.github/scripts/check-workflow-result.sh $TEST_RESULT ${{ matrix.force_fail }} curl

--- a/.github/workflows/net-snmp.yml
+++ b/.github/workflows/net-snmp.yml
@@ -134,6 +134,6 @@ jobs:
           export ${{ matrix.force_fail }}
           autoconf --version | grep -P '2\.\d\d' -o > dist/autoconf-version
           mkdir -p tests
-          make -j test TESTOPTS="-e agentxperl" | tee tests/test.log || true
+          make -j test TESTOPTS="-e agentxperl" | tee tests/test.log
           TEST_RESULT=$?
           $GITHUB_WORKSPACE/.github/scripts/check-workflow-result.sh $TEST_RESULT ${{ matrix.force_fail }} net-snmp

--- a/.github/workflows/nginx.yml
+++ b/.github/workflows/nginx.yml
@@ -142,6 +142,6 @@ jobs:
           export ${{ matrix.force_fail }}
 
           # Run tests and save result
-          TEST_NGINX_VERBOSE=y TEST_NGINX_CATLOG=y TEST_NGINX_BINARY=../nginx/objs/nginx prove -v . 2>&1 | tee nginx-test.log || true
+          TEST_NGINX_VERBOSE=y TEST_NGINX_CATLOG=y TEST_NGINX_BINARY=../nginx/objs/nginx prove -v . 2>&1 | tee nginx-test.log
           TEST_RESULT=$?
           $GITHUB_WORKSPACE/.github/scripts/check-workflow-result.sh $TEST_RESULT ${{ matrix.force_fail }} nginx

--- a/.github/workflows/openssh.yml
+++ b/.github/workflows/openssh.yml
@@ -145,6 +145,6 @@ jobs:
 
           # Run all the tests except (t-exec) as it takes too long
           export ${{ matrix.force_fail }}
-          make file-tests interop-tests extra-tests unit 2>&1 | tee openssh-test.log || true
+          make file-tests interop-tests extra-tests unit 2>&1 | tee openssh-test.log
           TEST_RESULT=$?
           $GITHUB_WORKSPACE/.github/scripts/check-workflow-result.sh $TEST_RESULT ${{ matrix.force_fail }} openssh

--- a/.github/workflows/openvpn.yml
+++ b/.github/workflows/openvpn.yml
@@ -134,6 +134,6 @@ jobs:
           export ${{ matrix.force_fail }}
 
           # Run tests and save result
-          make check 2>&1 | tee openvpn-test.log || true
+          make check 2>&1 | tee openvpn-test.log
           TEST_RESULT=$?
           $GITHUB_WORKSPACE/.github/scripts/check-workflow-result.sh $TEST_RESULT ${{ matrix.force_fail }} openvpn

--- a/.github/workflows/sssd.yml
+++ b/.github/workflows/sssd.yml
@@ -107,6 +107,6 @@ jobs:
           export ${{ matrix.force_fail }}
 
           # Run tests and save result
-          make check 2>&1 | tee sssd-test.log || true
+          make check 2>&1 | tee sssd-test.log
           TEST_RESULT=$?
           $GITHUB_WORKSPACE/.github/scripts/check-workflow-result.sh $TEST_RESULT ${{ matrix.force_fail }} sssd

--- a/.github/workflows/stunnel.yml
+++ b/.github/workflows/stunnel.yml
@@ -148,6 +148,6 @@ jobs:
 
           # Run tests and capture output
           mkdir -p $GITHUB_WORKSPACE/tests
-          make check 2>&1 | tee $GITHUB_WORKSPACE/tests/stunnel-test.log || true
+          make check 2>&1 | tee $GITHUB_WORKSPACE/tests/stunnel-test.log
           TEST_RESULT=$?
           $GITHUB_WORKSPACE/.github/scripts/check-workflow-result.sh $TEST_RESULT ${{ matrix.force_fail }} stunnel


### PR DESCRIPTION
Remove `|| true` at the end of several commands in github workflows which may override the output of test runs.