### PR TITLE
Add support for DH type specific SPKI decoder

### DIFF
--- a/src/wp_dh_kmgmt.c
+++ b/src/wp_dh_kmgmt.c
@@ -2208,6 +2208,12 @@ static int wp_dh_decode(wp_DhEncDecCtx* ctx, OSSL_CORE_BIO *cBio,
                 decoded = 0;
             }
         }
+        else if ((selection & OSSL_KEYMGMT_SELECT_PUBLIC_KEY) != 0) {
+            if (!wp_dh_decode_spki(dh, data, len)) {
+                ok = 0;
+                decoded = 0;
+            }
+        }
         else {
             if (!wp_dh_decode_params(dh, data, len)) {
                 ok = 0;


### PR DESCRIPTION
When openssl function i2d_PUBKEY() is used to encode a DH SPKI, it ends up calling for a type specific DH decoder which is not currently supported. Unfortunately there is no version of this function that takes a libctx so it is difficult to unit test. This will be covered by KRB5 CI when added. 