### PR TITLE
(WIP) test github actions for libeac3

### DIFF
--- a/.github/workflows/libeac3.yml
+++ b/.github/workflows/libeac3.yml
@@ -1,0 +1,87 @@
+name: libeac3 Tests
+
+# START OF COMMON SECTION
+on:
+  push:
+    branches: [ 'master', 'main', 'release/**' ]
+  pull_request:
+    branches: [ '*' ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+# END OF COMMON SECTION
+
+jobs:
+  build_wolfprovider:
+    uses: ./.github/workflows/build-wolfprovider.yml
+    with:
+      wolfssl_ref: ${{ matrix.wolfssl_ref }}
+      openssl_ref: ${{ matrix.openssl_ref }}
+    strategy:
+      matrix:
+        wolfssl_ref: [ 'master', 'v5.8.0-stable' ]
+        openssl_ref: [ 'openssl-3.5.0' ]
+
+  test_libeac3:
+    runs-on: ubuntu-22.04
+    needs: build_wolfprovider
+    # This should be a safe limit for the tests to run.
+    timeout-minutes: 20
+    strategy:
+      matrix:
+        openpace_ref: [ 'master' ]
+        wolfssl_ref: [ 'master', 'v5.8.0-stable' ]
+        openssl_ref: [ 'openssl-3.5.0' ]
+        force_fail: [ 'WOLFPROV_FORCE_FAIL=1', '' ]
+        exclude:
+          - openpace_ref: 'master'
+            force_fail: 'WOLFPROV_FORCE_FAIL=1'
+    steps:
+      # Checkout the source so we can run the check-workflow-result script
+      - name: Checkout wolfProvider
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Retrieving wolfProvider from cache
+        uses: actions/cache/restore@v4
+        id: wolfprov-cache-restore
+        with:
+          path: |
+            wolfssl-source
+            wolfssl-install
+            wolfprov-install
+            openssl-install
+            provider.conf
+          key: wolfprov-${{ matrix.wolfssl_ref }}-${{ matrix.openssl_ref }}-${{ github.sha }}
+          fail-on-cache-miss: true
+
+      - name: Install libeac3 dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y autoconf automake libtool libc6 help2man gengetopt pkg-config m4 libeac3
+      - name: Download openpace
+        uses: actions/checkout@v4
+        with:
+          repository: frankmorgner/openpace
+          ref: ${{ matrix.openpace_ref }}
+          path: openpace
+
+      - name: Build openpace
+        working-directory: openpace
+        run: |
+          autoreconf --verbose --install
+          ./configure
+          make
+          sudo make install
+      - name: Run libeac3 tests
+        working-directory: openpace
+        run: |
+          echo "Setting environment variables..."
+          source $GITHUB_WORKSPACE/scripts/env-setup
+          export ${{ matrix.force_fail }}
+          ./src/eactest > libeac3-test.log || echo "eactest failed with exit code $?"
+          cat libeac3-test.log
+
+          #$GITHUB_WORKSPACE/.github/scripts/check-workflow-result.sh $TEST_RESULT ${{ matrix.force_fail }} libeac3


### PR DESCRIPTION
Some tests fail when linking against wolfProvider on certain algorithms.
- Fails TA-ECDSA-SHA-512 on DP 13 but not on DP 12
- Fails some legacy algorithms that I don't think wolfProvider is supposed to support anyways.