### PR TITLE
Add FIPS private lock handling to ECC key encoding

### DIFF
--- a/src/wp_ecc_kmgmt.c
+++ b/src/wp_ecc_kmgmt.c
@@ -2377,7 +2377,9 @@ static int wp_ecc_encode_pki_size(const wp_Ecc *ecc, size_t* keyLen)
     int rc;
     word32 len;
 
+    PRIVATE_KEY_UNLOCK();
     rc = wc_EccKeyToPKCS8((ecc_key*)&ecc->key, NULL, &len);
+    PRIVATE_KEY_LOCK();
     if (rc != LENGTH_ONLY_E) {
         ok = 0;
     }
@@ -2407,7 +2409,9 @@ static int wp_ecc_encode_pki(const wp_Ecc *ecc, unsigned char* keyData,
     word32 len = (word32)*keyLen;
 
     /* TODO: for older versions, curve is always included! */
+    PRIVATE_KEY_UNLOCK();
     rc = wc_EccKeyToPKCS8((ecc_key*)&ecc->key, keyData, &len);
+    PRIVATE_KEY_LOCK();
     if (rc <= 0) {
         ok = 0;
     }
@@ -2434,7 +2438,9 @@ static int wp_ecc_encode_epki_size(const wp_Ecc *ecc, size_t* keyLen)
     int rc;
     word32 len;
 
+    PRIVATE_KEY_UNLOCK();
     rc = wc_EccKeyToPKCS8((ecc_key*)&ecc->key, NULL, &len);
+    PRIVATE_KEY_LOCK();
     if (rc != LENGTH_ONLY_E) {
         ok = 0;
     }
@@ -2469,7 +2475,9 @@ static int wp_ecc_encode_epki(const wp_EccEncDecCtx* ctx, const wp_Ecc *ecc,
     word32 len = (word32)*keyLen;
 
     /* Encode key. */
+    PRIVATE_KEY_UNLOCK();
     rc = wc_EccKeyToPKCS8((ecc_key*)&ecc->key, keyData, &len);
+    PRIVATE_KEY_LOCK();
     if (rc <= 0) {
         ok = 0;
     }


### PR DESCRIPTION
Adds missing FIPS lock/unlock handling for ECC key encoding.

Fixed ZD 19702