### PR TITLE
Update Test Suite

### DIFF
--- a/.github/scripts/check-workflow-result.sh
+++ b/.github/scripts/check-workflow-result.sh
@@ -33,9 +33,10 @@ TEST_SUITE="${3:-}"
 # Ensure TEST_RESULT is treated as a number
 TEST_RESULT=$((TEST_RESULT + 0))
 
-# If force fail is empty treat second arg as test suite
-if [ -z "$WOLFPROV_FORCE_FAIL" ]; then
-    TEST_SUITE="${2:-}"
+# If test suite is empty treat second arg as test suite
+if [ -z "$TEST_SUITE" ]; then
+    TEST_SUITE=$WOLFPROV_FORCE_FAIL
+    WOLFPROV_FORCE_FAIL=""
 fi
 
 if [ "$WOLFPROV_FORCE_FAIL" = "WOLFPROV_FORCE_FAIL=1" ]; then


### PR DESCRIPTION
When the check-workflow-result script runs, it grabs the commandline parameters into variables. If the force fail flag is left out, we are checking the force fail variable if it is blank, and then fixing it. We should check the test suite variable if blank and clear the force fail and update the test suite.