### PR TITLE
fixed timeout errors for x11vnc workflow

### DIFF
--- a/.github/scripts/x11vnc/test_x11vnc.sh
+++ b/.github/scripts/x11vnc/test_x11vnc.sh
@@ -52,8 +52,8 @@ fi
 
 echo -e "\n\nTesting -sslCertInfo\n" >> x11vnc_test.log
 
-OPENSSL_CONF='' OPENSSL_MODULES='' timeout 1 x11vnc -sslCertInfo ca-dir/server-wolf.pem > cert_info_ossl.txt
-timeout 1 x11vnc -sslCertInfo ca-dir/server-wolf.pem > cert_info.txt
+OPENSSL_CONF='' OPENSSL_MODULES='' timeout 5 x11vnc -sslCertInfo ca-dir/server-wolf.pem > cert_info_ossl.txt
+timeout 5 x11vnc -sslCertInfo ca-dir/server-wolf.pem > cert_info.txt
 
 if [ $? -eq 0 ] && diff -y cert_info.txt cert_info_ossl.txt >> x11vnc_test.log 2>> x11vnc_test.log \
     && cat cert_info.txt >> x11vnc_test.log
@@ -93,7 +93,7 @@ echo -e "\n\nTesting -ssl handshake, authentication, initialization...\n" >> x11
 PORT=`x11vnc -ssl TMP -display :0 -localhost -bg -o server.log`
 PORT=`echo "$PORT" | grep -m 1 "PORT=" | sed -e 's/PORT=//'`
 
-timeout 10 vncviewer -GnuTLSPriority=LEGACY -DesktopSize=0 -display :0 -log *:stderr:100 localhost::$PORT 2> client.log
+timeout 15 vncviewer -GnuTLSPriority=LEGACY -DesktopSize=0 -display :0 -log *:stderr:100 localhost::$PORT 2> client.log
 
 if grep -Eq "SSL: handshake with helper process[[0-9]+] succeeded" server.log \
     && grep -q "CConnection: Authentication success" client.log \
@@ -116,7 +116,7 @@ x11vnc -storepasswd wolfprov passwd 2>> x11vnc_test.log
 PORT=`x11vnc -ssl TMP -display :0 -localhost -bg -o server.log -rfbauth passwd`
 PORT=`echo "$PORT" | grep -m 1 "PORT=" | sed -e 's/PORT=//'`
 
-timeout 10 vncviewer -GnuTLSPriority=LEGACY -DesktopSize=0 -display :0 -passwd passwd -log *:stderr:100 localhost::$PORT 2> client.log
+timeout 15 vncviewer -GnuTLSPriority=LEGACY -DesktopSize=0 -display :0 -passwd passwd -log *:stderr:100 localhost::$PORT 2> client.log
 
 if grep -Eq "SSL: handshake with helper process[[0-9]+] succeeded" server.log \
     && grep -q "CConnection: Authentication success" client.log \

--- a/.github/scripts/x11vnc/x11vnc_sslenckey.exp
+++ b/.github/scripts/x11vnc/x11vnc_sslenckey.exp
@@ -1,7 +1,8 @@
 #!/bin/expect
 
-set timeout 1
+set timeout 5
 
+# encrypt the server certificate key
 spawn x11vnc -sslEncKey ca-dir/server-wolf.pem
 
 sleep 1

--- a/.github/scripts/x11vnc/x11vnc_sslgenca.exp
+++ b/.github/scripts/x11vnc/x11vnc_sslgenca.exp
@@ -1,7 +1,8 @@
 #!/bin/expect
 
-set timeout 1
+set timeout 5
 
+# generate a certificate authority
 spawn x11vnc -sslGenCA ca-dir
 
 sleep 1

--- a/.github/scripts/x11vnc/x11vnc_sslgencert_client.exp
+++ b/.github/scripts/x11vnc/x11vnc_sslgencert_client.exp
@@ -1,6 +1,6 @@
 #!/bin/expect
 
-set timeout 1
+set timeout 5
 
 # generate a cert for the client
 spawn x11vnc -ssldir ca-dir -sslGenCert client wolf

--- a/.github/scripts/x11vnc/x11vnc_sslgencert_server.exp
+++ b/.github/scripts/x11vnc/x11vnc_sslgencert_server.exp
@@ -1,6 +1,6 @@
 #!/bin/expect
 
-set timeout 1
+set timeout 5
 
 # generate a cert for the server
 spawn x11vnc -ssldir ca-dir -sslGenCert server wolf


### PR DESCRIPTION
Too small of a timeout causes sslgencert_client/server or sslgenca to fail periodically. Increased timeouts across the board to help mitigate this.

Created a loop with the offending tests and it took me about half an hour to get an error.
After fixing it I ran that same loop again for over 3 hours and have not gotten an error.

Presumably, it is fixed.