### PR TITLE
Libfido2 workflow

### DIFF
--- a/.github/workflows/libfido2.yml
+++ b/.github/workflows/libfido2.yml
@@ -1,0 +1,90 @@
+name: libfido2 Tests
+on:
+  push:
+    branches: [ 'master', 'main', 'release/**' ]
+  pull_request:
+    branches: [ '*' ]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  build_wolfprovider:
+    uses: ./.github/workflows/build-wolfprovider.yml
+    with:
+      wolfssl_ref: ${{ matrix.wolfssl_ref }}
+      openssl_ref: ${{ matrix.openssl_ref }}
+    strategy:
+      matrix:
+        wolfssl_ref: [ 'master', 'v5.8.0-stable' ]
+        openssl_ref: [ 'openssl-3.5.0' ]
+  test_libfido2:
+    runs-on: ubuntu-22.04
+    needs: build_wolfprovider
+    timeout-minutes: 15
+    strategy:
+      matrix:
+        wolfssl_ref: [ 'master', 'v5.8.0-stable' ]
+        openssl_ref: [ 'openssl-3.5.0' ]
+        libfido2_ref: [ 'main', '1.15.0' ]
+        force_fail: [ 'WOLFPROV_FORCE_FAIL=1', '' ]
+        exclude:
+          - libfido2_ref: 'main'
+            force_fail: 'WOLFPROV_FORCE_FAIL=1'
+    steps:
+      - name: Checkout wolfProvider
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+      - name: Retrieving wolfSSL/wolfProvider from cache
+        uses: actions/cache/restore@v4
+        id: wolfprov-cache
+        with:
+          path: |
+            scripts
+            wolfssl-source
+            wolfssl-install
+            wolfprov-install
+            openssl-install
+            provider.conf
+          key: wolfprov-${{ matrix.wolfssl_ref }}-${{ matrix.openssl_ref }}-${{ github.sha }}
+          fail-on-cache-miss: true
+      - name: Install test dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential cmake pkg-config libssl-dev libudev-dev zlib1g-dev libcbor-dev libpcsclite-dev pcscd
+      - name: Checkout libfido2
+        uses: actions/checkout@v4
+        with:
+          repository: Yubico/libfido2
+          path: libfido2_repo
+          ref: ${{ matrix.libfido2_ref }}
+          fetch-depth: 1
+      - name: Build and install libfido2
+        working-directory: libfido2_repo
+        run: |
+          mkdir build
+          cd build
+          cmake -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/libfido2-install ..
+          make -j$(nproc)
+          make install
+      - name: Run libfido2 tests
+        working-directory: libfido2_repo/build
+        run: |
+          # Set up the environment for wolfProvider
+          source $GITHUB_WORKSPACE/scripts/env-setup
+          export ${{ matrix.force_fail }}
+
+          # Run tests, excluding regress_dev which requires hardware/fails in CI
+          ctest --exclude-regex "regress_dev" 2>&1 | tee libfido2-test.log
+
+          # Check test results directly in YAML
+          if grep -q "100% tests passed" libfido2-test.log; then
+            TEST_RESULT=0
+          else
+            TEST_RESULT=1
+          fi
+
+          $GITHUB_WORKSPACE/.github/scripts/check-workflow-result.sh $TEST_RESULT ${{ matrix.force_fail }} libfido2
+
+
+


### PR DESCRIPTION
Added yaml workflow for libfido2. All checks pass and it seems to work with wolfProvider as expected.

I did exclude one test, regress_dev, because it tests libfido2's ability to communicate with physical FIDO devices, which fails due to environmental factors. I don't think it will impact libfido2's core cryptographic functionality or its integration with wolfProvider as all other test pass and WOLFPROV_FORCE_FAIL=1 still causes most of the other tests to fail as it should.