### PR TITLE
Modify FIPS build and fix AES-GCM stream handling for FIPS

### DIFF
--- a/scripts/utils-wolfssl.sh
+++ b/scripts/utils-wolfssl.sh
@@ -26,8 +26,10 @@ WOLFSSL_TAG=${WOLFSSL_TAG:-"v5.8.0-stable"}
 WOLFSSL_SOURCE_DIR=${SCRIPT_DIR}/../wolfssl-source
 WOLFSSL_INSTALL_DIR=${SCRIPT_DIR}/../wolfssl-install
 WOLFSSL_ISFIPS=${WOLFSSL_ISFIPS:-0}
+WOLFSSL_FIPS_CONFIG_OPTS=${WOLFSSL_CONFIG_OPTS:-'--enable-opensslcoexist '}
+WOLFSSL_FIPS_CONFIG_CFLAGS=${WOLFSSL_CONFIG_CFLAGS:-"-I${OPENSSL_INSTALL_DIR}/include"}
 WOLFSSL_CONFIG_OPTS=${WOLFSSL_CONFIG_OPTS:-'--enable-all-crypto --with-eccminsz=192 --with-max-ecc-bits=1024 --enable-opensslcoexist --enable-sha'}
-WOLFSSL_CONFIG_CFLAGS=${WOLFSSL_CONFIG_CFLAGS:-"-I${OPENSSL_INSTALL_DIR}/include -DWC_RSA_NO_PADDING -DWOLFSSL_PUBLIC_MP -DHAVE_PUBLIC_FFDHE -DHAVE_FFDHE_6144 -DHAVE_FFDHE_8192 -DWOLFSSL_PSS_LONG_SALT -DWOLFSSL_PSS_SALT_LEN_DISCOVER -DRSA_MIN_SIZE=1024 -DWOLFSSL_OLD_OID_SUM -DWOLFSSL_BIND "}
+WOLFSSL_CONFIG_CFLAGS=${WOLFSSL_CONFIG_CFLAGS:-"-I${OPENSSL_INSTALL_DIR}/include -DWC_RSA_NO_PADDING -DWOLFSSL_PUBLIC_MP -DHAVE_PUBLIC_FFDHE -DHAVE_FFDHE_6144 -DHAVE_FFDHE_8192 -DWOLFSSL_PSS_LONG_SALT -DWOLFSSL_PSS_SALT_LEN_DISCOVER -DRSA_MIN_SIZE=1024 -DWOLFSSL_OLD_OID_SUM "}
 
 WOLFPROV_DEBUG=${WOLFPROV_DEBUG:-0}
 USE_CUR_TAG=${USE_CUR_TAG:-0}
@@ -96,12 +98,16 @@ install_wolfssl() {
             fi
             printf "using FIPS bundle ... "
             CONF_ARGS+=" --enable-fips=$WOLFSSL_FIPS_VERSION"
+            WOLFSSL_CONFIG_OPTS=$WOLFSSL_FIPS_CONFIG_OPTS
+            WOLFSSL_CONFIG_CFLAGS=$WOLFSSL_FIPS_CONFIG_CFLAGS
         elif [ "$WOLFSSL_ISFIPS" = "1" ]; then
             printf "with FIPS ... "
             CONF_ARGS+=" --enable-fips=v5"
+            WOLFSSL_CONFIG_OPTS=$WOLFSSL_FIPS_CONFIG_OPTS
+            WOLFSSL_CONFIG_CFLAGS=$WOLFSSL_FIPS_CONFIG_CFLAGS
             if [ ! -e "XXX-fips-test" ]; then
                 # Sometimes the system OpenSSL is different than the one we're using. So for the 'git' commands, we'll just use whatever the system comes with
-                LD_LIBRARY_PATH="" ./fips-check.sh keep nomakecheck linuxv5 >>$LOG_FILE 2>&1
+                LD_LIBRARY_PATH="" ./fips-check.sh linuxv5.2.1 keep nomakecheck >>$LOG_FILE 2>&1
                 if [ $? != 0 ]; then
                     printf "ERROR checking out FIPS\n"
                     rm -rf ${WOLFSSL_INSTALL_DIR}

--- a/src/wp_aes_aead.c
+++ b/src/wp_aes_aead.c
@@ -1439,6 +1439,7 @@ static int wp_aesgcm_encdec(wp_AeadCtx *ctx, unsigned char *out, size_t* outLen,
         ctx->aadLen = 0;
         ctx->aadSet = 0;
         OPENSSL_free(ctx->in);
+        ctx->bufSize = 0;
         ctx->in = NULL;
         ctx->inLen = 0;
     }

--- a/src/wp_aes_aead.c
+++ b/src/wp_aes_aead.c
@@ -1395,17 +1395,32 @@ static int wp_aesgcm_encdec(wp_AeadCtx *ctx, unsigned char *out, size_t* outLen,
             }
         }
         else {
-            /* Only the most recent auth err matters */
-            ctx->authErr = 0;
-            rc = wc_AesGcmDecrypt(&ctx->aes, tmp, ctx->in, (word32)ctx->inLen,
-                iv, (word32)ctx->ivLen, ctx->buf, (word32)ctx->tagLen,
-                ctx->aad, (word32)ctx->aadLen);
-            if (rc == AES_GCM_AUTH_E) {
-                ctx->authErr = 1;
-                rc = 0;
+            if (done) {
+                /* Only the most recent auth err matters */
+                ctx->authErr = 0;
+                rc = wc_AesGcmDecrypt(&ctx->aes, tmp, ctx->in, (word32)ctx->inLen,
+                    iv, (word32)ctx->ivLen, ctx->buf, (word32)ctx->tagLen,
+                    ctx->aad, (word32)ctx->aadLen);
+                if (rc == AES_GCM_AUTH_E) {
+                    ctx->authErr = 1;
+                    rc = 0;
+                }
+                if (rc != 0) {
+                    ok = 0;
+                }
             }
-            if (rc != 0) {
-                ok = 0;
+            else {
+                byte tmpTag[16];
+
+                /* wc_AesGcmDecrypt does not yield plaintext on auth tag error.
+                 * For all calls except final we use encrypt instead to yield
+                 * the proper plaintext */
+                rc = wc_AesGcmEncrypt_ex(&ctx->aes, tmp, ctx->in,
+                    (word32)ctx->inLen, iv, (word32)ctx->ivLen, (byte*)tmpTag,
+                    (word32)ctx->tagLen, ctx->aad, (word32)ctx->aadLen);
+                if (rc != 0) {
+                    ok = 0;
+                }
             }
         }
         /* Copy out relevant portion of output */

--- a/src/wp_rsa_kmgmt.c
+++ b/src/wp_rsa_kmgmt.c
@@ -2184,6 +2184,8 @@ static int wp_rsa_decode_pki(wp_Rsa* rsa, unsigned char* data, word32 len)
     return ok;
 }
 
+#ifdef WOLFSSL_ENCRYPTED_KEYS
+
 /** PBKDF2 OPID. */
 unsigned char pbkdf2_oid[] = {
     42, 134, 72, 134, 247, 13, 1, 5, 12
@@ -2260,6 +2262,8 @@ static int wp_rsa_decode_enc_pki(wp_Rsa* rsa, unsigned char* data, word32 len,
 
     return ok;
 }
+
+#endif
 
 /**
  * Construct parameters from RSA key and pass off to callback.


### PR DESCRIPTION
Until now wolfProvider has been building underlying wolfSSL FIPS using the same flags as default, including --enable-all-crypto. This is not a valid option for wolfSSL FIPS and it enables many algo flags in options.h that dont or should not have underlying crypto support. Fix build to use only needed flags.

Depending on build flags, wc_AesGcmDecrypt() implementation may or may not yield plaintext on a auth tag error. Modify stream handling to use wc_AesGcmEncrypt() instead to yield plaintext on all calls except the last.