### PR TITLE
libhashkit2 yml workflow

### DIFF
--- a/.github/workflows/libhashkit2.yml
+++ b/.github/workflows/libhashkit2.yml
@@ -1,0 +1,100 @@
+name: libhashkit2 Tests
+
+# START OF COMMON SECTION
+on:
+  push:
+    branches: [ '*' ] #'master', 'main', 'release/**' ]
+  pull_request:
+    branches: [ '*' ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+# END OF COMMON SECTION
+
+jobs:
+  build_wolfprovider:
+    uses: ./.github/workflows/build-wolfprovider.yml
+    with:
+      wolfssl_ref: ${{ matrix.wolfssl_ref }}
+      openssl_ref: ${{ matrix.openssl_ref }}
+    strategy:
+      matrix:
+        wolfssl_ref: [ 'master', 'v5.8.0-stable' ]
+        openssl_ref: [ 'openssl-3.5.0' ]
+
+  test_libhashkit2:
+    runs-on: ubuntu-22.04
+    needs: build_wolfprovider
+    # This should be a safe limit for the tests to run.
+    timeout-minutes: 20
+    strategy:
+      matrix:
+        libhashkit2_ref: [ 'v1.x', '1.1.4' ]
+        wolfssl_ref: [ 'master', 'v5.8.0-stable' ]
+        openssl_ref: [ 'openssl-3.5.0' ]
+        force_fail: [ 'WOLFPROV_FORCE_FAIL=1', '' ]
+        exclude:
+          - libhashkit2_ref: 'v1.x'
+            force_fail: 'WOLFPROV_FORCE_FAIL=1'
+    steps:
+      - name: Checkout wolfProvider
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Retrieving wolfProvider from cache
+        uses: actions/cache/restore@v4
+        id: wolfprov-cache-restore
+        with:
+          path: |
+            wolfssl-install
+            wolfprov-install
+            openssl-install/lib64
+            openssl-install/include
+            openssl-install/bin
+
+          key: wolfprov-${{ matrix.wolfssl_ref }}-${{ matrix.openssl_ref }}-${{ github.sha }}
+          fail-on-cache-miss: true
+
+      - name: Install libmemcached dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install cmake build-essential bison flex memcached libc6
+
+      - name: Download libmemcached
+        uses: actions/checkout@v4
+        with:
+          repository: awesomized/libmemcached
+          ref: ${{ matrix.libhashkit2_ref }}
+          path: libmemcached
+          fetch-depth: 1
+
+      - name: Build libmemcached
+        working-directory: libmemcached
+        run: |
+          # OPENSSL_ROOT_DIR is needed for cmake to find OpenSSL headers
+          export OPENSSL_ROOT_DIR=$GITHUB_WORKSPACE/openssl-install/include
+          # Build libmemcached with OpenSSL support
+          mkdir build
+          cd build
+          cmake -DBUILD_TESTING=ON -DCMAKE_BUILD_TYPE=Debug -DENABLE_OPENSSL_CRYPTO=ON ..
+          make
+
+      - name: Run libhashkit2 tests
+        working-directory: libmemcached/build
+        run: |
+          # Set up the environment for wolfProvider
+          source $GITHUB_WORKSPACE/scripts/env-setup
+          export ${{ matrix.force_fail }}
+
+          # Run tests
+          make test 2>&1 | tee libhashkit2-test.log
+          if grep -q "(Failed)" libhashkit2-test.log; then
+            TEST_RESULT=1
+          else
+            TEST_RESULT=0
+          fi
+          echo "TEST_RESULT = $TEST_RESULT"
+
+          $GITHUB_WORKSPACE/.github/scripts/check-workflow-result.sh $TEST_RESULT ${{ matrix.force_fail }} libhashkit2


### PR DESCRIPTION
Added wolfProvider tests for libhashkit2 which is a part of the bigger repository, libmemcached.
- libhashkit is passing all tests now as expected with updated wolfProvider
