### PR TITLE
Add `HAVE_GETPID` to options.h to fix `dh->ctx` override by rng

### DIFF
--- a/.github/workflows/tnftp.yml
+++ b/.github/workflows/tnftp.yml
@@ -40,18 +40,16 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Retrieving wolfSSL/wolfProvider from cache
+      - name: Retrieve wolfSSL/wolfProvider from cache
         uses: actions/cache/restore@v4
         id: wolfprov-cache
         with:
           path: |
-            scripts
-            wolfssl-source
             wolfssl-install
             wolfprov-install
-            openssl-install
-            provider.conf
-
+            openssl-install/lib64
+            openssl-install/include
+            openssl-install/bin
           key: wolfprov-${{ matrix.wolfssl_ref }}-${{ matrix.openssl_ref }}-${{ github.sha }}
           fail-on-cache-miss: true
 

--- a/configure.ac
+++ b/configure.ac
@@ -52,6 +52,18 @@ if test "x$have_wolfssl" = "xyes"; then
     LDFLAGS="$LDFLAGS $WOLFSSL_LDFLAGS"
 fi
 
+# Check for required headers
+AC_CHECK_HEADERS([stdlib.h])
+AC_CHECK_HEADERS([unistd.h])
+AC_CHECK_HEADERS([ctype.h])
+
+# Check for getpid function and add HAVE_GETPID to AM_CFLAGS for inclusion in options.h
+AC_CHECK_FUNC([getpid])
+if test "$ac_cv_func_getpid" = "yes"
+then
+    AM_CFLAGS="$AM_CFLAGS -DHAVE_GETPID=1"
+fi
+
 # DEBUG
 DEBUG_CFLAGS="-g -O0 -DWOLFPROV_DEBUG"
 


### PR DESCRIPTION
# Description

- https://github.com/wolfSSL/wolfssl/pull/8867 introduced a problem with `HAVE_GETPID` that overrides the `dh->ctx` with the rng's value. Adding the `HAVE_GETPID` to options.h resolves these `WC_RNG rng` override issues. Specifically fixes the issues seen here on mac https://cloud.wolfssl-test.com/jenkins/job/wolfProvider/job/nightly-scripts-test/379/
- Also fixes oversight with the way we checkout our workflows now