### PR TITLE
Allow wolfProvider to be built with debug when wolfSSL is not built with debug

### DIFF
--- a/src/wp_wolfprov.c
+++ b/src/wp_wolfprov.c
@@ -1191,8 +1191,17 @@ int wolfssl_provider_init(const OSSL_CORE_HANDLE* handle,
     OSSL_FUNC_core_get_libctx_fn* c_get_libctx = NULL;
 
 #ifdef WOLFPROV_DEBUG
-    ok = (wolfProv_Debugging_ON() == 0) && (wolfSSL_Debugging_ON() == 0);
-    wolfSSL_SetLoggingPrefix("wolfSSL");
+    ok = (wolfProv_Debugging_ON() == 0);
+    if (ok) {
+      if (wolfSSL_Debugging_ON() != 0) {
+        WOLFPROV_MSG(WP_LOG_PROVIDER,
+          "WARNING: wolfProvider built with debug but underlying wolfSSL is not!"
+          "Building wolfSSl with debug is highly recommended, proceeding...");
+      }
+      else {
+        wolfSSL_SetLoggingPrefix("wolfSSL");
+      }
+    }
 #endif
 
 #ifdef HAVE_FIPS


### PR DESCRIPTION
Many customers have had issues where they enable wolfProvider debug to investigate an issue, forget to build the underlying wolfSSL with debug, and now they always fail init. Change this from a fatal error to a warning message. 