### PR TITLE
Implement locking around signature operations

### DIFF
--- a/include/wolfprovider/alg_funcs.h
+++ b/include/wolfprovider/alg_funcs.h
@@ -182,6 +182,8 @@ int wp_rsa_up_ref(wp_Rsa* rsa);
 void wp_rsa_free(wp_Rsa* rsa);
 int wp_rsa_get_type(wp_Rsa* rsa);
 int wp_rsa_get_bits(wp_Rsa* rsa);
+int wp_rsa_lock(wp_Rsa* rsa);
+int wp_rsa_unlock(wp_Rsa* rsa);
 RsaKey* wp_rsa_get_key(wp_Rsa* rsa);
 void wp_rsa_get_pss_mds(wp_Rsa* rsa, char** mdName, char** mgfMdName);
 int wp_rsa_get_pss_salt_len(wp_Rsa* rsa);
@@ -199,6 +201,8 @@ ecc_key* wp_ecc_get_key(wp_Ecc* ecc);
 WC_RNG* wp_ecc_get_rng(wp_Ecc* ecc);
 int wp_ecc_get_size(wp_Ecc* ecc);
 int wp_ecc_check_usage(wp_Ecc* ecc);
+int wp_ecc_lock(wp_Ecc* ecc);
+int wp_ecc_unlock(wp_Ecc* ecc);
 
 /* Internal ECX types and functions. */
 typedef struct wp_Ecx wp_Ecx;
@@ -206,6 +210,8 @@ typedef struct wp_Ecx wp_Ecx;
 int wp_ecx_up_ref(wp_Ecx* ecx);
 void wp_ecx_free(wp_Ecx* ecx);
 void* wp_ecx_get_key(wp_Ecx* ecx);
+int wp_ecx_lock(wp_Ecx* ecx);
+int wp_ecx_unlock(wp_Ecx* ecx);
 
 /* Internal DH types and functions. */
 typedef struct wp_Dh wp_Dh;

--- a/src/wp_ecc_kmgmt.c
+++ b/src/wp_ecc_kmgmt.c
@@ -300,6 +300,76 @@ int wp_ecc_get_size(wp_Ecc* ecc)
 }
 
 /**
+ * Lock the ECC key mutex.
+ *
+ * This function locks the mutex associated with the ECC key object.
+ * Use wp_ecc_unlock() to unlock after operations are complete.
+ *
+ * @param [in] ecc  ECC key object.
+ * @return  1 on success.
+ * @return  0 on failure or when single-threaded build.
+ */
+int wp_ecc_lock(wp_Ecc* ecc)
+{
+#ifndef WP_SINGLE_THREADED
+    int ok = 1;
+    int rc;
+
+    if (ecc == NULL) {
+        ok = 0;
+    }
+    else {
+        rc = wc_LockMutex(&ecc->mutex);
+        if (rc < 0) {
+            ok = 0;
+        }
+    }
+
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    return ok;
+#else
+    (void)ecc;
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), 1);
+    return 1;
+#endif
+}
+
+/**
+ * Unlock the ECC key mutex.
+ *
+ * This function unlocks the mutex associated with the ECC key object.
+ * Should only be called after a successful wp_ecc_lock() call.
+ *
+ * @param [in] ecc  ECC key object.
+ * @return  1 on success.
+ * @return  0 on failure or when single-threaded build.
+ */
+int wp_ecc_unlock(wp_Ecc* ecc)
+{
+#ifndef WP_SINGLE_THREADED
+    int ok = 1;
+    int rc;
+
+    if (ecc == NULL) {
+        ok = 0;
+    }
+    else {
+        rc = wc_UnLockMutex(&ecc->mutex);
+        if (rc < 0) {
+            ok = 0;
+        }
+    }
+
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    return ok;
+#else
+    (void)ecc;
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), 1);
+    return 1;
+#endif
+}
+
+/**
  * Create a new ECC key object.
  *
  * @param [in] provCtx  Provider context.

--- a/src/wp_ecdsa_sig.c
+++ b/src/wp_ecdsa_sig.c
@@ -280,15 +280,21 @@ static int wp_ecdsa_sign(wp_EcdsaSigCtx *ctx, unsigned char *sig,
                 sigSize = *sigLen;
             }
             len = (word32)sigSize;
-            PRIVATE_KEY_UNLOCK();
-            rc = wc_ecc_sign_hash(tbs, (word32)tbsLen, sig, &len,
-                wp_ecc_get_rng(ctx->ecc), wp_ecc_get_key(ctx->ecc));
-            PRIVATE_KEY_LOCK();
-            if (rc != 0) {
+            if (wp_ecc_lock(ctx->ecc) != 1) {
                 ok = 0;
             }
-            else {
-                *sigLen = len;
+            if (ok) {
+                PRIVATE_KEY_UNLOCK();
+                rc = wc_ecc_sign_hash(tbs, (word32)tbsLen, sig, &len,
+                    wp_ecc_get_rng(ctx->ecc), wp_ecc_get_key(ctx->ecc));
+                PRIVATE_KEY_LOCK();
+                wp_ecc_unlock(ctx->ecc);
+                if (rc != 0) {
+                    ok = 0;
+                }
+                else {
+                    *sigLen = len;
+                }
             }
         }
     }

--- a/src/wp_ecx_kmgmt.c
+++ b/src/wp_ecx_kmgmt.c
@@ -244,6 +244,76 @@ void* wp_ecx_get_key(wp_Ecx* ecx)
 }
 
 /**
+ * Lock the ECX key mutex.
+ *
+ * This function locks the mutex associated with the ECX key object.
+ * Use wp_ecx_unlock() to unlock after operations are complete.
+ *
+ * @param [in] ecx  ECX key object.
+ * @return  1 on success.
+ * @return  0 on failure or when single-threaded build.
+ */
+int wp_ecx_lock(wp_Ecx* ecx)
+{
+#ifndef WP_SINGLE_THREADED
+    int ok = 1;
+    int rc;
+
+    if (ecx == NULL) {
+        ok = 0;
+    }
+    else {
+        rc = wc_LockMutex(&ecx->mutex);
+        if (rc < 0) {
+            ok = 0;
+        }
+    }
+
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    return ok;
+#else
+    (void)ecx;
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), 1);
+    return 1;
+#endif
+}
+
+/**
+ * Unlock the ECX key mutex.
+ *
+ * This function unlocks the mutex associated with the ECX key object.
+ * Should only be called after a successful wp_ecx_lock() call.
+ *
+ * @param [in] ecx  ECX key object.
+ * @return  1 on success.
+ * @return  0 on failure or when single-threaded build.
+ */
+int wp_ecx_unlock(wp_Ecx* ecx)
+{
+#ifndef WP_SINGLE_THREADED
+    int ok = 1;
+    int rc;
+
+    if (ecx == NULL) {
+        ok = 0;
+    }
+    else {
+        rc = wc_UnLockMutex(&ecx->mutex);
+        if (rc < 0) {
+            ok = 0;
+        }
+    }
+
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    return ok;
+#else
+    (void)ecx;
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), 1);
+    return 1;
+#endif
+}
+
+/**
  * Create a new ECX key object. Base function.
  *
  * @param [in] provCtx   Provider context.

--- a/src/wp_ecx_sig.c
+++ b/src/wp_ecx_sig.c
@@ -436,12 +436,18 @@ static int wp_ed25519_digest_sign(wp_EcxSigCtx *ctx, unsigned char *sig,
             }
         }
         if (ok) {
-            rc = wc_ed25519_sign_msg(tbs, (word32)tbsLen, sig, &len, ed25519);
-            if (rc != 0) {
+            if (wp_ecx_lock(ctx->ecx) != 1) {
                 ok = 0;
             }
-            else {
-                *sigLen = len;
+            if (ok) {
+                rc = wc_ed25519_sign_msg(tbs, (word32)tbsLen, sig, &len, ed25519);
+                wp_ecx_unlock(ctx->ecx);
+                if (rc != 0) {
+                    ok = 0;
+                }
+                else {
+                    *sigLen = len;
+                }
             }
         }
     }
@@ -578,13 +584,19 @@ static int wp_ed448_digest_sign(wp_EcxSigCtx *ctx, unsigned char *sig,
             }
         }
         if (ok) {
-            rc = wc_ed448_sign_msg(tbs, (word32)tbsLen, sig, &len,
-                (ed448_key*)wp_ecx_get_key(ctx->ecx), NULL, 0);
-            if (rc != 0) {
+            if (wp_ecx_lock(ctx->ecx) != 1) {
                 ok = 0;
             }
-            else {
-                *sigLen = len;
+            if (ok) {
+                rc = wc_ed448_sign_msg(tbs, (word32)tbsLen, sig, &len,
+                    (ed448_key*)wp_ecx_get_key(ctx->ecx), NULL, 0);
+                wp_ecx_unlock(ctx->ecx);
+                if (rc != 0) {
+                    ok = 0;
+                }
+                else {
+                    *sigLen = len;
+                }
             }
         }
     }

--- a/src/wp_rsa_kmgmt.c
+++ b/src/wp_rsa_kmgmt.c
@@ -331,6 +331,76 @@ int wp_rsa_get_bits(wp_Rsa* rsa)
 }
 
 /**
+ * Lock the RSA key mutex.
+ *
+ * This function locks the mutex associated with the RSA key object to ensure
+ * thread-safe access to the key data.
+ *
+ * @param [in] rsa  RSA key object.
+ * @return  1 on success.
+ * @return  0 on failure or when single-threaded build.
+ */
+int wp_rsa_lock(wp_Rsa* rsa)
+{
+#ifndef WP_SINGLE_THREADED
+    int ok = 1;
+    int rc;
+
+    if (rsa == NULL) {
+        ok = 0;
+    }
+    else {
+        rc = wc_LockMutex(&rsa->mutex);
+        if (rc < 0) {
+            ok = 0;
+        }
+    }
+
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    return ok;
+#else
+    (void)rsa;
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), 1);
+    return 1;
+#endif
+}
+
+/**
+ * Unlock the RSA key mutex.
+ *
+ * This function unlocks the mutex associated with the RSA key object.
+ * Should only be called after a successful wp_rsa_lock() call.
+ *
+ * @param [in] rsa  RSA key object.
+ * @return  1 on success.
+ * @return  0 on failure or when single-threaded build.
+ */
+int wp_rsa_unlock(wp_Rsa* rsa)
+{
+#ifndef WP_SINGLE_THREADED
+    int ok = 1;
+    int rc;
+
+    if (rsa == NULL) {
+        ok = 0;
+    }
+    else {
+        rc = wc_UnLockMutex(&rsa->mutex);
+        if (rc < 0) {
+            ok = 0;
+        }
+    }
+
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    return ok;
+#else
+    (void)rsa;
+    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), 1);
+    return 1;
+#endif
+}
+
+/**
  * Check the RSA key size is valid.
  *
  * @param [in] keySize    RSA key size in bits.


### PR DESCRIPTION
Implement locking around wolfProvider signature operations to facilitate multithreaded flows with multiple threads sharing an underlying key. Designed to fix issues presented in bind9 multithreaded use case. 