### PR TITLE
Draft: Revert common caching strategy which was not working at scale

### DIFF
--- a/.github/workflows/build-wolfprovider.yml
+++ b/.github/workflows/build-wolfprovider.yml
@@ -12,140 +12,52 @@ on:
     outputs:
       cache_key:
         description: "Cache key for the build artifacts"
-        value: ${{ jobs.build_wolfprovider_common.outputs.cache_key }}
+        value: ${{ jobs.build_wolfprovider.outputs.cache_key }}
 
 jobs:
-  build_wolfprovider_common:
+  build_wolfprovider:
     name: Build wolfProvider
     runs-on: ubuntu-22.04
     timeout-minutes: 20
     outputs:
-      cache_key: wolfprov-${{ inputs.wolfssl_ref }}-${{ inputs.openssl_ref }}-${{ github.sha }}
+      cache_key: wolfprov-${{ inputs.wolfssl_ref }}-${{ github.sha }}
     steps:
+      - name: Checkout wolfProvider
+        uses: actions/checkout@v4
+
       # Check if this version of wolfssl/wolfprovider has already been built,
       # mark to cache these items on post if we do end up building
-      # On a push, the first workflow(s) will complete the build and cache it 
-      # and any delayed workflow will be able to utilize it.
-      # This is not designed to cache builds across commits.
       - name: Checking wolfSSL/wolfProvider in cache
         uses: actions/cache@v4
         id: wolfprov-cache
         with:
           path: |
-            scripts
             wolfssl-source
             wolfssl-install
             wolfprov-install
-            openssl-install
             provider.conf
 
-          key: wolfprov-${{ inputs.wolfssl_ref }}-${{ inputs.openssl_ref }}-${{ github.sha }}
+          key: wolfprov-${{ inputs.wolfssl_ref }}-${{ github.sha }}
           lookup-only: true
 
-      # if cache hit, exit the workflow
-      - name: Exit workflow if cache hit
-        if: steps.wolfprov-cache.outputs.cache-hit == 'true'
-        run: |
-          echo "Found cached build, exiting workflow"
-          exit 0
-
-      - name: Checkout wolfProvider
-        if: steps.wolfprov-cache.outputs.cache-hit != 'true'
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-
-      # Convert OpenSSL branch name to commit hash if needed
-      - name: Get OpenSSL commit hash
-        if: steps.wolfprov-cache.outputs.cache-hit != 'true'
-        id: openssl-ref
-        run: |
-          if [[ "${{ inputs.openssl_ref }}" =~ ^[0-9a-f]{40}$ ]]; then
-            echo "ref=${{ inputs.openssl_ref }}" >> $GITHUB_OUTPUT
-          else
-            sha=$(curl -s "https://api.github.com/repos/openssl/openssl/commits/${{ inputs.openssl_ref }}" | jq -r '.sha')
-            echo "ref=$sha" >> $GITHUB_OUTPUT
-            echo "OpenSSL ref ${{ inputs.openssl_ref }} is commit $sha"
-          fi
-
-      # Look for a cached version of OpenSSL
+      # If wolfssl/wolfprovider have not yet been built, pull ossl from cache
       - name: Checking OpenSSL in cache
         if: steps.wolfprov-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/restore@v4
+        uses: actions/cache@v4
         id: openssl-cache
         with:
           path: |
             openssl-source
             openssl-install
 
-          key: ossl-depends-${{ steps.openssl-ref.outputs.ref }}
-          lookup-only: false
+          key: ossl-depends-${{ inputs.openssl_ref }}-${{ github.sha }}
+          lookup-only: true
 
-      # Convert WolfSSL branch name to commit hash if needed
-      - name: Get WolfSSL commit hash
-        if: steps.wolfprov-cache.outputs.cache-hit != 'true'
-        id: wolfssl-ref
-        run: |
-          if [[ "${{ inputs.wolfssl_ref }}" =~ ^[0-9a-f]{40}$ ]]; then
-            echo "ref=${{ inputs.wolfssl_ref }}" >> $GITHUB_OUTPUT
-          else
-            sha=$(curl -s "https://api.github.com/repos/wolfssl/wolfssl/commits/${{ inputs.wolfssl_ref }}" | jq -r '.sha')
-            echo "ref=$sha" >> $GITHUB_OUTPUT
-            echo "WolfSSL ref ${{ inputs.wolfssl_ref }} is commit $sha"
-          fi
-
-      # Look for a cached version of WolfSSL
-      - name: Checking WolfSSL in cache
-        if: steps.wolfprov-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/restore@v4
-        id: wolfssl-cache
-        with:
-          path: |
-            wolfssl-source
-            wolfssl-install
-
-          key: wolfssl-depends-${{ steps.wolfssl-ref.outputs.ref }}
-          lookup-only: false
-
+      # If not yet built this version, build it now
       - name: Build wolfProvider
         if: steps.wolfprov-cache.outputs.cache-hit != 'true'
         run: |
           OPENSSL_TAG=${{ inputs.openssl_ref }} WOLFSSL_TAG=${{ inputs.wolfssl_ref }} ./scripts/build-wolfprovider.sh
-
-      # This is potentially chewing up a lot of cache space. 
-      # Could investigate reducing the size of this cache.
-      # Note that we use actions/cache/save and actions/cache/restore instead of 
-      # actions/cache to reduce the chance of a cache lock issue.
-      - name: Save wolfProvider into cache
-        if: steps.wolfprov-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
-        with: 
-          path: |
-            wolfssl-source
-            wolfssl-install
-            wolfprov-install
-            openssl-install
-            provider.conf
-          key: wolfprov-${{ inputs.wolfssl_ref }}-${{ inputs.openssl_ref }}-${{ github.sha }}
-
-      # If openssl cache miss, save it to the cache
-      - name: Save OpenSSL into cache
-        if: steps.openssl-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
-        with: 
-          path: |
-            openssl-source
-            openssl-install
-          key: ossl-depends-${{ steps.openssl-ref.outputs.ref }}
-
-      - name: Save WolfSSL into cache
-        if: steps.wolfssl-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
-        with: 
-          path: |
-            wolfssl-source
-            wolfssl-install
-          key: wolfssl-depends-${{ steps.wolfssl-ref.outputs.ref }}
 
       - name: Print errors
         if: ${{ failure() }}

--- a/.github/workflows/cjose.yml
+++ b/.github/workflows/cjose.yml
@@ -3,7 +3,7 @@ name: cjose Tests
 # START OF COMMON SECTION
 on:
   push:
-    branches: [ 'master', 'main', 'release/**' ]
+    branches: ['*'] # [ 'master', 'main', 'release/**' ]
   pull_request:
     branches: [ '*' ]
 
@@ -20,7 +20,7 @@ jobs:
       openssl_ref: ${{ matrix.openssl_ref }}
     strategy:
       matrix:
-        wolfssl_ref: [ 'master', 'v5.8.0-stable' ]
+        wolfssl_ref: [ 'v5.8.0-stable' ]
         openssl_ref: [ 'openssl-3.5.0' ]
 
   test_cjose:
@@ -31,28 +31,39 @@ jobs:
     strategy:
       matrix:
         cjose_ref: [ 'master', 'v0.6.2.1' ]
-        wolfssl_ref: [ 'master', 'v5.8.0-stable' ]
+        wolfssl_ref: [ 'v5.8.0-stable' ]
         openssl_ref: [ 'openssl-3.5.0' ]
         force_fail: [ 'WOLFPROV_FORCE_FAIL=1', '' ]
     steps:
+      # Checkout the source so we can run the check-workflow-result script
       - name: Checkout wolfProvider
         uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          sparse-checkout: |
+              .github
 
-      - name: Retrieving wolfProvider from cache
+      - name: Retrieving OpenSSL from cache
         uses: actions/cache/restore@v4
-        id: wolfprov-cache-restore
+        id: openssl-cache
         with:
           path: |
-            scripts
+            openssl-source
+            openssl-install
+
+          key: ossl-depends-${{ matrix.openssl_ref }}-${{ github.sha }}
+          fail-on-cache-miss: true
+
+      - name: Retrieving wolfSSL/wolfProvider from cache
+        uses: actions/cache/restore@v4
+        id: wolfprov-cache
+        with:
+          path: |
             wolfssl-source
             wolfssl-install
             wolfprov-install
-            openssl-install
             provider.conf
 
-          key: wolfprov-${{ matrix.wolfssl_ref }}-${{ matrix.openssl_ref }}-${{ github.sha }}
+          key: wolfprov-${{ matrix.wolfssl_ref }}-${{ github.sha }}
           fail-on-cache-miss: true
 
       - name: Install cjose dependencies
@@ -67,13 +78,12 @@ jobs:
           repository: OpenIDC/cjose
           ref: ${{ matrix.cjose_ref }}
           path: cjose
-          fetch-depth: 1
 
       - name: Build cjose
         working-directory: cjose
         run: |
           # Configure with OpenSSL
-          ./configure CFLAGS="-Wno-error=deprecated-declarations" --with-openssl=/git/wolfProvider/openssl-install
+          ./configure  CFLAGS="-Wno-error=deprecated-declarations" --with-openssl=/git/wolfProvider/openssl-install
 
           # Build cjose
           make
@@ -82,8 +92,15 @@ jobs:
         working-directory: cjose
         run: |
           # Set up the environment for wolfProvider
-          source $GITHUB_WORKSPACE/scripts/env-setup
+          export LD_LIBRARY_PATH=$GITHUB_WORKSPACE/wolfssl-install/lib:$GITHUB_WORKSPACE/openssl-install/lib64
+          export OPENSSL_CONF=$GITHUB_WORKSPACE/provider.conf
+          export OPENSSL_MODULES=$GITHUB_WORKSPACE/wolfprov-install/lib
           export ${{ matrix.force_fail }}
+          export SHELL=/bin/bash
+
+          echo "Checking OpenSSL providers:"
+          $GITHUB_WORKSPACE/openssl-install/bin/openssl list -providers | tee provider-list.log
+          grep -q libwolfprov provider-list.log || (echo "ERROR: libwolfprov not found in OpenSSL providers" && exit 1)
 
           # Run tests
           make test || true

--- a/.github/workflows/curl.yml
+++ b/.github/workflows/curl.yml
@@ -40,22 +40,29 @@ jobs:
     steps:
       - name: Checkout wolfProvider
         uses: actions/checkout@v4
+
+      - name: Retrieving OpenSSL from cache
+        uses: actions/cache/restore@v4
+        id: openssl-cache
         with:
-          fetch-depth: 1
-          
+          path: |
+            openssl-source
+            openssl-install
+
+          key: ossl-depends-${{ matrix.openssl_ref }}-${{ github.sha }}
+          fail-on-cache-miss: true
+
       - name: Retrieving wolfSSL/wolfProvider from cache
         uses: actions/cache/restore@v4
         id: wolfprov-cache
         with:
           path: |
-            scripts
             wolfssl-source
             wolfssl-install
             wolfprov-install
-            openssl-install
             provider.conf
 
-          key: wolfprov-${{ matrix.wolfssl_ref }}-${{ matrix.openssl_ref }}-${{ github.sha }}
+          key: wolfprov-${{ matrix.wolfssl_ref }}-${{ github.sha }}
           fail-on-cache-miss: true
 
       - name: Install dependencies
@@ -83,10 +90,17 @@ jobs:
       - name: Test curl with wolfProvider
         working-directory: curl
         run: |
-          # Set up the environment for wolfProvider
-          source $GITHUB_WORKSPACE/scripts/env-setup
+          # Set environment variables
+          export LD_LIBRARY_PATH=$GITHUB_WORKSPACE/wolfssl-install/lib:$GITHUB_WORKSPACE/openssl-install/lib64
+          export OPENSSL_CONF=$GITHUB_WORKSPACE/provider.conf
+          export OPENSSL_MODULES=$GITHUB_WORKSPACE/wolfprov-install/lib
+          export PKG_CONFIG_PATH=$GITHUB_WORKSPACE/openssl-install/lib64/pkgconfig
           export ${{ matrix.force_fail }}
           export CURL_REF=${{ matrix.curl_ref }}
+
+          echo "Checking OpenSSL providers:"
+          $GITHUB_WORKSPACE/openssl-install/bin/openssl list -providers | tee provider-list.log
+          grep -q libwolfprov provider-list.log || (echo "ERROR: libwolfprov not found in OpenSSL providers" && exit 1)
 
           # Run tests and save output to test.log
           mkdir -p tests

--- a/.github/workflows/grpc.yml
+++ b/.github/workflows/grpc.yml
@@ -44,22 +44,29 @@ jobs:
     steps:
       - name: Checkout wolfProvider
         uses: actions/checkout@v4
+
+      - name: Retrieving OpenSSL from cache
+        uses: actions/cache/restore@v4
+        id: openssl-cache
         with:
-          fetch-depth: 1
-          
+          path: |
+            openssl-source
+            openssl-install
+
+          key: ossl-depends-${{ matrix.openssl_ref }}-${{ github.sha }}
+          fail-on-cache-miss: true
+
       - name: Retrieving wolfSSL/wolfProvider from cache
         uses: actions/cache/restore@v4
         id: wolfprov-cache
         with:
           path: |
-            scripts
             wolfssl-source
             wolfssl-install
             wolfprov-install
-            openssl-install
             provider.conf
 
-          key: wolfprov-${{ matrix.wolfssl_ref }}-${{ matrix.openssl_ref }}-${{ github.sha }}
+          key: wolfprov-${{ matrix.wolfssl_ref }}-${{ github.sha }}
           fail-on-cache-miss: true
 
       - name: Confirm IPv4 and IPv6 support
@@ -87,9 +94,14 @@ jobs:
       - name: Build grpc with wolfProvider
         working-directory: ./grpc
         run: |
-          # Set up the environment for wolfProvider
-          source $GITHUB_WORKSPACE/scripts/env-setup
-          export ${{ matrix.force_fail }}
+          # Setup environment for wolfProviders
+          export LD_LIBRARY_PATH=$GITHUB_WORKSPACE/wolfssl-install/lib:$GITHUB_WORKSPACE/openssl-install/lib64
+          export OPENSSL_CONF=$GITHUB_WORKSPACE/provider.conf
+          export OPENSSL_MODULES=$GITHUB_WORKSPACE/wolfprov-install/lib
+
+          echo "Checking OpenSSL providers:"
+          $GITHUB_WORKSPACE/openssl-install/bin/openssl list -providers | tee provider-list.log
+          grep -q libwolfprov provider-list.log || (echo "ERROR: libwolfprov not found in OpenSSL providers" && exit 1)
 
           # Initialize submodules
           git submodule update --init

--- a/.github/workflows/iperf.yml
+++ b/.github/workflows/iperf.yml
@@ -37,22 +37,29 @@ jobs:
     steps:
       - name: Checkout wolfProvider
         uses: actions/checkout@v4
+
+      - name: Retrieving OpenSSL from cache
+        uses: actions/cache/restore@v4
+        id: openssl-cache
         with:
-          fetch-depth: 1
+          path: |
+            openssl-source
+            openssl-install
+
+          key: ossl-depends-${{ matrix.openssl_ref }}-${{ github.sha }}
+          fail-on-cache-miss: true
 
       - name: Retrieving wolfSSL/wolfProvider from cache
         uses: actions/cache/restore@v4
         id: wolfprov-cache
         with:
           path: |
-            scripts
             wolfssl-source
             wolfssl-install
             wolfprov-install
-            openssl-install
             provider.conf
 
-          key: wolfprov-${{ matrix.wolfssl_ref }}-${{ matrix.openssl_ref }}-${{ github.sha }}
+          key: wolfprov-${{ matrix.wolfssl_ref }}-${{ github.sha }}
           fail-on-cache-miss: true
 
       - name: Install dependencies
@@ -93,8 +100,11 @@ jobs:
         working-directory: iperf
         run: |
           # Set up the environment for wolfProvider
-          source $GITHUB_WORKSPACE/scripts/env-setup
+          export LD_LIBRARY_PATH=$GITHUB_WORKSPACE/wolfssl-install/lib:$GITHUB_WORKSPACE/openssl-install/lib64
+          export OPENSSL_CONF=$GITHUB_WORKSPACE/provider.conf
+          export OPENSSL_MODULES=$GITHUB_WORKSPACE/wolfprov-install/lib
           export ${{ matrix.force_fail }}
+          export SHELL=/bin/bash
 
           # Test variables for iperf
           export IPERF3_EXECUTABLE=$GITHUB_WORKSPACE/iperf/src/iperf3
@@ -105,6 +115,11 @@ jobs:
           export IPERF3_USER=mario
           export IPERF3_PASSWORD=rossi
           export KEY_DIR=$GITHUB_WORKSPACE/test-keys
+
+          # Verify OpenSSL loads wolfProvider to confirm configuration above
+          echo "Checking OpenSSL providers:"
+          $GITHUB_WORKSPACE/openssl-install/bin/openssl list -providers | tee provider-list.log
+          grep libwolfprov provider-list.log || (echo "ERROR: libwolfprov not found in OpenSSL providers" && exit 1)
 
           # Verify iperf loads OpenSSL containing wolfProvider
           ldd $IPERF3_LIB | grep -q wolfProvider

--- a/.github/workflows/ipmitool.yml
+++ b/.github/workflows/ipmitool.yml
@@ -37,22 +37,29 @@ jobs:
     steps:
       - name: Checkout wolfProvider
         uses: actions/checkout@v4
+
+      - name: Retrieving OpenSSL from cache
+        uses: actions/cache/restore@v4
+        id: openssl-cache
         with:
-          fetch-depth: 1
+          path: |
+            openssl-source
+            openssl-install
+
+          key: ossl-depends-${{ matrix.openssl_ref }}-${{ github.sha }}
+          fail-on-cache-miss: true
 
       - name: Retrieving wolfSSL/wolfProvider from cache
         uses: actions/cache/restore@v4
         id: wolfprov-cache
         with:
           path: |
-            scripts
             wolfssl-source
             wolfssl-install
             wolfprov-install
-            openssl-install
             provider.conf
 
-          key: wolfprov-${{ matrix.wolfssl_ref }}-${{ matrix.openssl_ref }}-${{ github.sha }}
+          key: wolfprov-${{ matrix.wolfssl_ref }}-${{ github.sha }}
           fail-on-cache-miss: true
 
       - name: Install dependencies
@@ -72,9 +79,14 @@ jobs:
       - name: Confirm built with OpenSSL and test with wolfProvider
         working-directory: ipmitool
         run: |
-          # Set up the environment for wolfProvider
-          source $GITHUB_WORKSPACE/scripts/env-setup
-          export ${{ matrix.force_fail }}
+          # Setup environment variables
+          export LD_LIBRARY_PATH=$GITHUB_WORKSPACE/wolfssl-install/lib:$GITHUB_WORKSPACE/openssl-install/lib64
+          export OPENSSL_CONF=$GITHUB_WORKSPACE/provider.conf
+          export OPENSSL_MODULES=$GITHUB_WORKSPACE/wolfprov-install/lib
+
+          echo "Checking OpenSSL providers:"
+          $GITHUB_WORKSPACE/openssl-install/bin/openssl list -providers | tee provider-list.log
+          grep -q libwolfprov provider-list.log || (echo "ERROR: libwolfprov not found in OpenSSL providers" && exit 1)
 
           # Verify ipmitool was built and linked correctly with OpenSSL
           ldd src/ipmitool | grep -E '(libssl|libcrypto)'

--- a/.github/workflows/kmod.yml
+++ b/.github/workflows/kmod.yml
@@ -1,0 +1,145 @@
+name: kmod Tests
+
+# START OF COMMON SECTION
+on:
+  push:
+    branches: [ '*' ] #  'master', 'main', 'release/**' ]
+  pull_request:
+    branches: [ '*' ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+# END OF COMMON SECTION
+
+jobs:
+  build_wolfprovider:
+    uses: ./.github/workflows/build-wolfprovider.yml
+    with:
+      wolfssl_ref: ${{ matrix.wolfssl_ref }}
+      openssl_ref: ${{ matrix.openssl_ref }}
+    strategy:
+      matrix:
+        wolfssl_ref: [ 'master', 'v5.8.0-stable' ]
+        openssl_ref: [ 'openssl-3.5.0' ]
+
+  test_kmod:
+    runs-on: ubuntu-22.04
+    needs: build_wolfprovider
+    # This should be a safe limit for the tests to run.
+    timeout-minutes: 20
+    strategy:
+      matrix:
+        kmod_ref: [ 'master' ] #, 'v33' ]
+        wolfssl_ref: [ 'master', 'v5.8.0-stable' ]
+        openssl_ref: [ 'openssl-3.5.0' ]
+        force_fail: [ 'WOLFPROV_FORCE_FAIL=1', '' ]
+    steps:
+      # Checkout the source so we can run the check-workflow-result script
+      - name: Checkout wolfProvider
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+              .github
+
+      - name: Retrieving OpenSSL from cache
+        uses: actions/cache/restore@v4
+        id: openssl-cache
+        with:
+          path: |
+            openssl-source
+            openssl-install
+
+          key: ossl-depends-${{ matrix.openssl_ref }}-${{ github.sha }}
+          fail-on-cache-miss: true
+
+      - name: Retrieving wolfSSL/wolfProvider from cache
+        uses: actions/cache/restore@v4
+        id: wolfprov-cache
+        with:
+          path: |
+            wolfssl-source
+            wolfssl-install
+            wolfprov-install
+            provider.conf
+
+          key: wolfprov-${{ matrix.wolfssl_ref }}-${{ github.sha }}
+          fail-on-cache-miss: true
+
+      - name: Install kmod dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            build-essential \
+            autoconf \
+            libtool \
+            meson \
+            pkg-config \
+            libzstd-dev \
+            liblzma-dev \
+            scdoc \
+            zlib1g-dev \
+            libtool \
+            dwarves
+
+          sudo apt install -y linux-image-$(uname -r)
+          # make sure openssl is not installed
+          # sudo apt remove openssl libssl-dev
+          sudo apt remove libssl-dev
+
+      - name: Download kmod
+        uses: actions/checkout@v4
+        with:
+          repository: kmod-project/kmod
+          ref: ${{ matrix.kmod_ref }}
+          path: kmod
+
+      - name: Setup package config file
+        run: |
+          mkdir -p $GITHUB_WORKSPACE/openssl-install/lib64/pkgconfig
+          printf "%s\n" \
+            "prefix=$GITHUB_WORKSPACE/openssl-install" \
+            "exec_prefix=\${prefix}" \
+            "libdir=\${exec_prefix}/lib64" \
+            "includedir=\${prefix}/include" \
+            "" \
+            "Name: OpenSSL-libcrypto" \
+            "Description: OpenSSL cryptography library" \
+            "Version: 3.5.0" \
+            "Libs: -L\${libdir} -lcrypto" \
+            "Cflags: -I\${includedir}" \
+            > "$GITHUB_WORKSPACE/openssl-install/lib64/pkgconfig/libcrypto.pc"
+
+      - name: Build kmod
+        working-directory: kmod
+        run: |
+          echo "expect lcrypto to be in $GITHUB_WORKSPACE/openssl-install/lib64:"
+          ls -l $GITHUB_WORKSPACE/openssl-install/lib64
+          export LD_LIBRARY_PATH=$GITHUB_WORKSPACE/wolfssl-install/lib:$GITHUB_WORKSPACE/openssl-install/lib64
+          export PKG_CONFIG_PATH=$PWD/build/meson-private:$GITHUB_WORKSPACE/openssl-install/lib64/pkgconfig
+          meson setup build -Dbuild-tests=true
+          meson compile -C build
+
+      - name: Run kmod tests
+        working-directory: kmod
+        run: |
+          # Set up the environment for wolfProvider
+          export LD_LIBRARY_PATH=$GITHUB_WORKSPACE/wolfssl-install/lib:$GITHUB_WORKSPACE/openssl-install/lib64
+          export OPENSSL_CONF=$GITHUB_WORKSPACE/provider.conf
+          export OPENSSL_MODULES=$GITHUB_WORKSPACE/wolfprov-install/lib
+          export PKG_CONFIG_PATH=$PWD/build/meson-private:$GITHUB_WORKSPACE/openssl-install/lib64/pkgconfig
+          export ${{ matrix.force_fail }}
+          export SHELL=/bin/bash
+
+          echo "Checking OpenSSL providers:"
+          $GITHUB_WORKSPACE/openssl-install/bin/openssl list -providers | tee provider-list.log
+          grep -q libwolfprov provider-list.log || (echo "ERROR: libwolfprov not found in OpenSSL providers" && exit 1)
+
+          # Run tests
+          meson compile -C build
+
+          # Logs written to build/meson-logs/testlog.txt
+
+          # Capture result
+          # TEST_RESULT=$(tail -1 ./test/check_cjose.log | grep PASS; echo $?)
+          # $GITHUB_WORKSPACE/.github/scripts/check-workflow-result.sh $TEST_RESULT ${{ matrix.force_fail }} cjose

--- a/.github/workflows/liboauth2.yml
+++ b/.github/workflows/liboauth2.yml
@@ -36,22 +36,29 @@ jobs:
     steps:
       - name: Checkout wolfProvider
         uses: actions/checkout@v4
+
+      - name: Retrieving OpenSSL from cache
+        uses: actions/cache/restore@v4
+        id: openssl-cache
         with:
-          fetch-depth: 1
-          
+          path: |
+            openssl-source
+            openssl-install
+
+          key: ossl-depends-${{ matrix.openssl_ref }}-${{ github.sha }}
+          fail-on-cache-miss: true
+
       - name: Retrieving wolfSSL/wolfProvider from cache
         uses: actions/cache/restore@v4
         id: wolfprov-cache
         with:
           path: |
-            scripts
             wolfssl-source
             wolfssl-install
             wolfprov-install
-            openssl-install
             provider.conf
 
-          key: wolfprov-${{ matrix.wolfssl_ref }}-${{ matrix.openssl_ref }}-${{ github.sha }}
+          key: wolfprov-${{ matrix.wolfssl_ref }}-${{ github.sha }}
           fail-on-cache-miss: true
 
       - name: Install liboauth2 dependencies
@@ -81,9 +88,16 @@ jobs:
       - name: Run liboauth2 tests
         working-directory: liboauth2
         run: |
-          # Set up the environment for wolfProvider
-          source $GITHUB_WORKSPACE/scripts/env-setup
+          # Set environment variables
+          export LD_LIBRARY_PATH=$GITHUB_WORKSPACE/wolfssl-install/lib:$GITHUB_WORKSPACE/openssl-install/lib64
+          export OPENSSL_CONF=$GITHUB_WORKSPACE/provider.conf
+          export OPENSSL_MODULES=$GITHUB_WORKSPACE/wolfprov-install/lib
+          export PKG_CONFIG_PATH=$GITHUB_WORKSPACE/openssl-install/lib64/pkgconfig
           export ${{ matrix.force_fail }}
+
+          echo "Checking OpenSSL providers:"
+          $GITHUB_WORKSPACE/openssl-install/bin/openssl list -providers | tee provider-list.log
+          grep -q libwolfprov provider-list.log || (echo "ERROR: libwolfprov not found in OpenSSL providers" && exit 1)
 
           # Build and run tests
           make check 2>&1 | tee liboauth2-test.log

--- a/.github/workflows/multi-compiler.yml
+++ b/.github/workflows/multi-compiler.yml
@@ -73,7 +73,6 @@ jobs:
         id: wolfprov-cache
         with:
           path: |
-            scripts
             wolfssl-source
             wolfssl-install
             wolfprov-install

--- a/.github/workflows/net-snmp.yml
+++ b/.github/workflows/net-snmp.yml
@@ -38,22 +38,29 @@ jobs:
     steps:
       - name: Checkout wolfProvider
         uses: actions/checkout@v4
+
+      - name: Retrieving OpenSSL from cache
+        uses: actions/cache/restore@v4
+        id: openssl-cache
         with:
-          fetch-depth: 1
+          path: |
+            openssl-source
+            openssl-install
+
+          key: ossl-depends-${{ matrix.openssl_ref }}-${{ github.sha }}
+          fail-on-cache-miss: true
 
       - name: Retrieving wolfSSL/wolfProvider from cache
         uses: actions/cache/restore@v4
         id: wolfprov-cache
         with:
           path: |
-            scripts
             wolfssl-source
             wolfssl-install
             wolfprov-install
-            openssl-install
             provider.conf
 
-          key: wolfprov-${{ matrix.wolfssl_ref }}-${{ matrix.openssl_ref }}-${{ github.sha }}
+          key: wolfprov-${{ matrix.wolfssl_ref }}-${{ github.sha }}
           fail-on-cache-miss: true
 
       - name: Install dependencies
@@ -78,9 +85,14 @@ jobs:
       - name: Run tests
         working-directory: net-snmp
         run: |
-          # Set up the environment for wolfProvider
-          source $GITHUB_WORKSPACE/scripts/env-setup
+          export LD_LIBRARY_PATH=$GITHUB_WORKSPACE/wolfssl-install/lib:$GITHUB_WORKSPACE/openssl-install/lib64
+          export OPENSSL_CONF=$GITHUB_WORKSPACE/provider.conf
+          export OPENSSL_MODULES=$GITHUB_WORKSPACE/wolfprov-install/lib
           export ${{ matrix.force_fail }}
+
+          echo "Checking OpenSSL providers:"
+          $GITHUB_WORKSPACE/openssl-install/bin/openssl list -providers | tee provider-list.log
+          grep -q libwolfprov provider-list.log || (echo "ERROR: libwolfprov not found in OpenSSL providers" && exit 1)
 
           autoconf --version | grep -P '2\.\d\d' -o > dist/autoconf-version
           mkdir -p tests

--- a/.github/workflows/nginx.yml
+++ b/.github/workflows/nginx.yml
@@ -40,22 +40,29 @@ jobs:
     steps:
       - name: Checkout wolfProvider
         uses: actions/checkout@v4
+
+      - name: Retrieving OpenSSL from cache
+        uses: actions/cache/restore@v4
+        id: openssl-cache
         with:
-          fetch-depth: 1
+          path: |
+            openssl-source
+            openssl-install
+
+          key: ossl-depends-${{ matrix.openssl_ref }}-${{ github.sha }}
+          fail-on-cache-miss: true
 
       - name: Retrieving wolfSSL/wolfProvider from cache
         uses: actions/cache/restore@v4
         id: wolfprov-cache
         with:
           path: |
-            scripts
             wolfssl-source
             wolfssl-install
             wolfprov-install
-            openssl-install
             provider.conf
 
-          key: wolfprov-${{ matrix.wolfssl_ref }}-${{ matrix.openssl_ref }}-${{ github.sha }}
+          key: wolfprov-${{ matrix.wolfssl_ref }}-${{ github.sha }}
           fail-on-cache-miss: true
 
       - name: Install dependencies
@@ -85,9 +92,15 @@ jobs:
       - name: Run nginx-tests with wolfProvider
         working-directory: nginx-tests
         run: |
-          # Set up the environment for wolfProvider
-          source $GITHUB_WORKSPACE/scripts/env-setup
+          # Set environment variables
+          export LD_LIBRARY_PATH=$GITHUB_WORKSPACE/wolfssl-install/lib:$GITHUB_WORKSPACE/openssl-install/lib64
+          export OPENSSL_CONF=$GITHUB_WORKSPACE/provider.conf
+          export OPENSSL_MODULES=$GITHUB_WORKSPACE/wolfprov-install/lib
           export ${{ matrix.force_fail }}
+
+          echo "Checking OpenSSL providers:"
+          $GITHUB_WORKSPACE/openssl-install/bin/openssl list -providers | tee provider-list.log
+          grep -q libwolfprov provider-list.log || (echo "ERROR: libwolfprov not found in OpenSSL providers" && exit 1)
 
           # Run tests and save result
           TEST_NGINX_VERBOSE=y TEST_NGINX_CATLOG=y TEST_NGINX_BINARY=../nginx/objs/nginx prove -v . 2>&1 | tee nginx-test.log

--- a/.github/workflows/openldap.yml
+++ b/.github/workflows/openldap.yml
@@ -37,22 +37,29 @@ jobs:
     steps:
       - name: Checkout wolfProvider
         uses: actions/checkout@v4
+
+      - name: Retrieving OpenSSL from cache
+        uses: actions/cache/restore@v4
+        id: openssl-cache
         with:
-          fetch-depth: 1
+          path: |
+            openssl-source
+            openssl-install
+
+          key: ossl-depends-${{ matrix.openssl_ref }}-${{ github.sha }}
+          fail-on-cache-miss: true
 
       - name: Retrieving wolfSSL/wolfProvider from cache
         uses: actions/cache/restore@v4
         id: wolfprov-cache
         with:
           path: |
-            scripts
             wolfssl-source
             wolfssl-install
             wolfprov-install
-            openssl-install
             provider.conf
 
-          key: wolfprov-${{ matrix.wolfssl_ref }}-${{ matrix.openssl_ref }}-${{ github.sha }}
+          key: wolfprov-${{ matrix.wolfssl_ref }}-${{ github.sha }}
           fail-on-cache-miss: true
 
       - name: Install dependencies
@@ -70,9 +77,14 @@ jobs:
       - name: Build and test OpenLDAP with wolfProvider
         working-directory: openldap
         run: |
-          # Set up the environment for wolfProvider
-          source $GITHUB_WORKSPACE/scripts/env-setup
-          export ${{ matrix.force_fail }}
+          # Setup environment for wolfProvider
+          export LD_LIBRARY_PATH=$GITHUB_WORKSPACE/wolfssl-install/lib:$GITHUB_WORKSPACE/openssl-install/lib64
+          export OPENSSL_CONF=$GITHUB_WORKSPACE/provider.conf
+          export OPENSSL_MODULES=$GITHUB_WORKSPACE/wolfprov-install/lib
+
+          echo "Checking OpenSSL providers:"
+          $GITHUB_WORKSPACE/openssl-install/bin/openssl list -providers | tee provider-list.log
+          grep -q libwolfprov provider-list.log || (echo "ERROR: libwolfprov not found in OpenSSL providers" && exit 1)
 
           # Generate configure script
           rm -f aclocal.m4

--- a/.github/workflows/openssh.yml
+++ b/.github/workflows/openssh.yml
@@ -40,22 +40,29 @@ jobs:
     steps:
       - name: Checkout wolfProvider
         uses: actions/checkout@v4
+
+      - name: Retrieving OpenSSL from cache
+        uses: actions/cache/restore@v4
+        id: openssl-cache
         with:
-          fetch-depth: 1
+          path: |
+            openssl-source
+            openssl-install
+
+          key: ossl-depends-${{ matrix.openssl_ref }}-${{ github.sha }}
+          fail-on-cache-miss: true
 
       - name: Retrieving wolfSSL/wolfProvider from cache
         uses: actions/cache/restore@v4
         id: wolfprov-cache
         with:
           path: |
-            scripts
             wolfssl-source
             wolfssl-install
             wolfprov-install
-            openssl-install
             provider.conf
 
-          key: wolfprov-${{ matrix.wolfssl_ref }}-${{ matrix.openssl_ref }}-${{ github.sha }}
+          key: wolfprov-${{ matrix.wolfssl_ref }}-${{ github.sha }}
           fail-on-cache-miss: true
 
       - name: Checkout OSP
@@ -74,9 +81,14 @@ jobs:
       - name: Build and Test openssh-portable
         working-directory: openssh-portable
         run: |
-          # Set up the environment for wolfProvider
-          source $GITHUB_WORKSPACE/scripts/env-setup
-          export ${{ matrix.force_fail }}
+          # Set environment variables
+          export LD_LIBRARY_PATH=$GITHUB_WORKSPACE/wolfssl-install/lib:$GITHUB_WORKSPACE/openssl-install/lib64
+          export OPENSSL_CONF=$GITHUB_WORKSPACE/provider.conf
+          export OPENSSL_MODULES=$GITHUB_WORKSPACE/wolfprov-install/lib
+
+          echo "Checking OpenSSL providers:"
+          $GITHUB_WORKSPACE/openssl-install/bin/openssl list -providers | tee provider-list.log
+          grep -q libwolfprov provider-list.log || (echo "ERROR: libwolfprov not found in OpenSSL providers" && exit 1)
 
           # Apply the patch for the correct version of OpenSSH
           if [ "${{ matrix.openssh_ref }}" != "master" ]; then

--- a/.github/workflows/openvpn.yml
+++ b/.github/workflows/openvpn.yml
@@ -40,22 +40,29 @@ jobs:
     steps:
       - name: Checkout wolfProvider
         uses: actions/checkout@v4
+
+      - name: Retrieving OpenSSL from cache
+        uses: actions/cache/restore@v4
+        id: openssl-cache
         with:
-          fetch-depth: 1
+          path: |
+            openssl-source
+            openssl-install
+
+          key: ossl-depends-${{ matrix.openssl_ref }}-${{ github.sha }}
+          fail-on-cache-miss: true
 
       - name: Retrieving wolfSSL/wolfProvider from cache
         uses: actions/cache/restore@v4
         id: wolfprov-cache
         with:
           path: |
-            scripts
             wolfssl-source
             wolfssl-install
             wolfprov-install
-            openssl-install
             provider.conf
 
-          key: wolfprov-${{ matrix.wolfssl_ref }}-${{ matrix.openssl_ref }}-${{ github.sha }}
+          key: wolfprov-${{ matrix.wolfssl_ref }}-${{ github.sha }}
           fail-on-cache-miss: true
 
       - name: Install test dependencies
@@ -77,9 +84,15 @@ jobs:
       - name: Test OpenVPN with wolfProvider
         working-directory: openvpn
         run: |
-          # Set up the environment for wolfProvider
-          source $GITHUB_WORKSPACE/scripts/env-setup
+          # Set environment variables
+          export LD_LIBRARY_PATH=$GITHUB_WORKSPACE/wolfssl-install/lib:$GITHUB_WORKSPACE/openssl-install/lib64
+          export OPENSSL_CONF=$GITHUB_WORKSPACE/provider.conf
+          export OPENSSL_MODULES=$GITHUB_WORKSPACE/wolfprov-install/lib
           export ${{ matrix.force_fail }}
+
+          echo "Checking OpenSSL providers:"
+          $GITHUB_WORKSPACE/openssl-install/bin/openssl list -providers | tee provider-list.log
+          grep -q libwolfprov provider-list.log || (echo "ERROR: libwolfprov not found in OpenSSL providers" && exit 1)
 
           # Run tests and save result
           make check 2>&1 | tee openvpn-test.log

--- a/.github/workflows/pam_pkcs11.yml
+++ b/.github/workflows/pam_pkcs11.yml
@@ -1,0 +1,72 @@
+name: pam_pkcs11 Tests
+
+# START OF COMMON SECTION
+on:
+  push:
+    branches: [ 'master', 'main', 'release/**' ]
+  pull_request:
+    branches: [ '*' ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+# END OF COMMON SECTION
+
+jobs:
+  build_wolfprovider:
+    uses: ./.github/workflows/build-wolfprovider.yml
+    with:
+      wolfssl_ref: ${{ matrix.wolfssl_ref }}
+      openssl_ref: ${{ matrix.openssl_ref }}
+    strategy:
+      matrix:
+        wolfssl_ref: [ 'master', 'v5.8.0-stable' ]
+        openssl_ref: [ 'openssl-3.5.0' ]
+
+  test_pam_pkcs11:
+    runs-on: ubuntu-22.04
+    needs: build_wolfprovider
+    # This should be a safe limit for the tests to run.
+    timeout-minutes: 20
+    strategy:
+      matrix:
+        pam_pkcs11_ref: [ 'master', 'pam_pkcs11-0.6.12' ]
+        wolfssl_ref: [ 'master', 'v5.8.0-stable' ]
+        openssl_ref: [ 'openssl-3.5.0' ]
+        force_fail: [ 'WOLFPROV_FORCE_FAIL=1', '' ]
+    steps:
+      # Checkout the source so we can run the check-workflow-result script
+      - name: Checkout wolfProvider
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+              .github
+
+      - name: Retrieving wolfSSL/wolfProvider from cache
+        uses: actions/cache/restore@v4
+        id: wolfprov-cache
+        with:
+          path: |
+            wolfssl-source
+            wolfssl-install
+            wolfprov-install
+            openssl-install
+            provider.conf
+
+          key: wolfprov-${{ matrix.wolfssl_ref }}-${{ github.sha }}
+          fail-on-cache-miss: true
+
+      - name: Run pam_pkcs11 tests
+        run: |
+          # Setup environment variables
+          source $GITHUB_WORKSPACE/scripts/env-setup
+
+          # Run tests
+          if timeout 300 ${{ matrix.force_fail }} sudo bash -c $GITHUB_WORKSPACE/.github/scripts/pam-pkcs11-test.sh; then
+            TEST_RESULT=0
+          else
+            TEST_RESULT=1
+          fi
+
+          # Capture result
+          $GITHUB_WORKSPACE/.github/scripts/check-workflow-result.sh $TEST_RESULT ${{ matrix.force_fail }} pam_pkcs11

--- a/.github/workflows/simple.yml
+++ b/.github/workflows/simple.yml
@@ -34,14 +34,12 @@ jobs:
         id: wolfprov-cache
         with:
           path: |
-            scripts
             wolfssl-source
             wolfssl-install
             wolfprov-install
-            openssl-install
             provider.conf
 
-          key: wolfprov-${{ matrix.wolfssl_ref }}-${{ matrix.openssl_ref }}-${{ github.sha }}
+          key: wolfprov-${{ matrix.wolfssl_ref }}-${{ github.sha }}
           lookup-only: true
 
       # If wolfssl/wolfprovider have not yet been built, pull ossl from cache

--- a/.github/workflows/socat.yml
+++ b/.github/workflows/socat.yml
@@ -35,22 +35,29 @@ jobs:
     steps:
       - name: Checkout wolfProvider
         uses: actions/checkout@v4
+
+      - name: Retrieving OpenSSL from cache
+        uses: actions/cache/restore@v4
+        id: openssl-cache
         with:
-          fetch-depth: 1
+          path: |
+            openssl-source
+            openssl-install
+
+          key: ossl-depends-${{ matrix.openssl_ref }}-${{ github.sha }}
+          fail-on-cache-miss: true
 
       - name: Retrieving wolfSSL/wolfProvider from cache
         uses: actions/cache/restore@v4
         id: wolfprov-cache
         with:
           path: |
-            scripts
             wolfssl-source
             wolfssl-install
             wolfprov-install
-            openssl-install
             provider.conf
 
-          key: wolfprov-${{ matrix.wolfssl_ref }}-${{ matrix.openssl_ref }}-${{ github.sha }}
+          key: wolfprov-${{ matrix.wolfssl_ref }}-${{ github.sha }}
           fail-on-cache-miss: true
 
       - name: Install dependencies
@@ -74,8 +81,14 @@ jobs:
         working-directory: ./socat-1.8.0.0
         run: |
           # Set up the environment for wolfProvider
-          source $GITHUB_WORKSPACE/scripts/env-setup
-          export ${{ matrix.force_fail }}
+          export LD_LIBRARY_PATH=$GITHUB_WORKSPACE/wolfssl-install/lib:$GITHUB_WORKSPACE/openssl-install/lib64
+          export OPENSSL_CONF=$GITHUB_WORKSPACE/provider.conf
+          export OPENSSL_MODULES=$GITHUB_WORKSPACE/wolfprov-install/lib
+          export SHELL=/bin/bash
+
+          echo "Checking OpenSSL providers:"
+          $GITHUB_WORKSPACE/openssl-install/bin/openssl list -providers | tee provider-list.log
+          grep -q libwolfprov provider-list.log || (echo "ERROR: libwolfprov not found in OpenSSL providers" && exit 1)
 
           # Verify OpenSSL loads wolfProvider
           $GITHUB_WORKSPACE/openssl-install/bin/openssl list -providers

--- a/.github/workflows/sssd.yml
+++ b/.github/workflows/sssd.yml
@@ -33,8 +33,6 @@ jobs:
     steps:
       - name: Checkout wolfProvider
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
 
       # Check if this version of wolfssl/wolfprovider has already been built,
       # mark to cache these items on post if we do end up building
@@ -46,15 +44,27 @@ jobs:
             wolfssl-source
             wolfssl-install
             wolfprov-install
-            openssl-install
             provider.conf
 
-          key: wolfprov-${{ matrix.wolfssl_ref }}-${{ matrix.openssl_ref }}-${{ github.sha }}
+          key: wolfprov-${{ matrix.wolfssl_ref }}-${{ github.sha }}
+          lookup-only: true
+
+      # If wolfssl/wolfprovider have not yet been built, pull ossl from cache
+      - name: Checking OpenSSL in cache
+        if: steps.wolfprov-${{ matrix.wolfssl_ref }}-cache.hit != 'true'
+        uses: actions/cache@v4
+        id: openssl-cache
+        with:
+          path: |
+            openssl-source
+            openssl-install
+
+          key: ossl-depends-${{ matrix.openssl_ref }}-${{ github.sha }}
           lookup-only: true
 
       # If not yet built this version, build it now
       - name: Build wolfProvider
-        if: steps.wolfprov-cache.outputs.cache-hit != 'true'
+        if: steps.wolfprov-${{ matrix.wolfssl_ref }}-cache.hit != 'true'
         run: |
           OPENSSL_TAG=${{ matrix.openssl_ref }} WOLFSSL_TAG=${{ matrix.wolfssl_ref }} ./scripts/build-wolfprovider.sh
 

--- a/.github/workflows/stunnel.yml
+++ b/.github/workflows/stunnel.yml
@@ -40,22 +40,29 @@ jobs:
     steps:
       - name: Checkout wolfProvider
         uses: actions/checkout@v4
+
+      - name: Retrieving OpenSSL from cache
+        uses: actions/cache/restore@v4
+        id: openssl-cache
         with:
-          fetch-depth: 1
+          path: |
+            openssl-source
+            openssl-install
+
+          key: ossl-depends-${{ matrix.openssl_ref }}-${{ github.sha }}
+          fail-on-cache-miss: true
 
       - name: Retrieving wolfSSL/wolfProvider from cache
         uses: actions/cache/restore@v4
         id: wolfprov-cache
         with:
           path: |
-            scripts
             wolfssl-source
             wolfssl-install
             wolfprov-install
-            openssl-install
             provider.conf
 
-          key: wolfprov-${{ matrix.wolfssl_ref }}-${{ matrix.openssl_ref }}-${{ github.sha }}
+          key: wolfprov-${{ matrix.wolfssl_ref }}-${{ github.sha }}
           fail-on-cache-miss: true
 
       - name: Install dependencies
@@ -86,13 +93,19 @@ jobs:
       - name: Verify stunnel with wolfProvider
         working-directory: ./stunnel
         run: |
-          # Set up the environment for wolfProvider
-          source $GITHUB_WORKSPACE/scripts/env-setup
+          # Setup environment variables
+          export LD_LIBRARY_PATH=$GITHUB_WORKSPACE/wolfssl-install/lib:$GITHUB_WORKSPACE/openssl-install/lib64
+          export OPENSSL_CONF=$GITHUB_WORKSPACE/provider.conf
+          export OPENSSL_MODULES=$GITHUB_WORKSPACE/wolfprov-install/lib
           export ${{ matrix.force_fail }}
 
           # Verify stunnel
           ldd src/stunnel | grep -E '(libssl|libcrypto)'
           ./src/stunnel -version
+
+          echo "Checking OpenSSL providers:"
+          $GITHUB_WORKSPACE/openssl-install/bin/openssl list -providers | tee provider-list.log
+          grep -q libwolfprov provider-list.log || (echo "ERROR: libwolfprov not found in OpenSSL providers" && exit 1)
 
           # Run tests and capture output
           mkdir -p $GITHUB_WORKSPACE/tests

--- a/.github/workflows/tcpdump.yml
+++ b/.github/workflows/tcpdump.yml
@@ -37,21 +37,27 @@ jobs:
     steps:
       - name: Checkout wolfProvider
         uses: actions/checkout@v4
+
+      - name: Retrieve OpenSSL from cache
+        uses: actions/cache/restore@v4
+        id: openssl-cache
         with:
-          fetch-depth: 1
+          path: |
+            openssl-source
+            openssl-install
+          key: ossl-depends-${{ matrix.openssl_ref }}-${{ github.sha }}
+          fail-on-cache-miss: true
 
       - name: Retrieve wolfSSL/wolfProvider from cache
         uses: actions/cache/restore@v4
         id: wolfprov-cache
         with:
           path: |
-            scripts
             wolfssl-source
             wolfssl-install
             wolfprov-install
-            openssl-install
             provider.conf
-          key: wolfprov-${{ matrix.wolfssl_ref }}-${{ matrix.openssl_ref }}-${{ github.sha }}
+          key: wolfprov-${{ matrix.wolfssl_ref }}-${{ github.sha }}
           fail-on-cache-miss: true
 
       - name: Install test dependencies
@@ -96,9 +102,17 @@ jobs:
       - name: Run tcpdump tests
         working-directory: tcpdump_repo
         run: |
-          # Set up the environment for wolfProvider
-          source $GITHUB_WORKSPACE/scripts/env-setup
+          export LD_LIBRARY_PATH="$GITHUB_WORKSPACE/wolfssl-install/lib:$GITHUB_WORKSPACE/openssl-install/lib:$GITHUB_WORKSPACE/openssl-install/lib64:$GITHUB_WORKSPACE/libpcap-install/lib:$GITHUB_WORKSPACE/tcpdump-install/lib:$LD_LIBRARY_PATH"
+          export OPENSSL_CONF="$GITHUB_WORKSPACE/provider.conf"
+          export OPENSSL_MODULES="$GITHUB_WORKSPACE/wolfprov-install/lib"
+          export PKG_CONFIG_PATH="$GITHUB_WORKSPACE/openssl-install/lib64/pkgconfig:$GITHUB_WORKSPACE/libpcap-install/lib/pkgconfig:$PKG_CONFIG_PATH"
+          export PATH="$GITHUB_WORKSPACE/tcpdump-install/sbin:$GITHUB_WORKSPACE/tcpdump-install/bin:$PATH"
+          
           export ${{ matrix.force_fail }}
+
+          echo "Checking OpenSSL providers:"
+          $GITHUB_WORKSPACE/openssl-install/bin/openssl list -providers | tee provider-list.log
+          grep libwolfprov provider-list.log || (echo "ERROR: libwolfprov not found in OpenSSL providers" && exit 1)
           
           # Run tests
           make check 2>&1 | tee tcpdump-test.log


### PR DESCRIPTION
There are a couple limitations with github actions....

First is that the caches aren't visible across branches -- with some exceptions if the cache was created on the main branch.

Second is that they don't guard against race conditions where multiple jobs access the cache. And the result is a corrupted cache entry or unexpected cache hit/miss