### PR TITLE
Add CI Github workflow for libssh2

### DIFF
--- a/.github/workflows/libssh2.yml
+++ b/.github/workflows/libssh2.yml
@@ -58,20 +58,22 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y build-essential autoconf libtool pkg-config clang libc++-dev python3-impacket
 
+      - name: Download libssh2
+        uses: actions/checkout@v4
+        with:
+          repository: libssh2/libssh2
+          ref: ${{ matrix.libssh2_ref }}
+          path: libssh2
+          fetch-depth: 1
+
       - name: Checkout OSP
         uses: actions/checkout@v4
         with:
           repository: wolfssl/osp
           path: osp
           fetch-depth: 1
-
-      - name: Clone libssh2
-        run: |
-          git clone --depth=1 --branch ${{ matrix.libssh2_ref }} https://github.com/libssh2/libssh2.git libssh2
-
-      - name: Apply patch
-        working-directory: libssh2
-        run: |
+      - run: |
+          cd libssh2
           patch -p1 < $GITHUB_WORKSPACE/osp/wolfProvider/libssh2/${{ matrix.libssh2_ref }}-wolfprov.patch
 
       - name: Build libssh2


### PR DESCRIPTION
# Description 

- [x] Needs [268 - libssh2 support](https://github.com/wolfSSL/osp/pull/268) to be merged first
- Verified with WPFF, only using 1.10.0 because of patch for now