### PR TITLE
Fix RSA decode and empty Keygen OID with FIPS

### DIFF
--- a/src/wp_dh_kmgmt.c
+++ b/src/wp_dh_kmgmt.c
@@ -2529,10 +2529,9 @@ static int wp_dh_encode(wp_DhEncDecCtx* ctx, OSSL_CORE_BIO *cBio,
     OSSL_PASSPHRASE_CALLBACK *pwCb, void *pwCbArg)
 {
     int ok = 1;
-    BIO* out = NULL;
 #if (LIBWOLFSSL_VERSION_HEX >= 0x05000000 && defined(WOLFSSL_DH_EXTRA))
     int rc;
-    out = wp_corebio_get_bio(ctx->provCtx, cBio);
+    BIO* out = wp_corebio_get_bio(ctx->provCtx, cBio);
     unsigned char* keyData = NULL;
     size_t keyLen;
     unsigned char* derData = NULL;
@@ -2656,6 +2655,8 @@ static int wp_dh_encode(wp_DhEncDecCtx* ctx, OSSL_CORE_BIO *cBio,
         OPENSSL_free(pemData);
     }
     OPENSSL_free(cipherInfo);
+
+    BIO_free(out);
 #else
     (void)ctx;
     (void)cBio;
@@ -2666,9 +2667,6 @@ static int wp_dh_encode(wp_DhEncDecCtx* ctx, OSSL_CORE_BIO *cBio,
     (void)pwCbArg;
 #endif
 
-    if (out != NULL) {
-        BIO_free(out);
-    }
     WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }

--- a/src/wp_dh_kmgmt.c
+++ b/src/wp_dh_kmgmt.c
@@ -2529,9 +2529,10 @@ static int wp_dh_encode(wp_DhEncDecCtx* ctx, OSSL_CORE_BIO *cBio,
     OSSL_PASSPHRASE_CALLBACK *pwCb, void *pwCbArg)
 {
     int ok = 1;
+    BIO* out = NULL;
 #if (LIBWOLFSSL_VERSION_HEX >= 0x05000000 && defined(WOLFSSL_DH_EXTRA))
     int rc;
-    BIO* out = wp_corebio_get_bio(ctx->provCtx, cBio);
+    out = wp_corebio_get_bio(ctx->provCtx, cBio);
     unsigned char* keyData = NULL;
     size_t keyLen;
     unsigned char* derData = NULL;
@@ -2665,7 +2666,9 @@ static int wp_dh_encode(wp_DhEncDecCtx* ctx, OSSL_CORE_BIO *cBio,
     (void)pwCbArg;
 #endif
 
-    BIO_free(out);
+    if (out != NULL) {
+        BIO_free(out);
+    }
     WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }

--- a/src/wp_internal.c
+++ b/src/wp_internal.c
@@ -573,6 +573,7 @@ int wp_cipher_from_params(const OSSL_PARAM params[], int* cipher,
 }
 
 #ifndef WOLFSSL_ENCRYPTED_KEYS
+#ifdef WP_HAVE_MD5
 /*
  * wolfProvider version of EncryptedInfo.
  */
@@ -695,6 +696,7 @@ static int wp_BufferKeyEncrypt(wp_EncryptedInfo* info, byte* der, word32 derSz,
 
     return ret;
 }
+#endif /* WP_HAVE_MD5 */
 #endif /* WOLFSSL_ENCRYPTED_KEYS */
 
 /**

--- a/src/wp_rsa_kmgmt.c
+++ b/src/wp_rsa_kmgmt.c
@@ -2167,7 +2167,7 @@ static int wp_rsa_decode_pki(wp_Rsa* rsa, unsigned char* data, word32 len)
     if (rc != 0) {
         ok = 0;
     }
-#if LIBWOLFSSL_VERSION_HEX < 0x05000000
+#if LIBWOLFSSL_VERSION_HEX < 0x05000000 || defined(HAVE_FIPS)
     if (!ok) {
         idx = 0;
         rc = wc_GetPkcs8TraditionalOffset(data, &idx, len);


### PR DESCRIPTION
# Description

- Adds `WOLFSSL_OLD_OID_SUM` which is needed with FIPS v5.2.1 which uses old OID logic. (Fixes errors with OID not being propagated with FIPS)
- Always do `wc_GetPkcs8TraditionalOffset` with FIPS because keys are created and wrapped in PKCS8 encoding. This removes so we can decode correctly. (Fixes errors with decode in RSA FIPS)
- Adds `WOLFSSL_DEBUG_ASN_TEMPLATE=1` option to enable `WOLFSSL_DEBUG_ASN_TEMPLATE` to help developers debug. Useful for ASN.1 parsing debug
- `Adds WOLFPROV_DISABLE_ERR_TRACE` options to remove error trace with debug. 
- Fixes `out` uninitialized value
