### PR TITLE
Ensure yamls use header files from wolfProvider, rather than from the system

### DIFF
--- a/.github/workflows/build-wolfprovider.yml
+++ b/.github/workflows/build-wolfprovider.yml
@@ -22,11 +22,6 @@ jobs:
     outputs:
       cache_key: wolfprov-${{ inputs.wolfssl_ref }}-${{ inputs.openssl_ref }}-${{ github.sha }}
     steps:
-      - name: Install build dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y build-essential autoconf libtool pkg-config
-
       - name: Checkout wolfProvider
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/cjose.yml
+++ b/.github/workflows/cjose.yml
@@ -70,7 +70,7 @@ jobs:
         working-directory: cjose
         run: |
           # Configure with OpenSSL
-          ./configure CFLAGS="-Wno-error=deprecated-declarations" --with-openssl=/git/wolfProvider/openssl-install
+          ./configure CFLAGS="-Wno-error=deprecated-declarations" --with-openssl=$GITHUB_WORKSPACE/openssl-install
 
           # Build cjose
           make

--- a/.github/workflows/libfido2.yml
+++ b/.github/workflows/libfido2.yml
@@ -7,6 +7,7 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
+
 jobs:
   build_wolfprovider:
     uses: ./.github/workflows/build-wolfprovider.yml
@@ -17,6 +18,7 @@ jobs:
       matrix:
         wolfssl_ref: [ 'master', 'v5.8.0-stable' ]
         openssl_ref: [ 'openssl-3.5.0' ]
+
   test_libfido2:
     runs-on: ubuntu-22.04
     needs: build_wolfprovider
@@ -35,6 +37,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
+
       - name: Retrieving wolfSSL/wolfProvider from cache
         uses: actions/cache/restore@v4
         id: wolfprov-cache
@@ -47,10 +50,13 @@ jobs:
             openssl-install/bin
           key: wolfprov-${{ matrix.wolfssl_ref }}-${{ matrix.openssl_ref }}-${{ github.sha }}
           fail-on-cache-miss: true
+
       - name: Install test dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y build-essential cmake pkg-config libssl-dev libudev-dev zlib1g-dev libcbor-dev libpcsclite-dev pcscd
+          sudo apt-get install -y build-essential cmake pkg-config libudev-dev \
+            zlib1g-dev libcbor-dev libpcsclite-dev pcscd
+
       - name: Checkout libfido2
         uses: actions/checkout@v4
         with:
@@ -58,14 +64,18 @@ jobs:
           path: libfido2_repo
           ref: ${{ matrix.libfido2_ref }}
           fetch-depth: 1
+
       - name: Build and install libfido2
         working-directory: libfido2_repo
         run: |
+          # Set up the environment for wolfProvider
+          source $GITHUB_WORKSPACE/scripts/env-setup
           mkdir build
           cd build
           cmake -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/libfido2-install ..
           make -j$(nproc)
           make install
+
       - name: Run libfido2 tests
         working-directory: libfido2_repo/build
         run: |

--- a/.github/workflows/liboauth2.yml
+++ b/.github/workflows/liboauth2.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Install liboauth2 dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libssl-dev libcurl4-openssl-dev libjansson-dev \
+          sudo apt-get install -y libcurl4-openssl-dev libjansson-dev \
             libcjose-dev pkg-config build-essential apache2-dev libhiredis-dev \
             libmemcached-dev autotools-dev autoconf automake libtool check
 
@@ -65,12 +65,23 @@ jobs:
         with:
           repository: wolfssl/osp
           path: osp
+          fetch-depth: 1
+
+      - name: Checkout liboauth2
+        uses: actions/checkout@v4
+        with:
+          repository: OpenIDC/liboauth2
+          ref: ${{ matrix.liboauth2_ref }}
+          path: liboauth2
+          fetch-depth: 1
 
       - name: Build liboauth2
+        working-directory: liboauth2
         run: |
-          git clone https://github.com/OpenIDC/liboauth2.git
-          cd liboauth2
-          git checkout ${{ matrix.liboauth2_ref }}
+          # Set up the environment for wolfProvider
+          source $GITHUB_WORKSPACE/scripts/env-setup
+
+          # Apply patch from OSP repo
           patch -p1 < $GITHUB_WORKSPACE/osp/wolfProvider/liboauth2/liboauth2-${{ matrix.liboauth2_ref }}-wolfprov.patch
 
           autoreconf -fiv

--- a/.github/workflows/openssh.yml
+++ b/.github/workflows/openssh.yml
@@ -62,6 +62,7 @@ jobs:
         with:
           repository: wolfssl/osp
           path: osp
+          fetch-depth: 1
 
       - name: Checkout openssh
         uses: actions/checkout@v4
@@ -69,6 +70,7 @@ jobs:
           repository: openssh/openssh-portable
           path: openssh-portable
           ref: ${{ matrix.openssh_ref }}
+          fetch-depth: 1
 
       - name: Build and Test openssh-portable
         working-directory: openssh-portable


### PR DESCRIPTION
Specifically, ensure `libssl-dev` is not installed by the workflow.