### PR TITLE
Fix tag logic in build script

### DIFF
--- a/scripts/utils-general.sh
+++ b/scripts/utils-general.sh
@@ -53,9 +53,7 @@ check_git_match() {
     local target_ref="$1"
     local repo_dir="${2:-.}"
 
-    # Save current directory and move to repo
-    local oldpwd="$PWD"
-    cd "$repo_dir" || return 2
+    pushd "$repo_dir" > /dev/null || return 2
 
     local current_tag current_branch current_commit_long current_commit_short
     current_tag=$(git describe --tags --exact-match 2>/dev/null || true)
@@ -65,25 +63,25 @@ check_git_match() {
 
     if [[ -n "$current_tag" && "$target_ref" == "$current_tag" ]]; then
         echo "match: tag ($current_tag)"
-        cd "$oldpwd"
+        popd > /dev/null
         return 0
     elif [[ -n "$current_branch" && "$target_ref" == "$current_branch" ]]; then
         echo "match: branch ($current_branch)"
-        cd "$oldpwd"
+        popd > /dev/null
         return 0
     elif [[ -n "$current_commit_long" && "$target_ref" == "$current_commit_long" ]]; then
         echo "match: commit (long $current_commit_long)"
-        cd "$oldpwd"
+        popd > /dev/null
         return 0
     elif [[ -n "$current_commit_short" && "$target_ref" == "$current_commit_short" ]]; then
         echo "match: commit (short $current_commit_short)"
-        cd "$oldpwd"
+        popd > /dev/null
         return 0
     else
         echo "no match found for $target_ref"
         printf "Version inconsistency. Please fix ${repo_dir}\n"
         printf "(expected: ${target_ref}, got: ${current_tag} ${current_branch} ${current_commit_long} ${current_commit_short})\n"
-        cd "$oldpwd"
+        popd > /dev/null
         exit 1
     fi
 }

--- a/scripts/utils-general.sh
+++ b/scripts/utils-general.sh
@@ -48,3 +48,42 @@ check_folder_age() {
     fi
 }
 
+# Usage: check_git_match <target_ref> [<repo_dir>]
+check_git_match() {
+    local target_ref="$1"
+    local repo_dir="${2:-.}"
+
+    # Save current directory and move to repo
+    local oldpwd="$PWD"
+    cd "$repo_dir" || return 2
+
+    local current_tag current_branch current_commit_long current_commit_short
+    current_tag=$(git describe --tags --exact-match 2>/dev/null || true)
+    current_branch=$(git symbolic-ref --short HEAD 2>/dev/null || true)
+    current_commit_long=$(git rev-parse HEAD 2>/dev/null || true)
+    current_commit_short=$(git rev-parse --short HEAD 2>/dev/null || true)
+
+    if [[ -n "$current_tag" && "$target_ref" == "$current_tag" ]]; then
+        echo "match: tag ($current_tag)"
+        cd "$oldpwd"
+        return 0
+    elif [[ -n "$current_branch" && "$target_ref" == "$current_branch" ]]; then
+        echo "match: branch ($current_branch)"
+        cd "$oldpwd"
+        return 0
+    elif [[ -n "$current_commit_long" && "$target_ref" == "$current_commit_long" ]]; then
+        echo "match: commit (long $current_commit_long)"
+        cd "$oldpwd"
+        return 0
+    elif [[ -n "$current_commit_short" && "$target_ref" == "$current_commit_short" ]]; then
+        echo "match: commit (short $current_commit_short)"
+        cd "$oldpwd"
+        return 0
+    else
+        echo "no match found for $target_ref"
+        printf "Version inconsistency. Please fix ${repo_dir}\n"
+        printf "(expected: ${target_ref}, got: ${current_tag} ${current_branch} ${current_commit_long} ${current_commit_short})\n"
+        cd "$oldpwd"
+        exit 1
+    fi
+}

--- a/scripts/utils-openssl.sh
+++ b/scripts/utils-openssl.sh
@@ -39,16 +39,7 @@ USE_CUR_TAG=${USE_CUR_TAG:-0}
 
 clone_openssl() {
     if [ -d ${OPENSSL_SOURCE_DIR} ] && [ "$USE_CUR_TAG" != "1" ]; then
-        if [[ "${OPENSSL_TAG}" == openssl-* ]]; then
-            OPENSSL_TAG_CUR=$(cd ${OPENSSL_SOURCE_DIR} && (git describe --tags 2>/dev/null || git branch --show-current 2>/dev/null))
-        else
-            OPENSSL_TAG_CUR=$(cd ${OPENSSL_SOURCE_DIR} && (git branch --show-current 2>/dev/null || git describe --tags 2>/dev/null))
-        fi
-        if [ "${OPENSSL_TAG_CUR}" != "${OPENSSL_TAG}" ]; then # force a rebuild
-            printf "Version inconsistency. Please fix ${OPENSSL_SOURCE_DIR} (expected: ${OPENSSL_TAG}, got: ${OPENSSL_TAG_CUR})\n"
-            do_cleanup
-            exit 1
-        fi
+        check_git_match "${OPENSSL_TAG}" "${OPENSSL_SOURCE_DIR}"
     fi
 
     if [ ! -d ${OPENSSL_SOURCE_DIR} ]; then
@@ -87,7 +78,7 @@ clone_openssl() {
 }
 
 install_openssl() {
-    printf "\nInstalling OpenSSL ${OPENSSL_TAG} ..."
+    printf "\nInstalling OpenSSL ${OPENSSL_TAG} ...\n"
     clone_openssl
     cd ${OPENSSL_SOURCE_DIR}
 

--- a/scripts/utils-openssl.sh
+++ b/scripts/utils-openssl.sh
@@ -39,7 +39,11 @@ USE_CUR_TAG=${USE_CUR_TAG:-0}
 
 clone_openssl() {
     if [ -d ${OPENSSL_SOURCE_DIR} ] && [ "$USE_CUR_TAG" != "1" ]; then
-        OPENSSL_TAG_CUR=$(cd ${OPENSSL_SOURCE_DIR} && (git describe --tags 2>/dev/null || git branch --show-current))
+        if [[ "${OPENSSL_TAG}" == openssl-* ]]; then
+            OPENSSL_TAG_CUR=$(cd ${OPENSSL_SOURCE_DIR} && (git describe --tags 2>/dev/null || git branch --show-current 2>/dev/null))
+        else
+            OPENSSL_TAG_CUR=$(cd ${OPENSSL_SOURCE_DIR} && (git branch --show-current 2>/dev/null || git describe --tags 2>/dev/null))
+        fi
         if [ "${OPENSSL_TAG_CUR}" != "${OPENSSL_TAG}" ]; then # force a rebuild
             printf "Version inconsistency. Please fix ${OPENSSL_SOURCE_DIR} (expected: ${OPENSSL_TAG}, got: ${OPENSSL_TAG_CUR})\n"
             do_cleanup

--- a/scripts/utils-wolfssl.sh
+++ b/scripts/utils-wolfssl.sh
@@ -44,16 +44,7 @@ clone_wolfssl() {
         cp -pr ${WOLFSSL_FIPS_BUNDLE}/* ${WOLFSSL_SOURCE_DIR}/
     else
         if [ -d ${WOLFSSL_SOURCE_DIR} ] && [ "$USE_CUR_TAG" != "1" ]; then
-            if [[ "${WOLFSSL_TAG}" == v* ]] || [[ "${WOLFSSL_TAG}" == *-stable ]]; then
-                WOLFSSL_TAG_CUR=$(cd ${WOLFSSL_SOURCE_DIR} && (git describe --tags 2>/dev/null || git branch --show-current 2>/dev/null))
-            else
-                WOLFSSL_TAG_CUR=$(cd ${WOLFSSL_SOURCE_DIR} && (git branch --show-current 2>/dev/null || git describe --tags 2>/dev/null))
-            fi
-            if [ "${WOLFSSL_TAG_CUR}" != "${WOLFSSL_TAG}" ]; then # force a rebuild
-                printf "Version inconsistency. Please fix ${WOLFSSL_SOURCE_DIR} (expected: ${WOLFSSL_TAG}, got: ${WOLFSSL_TAG_CUR})\n"
-                do_cleanup
-                exit 1
-            fi
+            check_git_match "${WOLFSSL_TAG}" "${WOLFSSL_SOURCE_DIR}"
         fi
 
         if [ ! -d ${WOLFSSL_SOURCE_DIR} ]; then

--- a/scripts/utils-wolfssl.sh
+++ b/scripts/utils-wolfssl.sh
@@ -44,7 +44,11 @@ clone_wolfssl() {
         cp -pr ${WOLFSSL_FIPS_BUNDLE}/* ${WOLFSSL_SOURCE_DIR}/
     else
         if [ -d ${WOLFSSL_SOURCE_DIR} ] && [ "$USE_CUR_TAG" != "1" ]; then
-            WOLFSSL_TAG_CUR=$(cd ${WOLFSSL_SOURCE_DIR} && (git describe --tags 2>/dev/null || git branch --show-current))
+            if [[ "${WOLFSSL_TAG}" == v* ]] || [[ "${WOLFSSL_TAG}" == *-stable ]]; then
+                WOLFSSL_TAG_CUR=$(cd ${WOLFSSL_SOURCE_DIR} && (git describe --tags 2>/dev/null || git branch --show-current 2>/dev/null))
+            else
+                WOLFSSL_TAG_CUR=$(cd ${WOLFSSL_SOURCE_DIR} && (git branch --show-current 2>/dev/null || git describe --tags 2>/dev/null))
+            fi
             if [ "${WOLFSSL_TAG_CUR}" != "${WOLFSSL_TAG}" ]; then # force a rebuild
                 printf "Version inconsistency. Please fix ${WOLFSSL_SOURCE_DIR} (expected: ${WOLFSSL_TAG}, got: ${WOLFSSL_TAG_CUR})\n"
                 do_cleanup


### PR DESCRIPTION
# Description 

Our nightly's are failing [here](https://cloud.wolfssl-test.com/jenkins/job/wolfProvider/job/nightly-scripts-test/399/pipeline-console/) with wolfssl master because the current tag is `v5.8.2-stable` while it is expecting master. This changes the logic so it prioritizes `git branch --show-current` for master and `git describe --tags` for `*-stable || v*`. It will fall back if none of those work to the opposite just like it did before. 
- Now it can also take commit hashes like `b077c81eb635392e694ccedbab8b644297ec0285` or `b077c81` when building by setting `WOLFSSL_TAG` or `OPENSSL_TAG` with the commit. 