### PR TITLE
Modify core libctx handling to instead create a new child libctx

### DIFF
--- a/src/wp_wolfprov.c
+++ b/src/wp_wolfprov.c
@@ -1212,7 +1212,6 @@ int wolfssl_provider_init(const OSSL_CORE_HANDLE* handle,
     const OSSL_DISPATCH* in, const OSSL_DISPATCH** out, void** provCtx)
 {
     int ok = 1;
-    OSSL_FUNC_core_get_libctx_fn* c_get_libctx = NULL;
 
 #ifdef WOLFPROV_DEBUG
     ok = (wolfProv_Debugging_ON() == 0);
@@ -1253,9 +1252,6 @@ int wolfssl_provider_init(const OSSL_CORE_HANDLE* handle,
             case OSSL_FUNC_CORE_GET_PARAMS:
                 c_get_params = OSSL_FUNC_core_get_params(in);
                 break;
-            case OSSL_FUNC_CORE_GET_LIBCTX:
-                c_get_libctx = OSSL_FUNC_core_get_libctx(in);
-                break;
             case OSSL_FUNC_BIO_READ_EX:
                 c_bio_read_ex = OSSL_FUNC_BIO_read_ex(in);
                 break;
@@ -1283,10 +1279,6 @@ int wolfssl_provider_init(const OSSL_CORE_HANDLE* handle,
         }
     }
 
-    if (c_get_libctx == NULL) {
-        ok = 0;
-    }
-
     if (ok) {
         /* Create a new provider context. */
         *provCtx = wolfssl_prov_ctx_new();
@@ -1295,9 +1287,11 @@ int wolfssl_provider_init(const OSSL_CORE_HANDLE* handle,
         }
     }
     if (ok) {
-        /* Store the library context in provider context. */
+        /* Using the OSSL_FUNC_core_get_libctx can yield you an
+         * uninitialized libctx in certain init flows. Instead create
+         * a new child libctx. The child libctx being NULL is allowed. */
         wolfssl_prov_ctx_set0_lib_ctx(*provCtx,
-            (OSSL_LIB_CTX*)c_get_libctx(handle));
+            OSSL_LIB_CTX_new_child(handle, in));
         /* Cache the handle in provider context. */
         wolfssl_prov_ctx_set0_handle(*provCtx, handle);
 


### PR DESCRIPTION
There are certain initialization flows that yield an uninitialized libctx pointer, which is a problem when we go to fetch for something like KDF later. Instead attempt to create a new child libctx, which is associated with the parent ctx to be instantiated. 