### PR TITLE
wolfprovider build script updates

### DIFF
--- a/scripts/build-wolfprovider.sh
+++ b/scripts/build-wolfprovider.sh
@@ -6,25 +6,32 @@ show_help() {
   echo "Usage: $0"
   echo ""
   echo "Script Arguments:"
-  echo "  --help, -help, -h      Display this help menu and exit"
-  echo "  --debug                Builds OpenSSL, wolfSSL, and WolfProvider with debugging enabled"
-  echo "  --openssl-ver=VER      Which version of OpenSSL to clone"
-  echo "  --wolfssl-ver=VER      Which version of wolfSSL to clone"
-  echo "  --enable-fips          Build wolfProvider with a cloned FIPS bundle. Cloned FIPS bundle can be changed with --fips-check"
-  echo "  --fips-bundle=DIR      Build wolfProvider with a directory containing a wolfSSL FIPS bundle instead of cloning from GitHub. Requires a FIPS version to be given by --fips-version"
-  echo "  --fips-check=TAG       Choose a FIPS tag to clone. May require a version to be given by --fips-version"
-  echo "  --fips-version=VER     Choose the wolfSSL FIPS version"
-  echo "  --quicktest            Disable some tests for a faster testing suite"
+  echo "  --help, -help, -h          Display this help menu and exit"
+  echo "  --clean                    Run make clean in OpenSSL, wolfSSL, and wolfProvider"
+  echo "  --distclean                Remove source directories of OpenSSL and wolfSSL. If using wolfProvider it must be disabled or cloning will fail"
+  echo "  --debug                    Builds OpenSSL, wolfSSL, and WolfProvider with debugging enabled. This is the same as setting WOLFPROV_DEBUG=1"
+  echo "  --debug-asn-template       Enable debug information for asn within wolfSSL"
+  echo "  --disable-err-trace        No debug trace messages from library errors in wolfSSL"
+  echo "  --openssl-ver=VER          Which version of OpenSSL to clone"
+  echo "  --wolfssl-ver=VER          Which version of wolfSSL to clone"
+  echo "  --enable-fips              Build wolfProvider with a cloned FIPS bundle. Cloned FIPS bundle can be changed with --fips-check"
+  echo "  --fips-bundle=DIR          Build wolfProvider with a directory containing a wolfSSL FIPS bundle instead of cloning from GitHub. Requires a FIPS version to be given by --fips-version"
+  echo "  --fips-check=TAG           Choose a FIPS tag to clone. May require a version to be given by --fips-version"
+  echo "  --fips-version=VER         Choose the wolfSSL FIPS version"
+  echo "  --quicktest                Disable some tests for a faster testing suite"
   echo ""
   echo "Environment Variables:"
-  echo "  OPENSSL_TAG            OpenSSL tag to use (e.g., openssl-3.5.0)"
-  echo "  WOLFSSL_TAG            wolfSSL tag to use (e.g., v5.8.0-stable)"
-  echo "  WOLFPROV_DEBUG         If set to 1, builds OpenSSL, wolfSSL, and wolfProvider with debug options enabled"
-  echo "  WOLFSSL_ISFIPS         If set to 1, clones a wolfSSL FIPS bundle from GitHub"
-  echo "  WOLFSSL_FIPS_BUNDLE    Directory containing the wolfSSL FIPS bundle to use instead of cloning from GitHub"
-  echo "  WOLFSSL_FIPS_VERSION   Version of wolfSSL FIPS bundle (v5, v6, ready), used as an argument for --enable-fips when configuring wolfSSL"
-  echo "  WOLFSSL_FIPS_CHECK_TAG Tag for wolfSSL FIPS bundle (linuxv5.2.1, v6.0.0, etc), used as an argument for fips-check.sh when cloning a wolfSSL FIPS version"
-  echo "  WOLFPROV_QUICKTEST     If set to 1, disables some tests in the test suite to increase test speed"
+  echo "  OPENSSL_TAG                OpenSSL tag to use (e.g., openssl-3.5.0)"
+  echo "  WOLFSSL_TAG                wolfSSL tag to use (e.g., v5.8.0-stable)"
+  echo "  WOLFSSL_ISFIPS             If set to 1, clones a wolfSSL FIPS bundle from GitHub"
+  echo "  WOLFSSL_FIPS_BUNDLE        Directory containing the wolfSSL FIPS bundle to use instead of cloning from GitHub"
+  echo "  WOLFSSL_FIPS_VERSION       Version of wolfSSL FIPS bundle (v5, v6, ready), used as an argument for --enable-fips when configuring wolfSSL"
+  echo "  WOLFSSL_FIPS_CHECK_TAG     Tag for wolfSSL FIPS bundle (linuxv5.2.1, v6.0.0, etc), used as an argument for fips-check.sh when cloning a wolfSSL FIPS version"
+  echo "  WOLFPROV_CLEAN             If set to 1, run make clean in OpenSSL, wolfSSL, and wolfProvider"
+  echo "  WOLFPROV_DISTCLEAN         If set to 1, remove the source directories of OpenSSL and wolfSSL"
+  echo "  WOLFPROV_DEBUG             If set to 1, builds OpenSSL, wolfSSL, and wolfProvider with debug options enabled"
+  echo "  WOLFPROV_QUICKTEST         If set to 1, disables some tests in the test suite to increase test speed"
+  echo "  WOLFPROV_DISABLE_ERR_TRACE If set to 1, wolfSSL will not be configured with --enable-debug-trace-errcodes=backtrace"
   echo ""
 }
 
@@ -37,8 +44,20 @@ for arg in "$@"; do
             show_help
             exit 0
             ;;
+        --clean)
+            WOLFPROV_CLEAN=1
+            ;;
+        --distclean)
+            WOLFPROV_DISTCLEAN=1
+            ;;
         --debug)
             WOLFPROV_DEBUG=1
+            ;;
+        --debug-asn-template)
+            WOLFSSL_DEBUG_ASN_TEMPLATE=1
+            ;;
+        --disable-err-trace)
+            WOLFPROV_DISABLE_ERR_TRACE=1
             ;;
         --openssl-ver=*)
             IFS='=' read -r trash ossl_ver <<< "$arg"
@@ -91,7 +110,7 @@ for arg in "$@"; do
             WOLFPROV_QUICKTEST=1
             ;;
         *)
-            args_wrong+="$arg "
+            args_wrong+="$arg, "
             ;;
     esac
 done

--- a/scripts/build-wolfprovider.sh
+++ b/scripts/build-wolfprovider.sh
@@ -8,7 +8,7 @@ show_help() {
   echo "Script Arguments:"
   echo "  --help, -help, -h          Display this help menu and exit"
   echo "  --clean                    Run make clean in OpenSSL, wolfSSL, and wolfProvider"
-  echo "  --distclean                Remove source directories of OpenSSL and wolfSSL. If using wolfProvider it must be disabled or cloning will fail"
+  echo "  --distclean                Remove source directories of OpenSSL and wolfSSL"
   echo "  --debug                    Builds OpenSSL, wolfSSL, and WolfProvider with debugging enabled. This is the same as setting WOLFPROV_DEBUG=1"
   echo "  --debug-asn-template       Enable debug information for asn within wolfSSL"
   echo "  --disable-err-trace        No debug trace messages from library errors in wolfSSL"

--- a/scripts/build-wolfprovider.sh
+++ b/scripts/build-wolfprovider.sh
@@ -2,26 +2,116 @@
 # This script provides the bare minimum function definitions for compiling
 # the wolfProvider library
 
-SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-LOG_FILE=${SCRIPT_DIR}/build-release.log
-source ${SCRIPT_DIR}/utils-wolfprovider.sh
-
 show_help() {
   echo "Usage: $0"
   echo ""
+  echo "Script Arguments:"
+  echo "  --help, -help, -h      Display this help menu and exit"
+  echo "  --debug                Builds OpenSSL, wolfSSL, and WolfProvider with debugging enabled"
+  echo "  --openssl-ver=VER      Which version of OpenSSL to clone"
+  echo "  --wolfssl-ver=VER      Which version of wolfSSL to clone"
+  echo "  --enable-fips          Build wolfProvider with a cloned FIPS bundle. Cloned FIPS bundle can be changed with --fips-check"
+  echo "  --fips-bundle=DIR      Build wolfProvider with a directory containing a wolfSSL FIPS bundle instead of cloning from GitHub. Requires a FIPS version to be given by --fips-version"
+  echo "  --fips-check=TAG       Choose a FIPS tag to clone. May require a version to be given by --fips-version"
+  echo "  --fips-version=VER     Choose the wolfSSL FIPS version"
+  echo "  --quicktest            Disable some tests for a faster testing suite"
+  echo ""
   echo "Environment Variables:"
-  echo "  OPENSSL_TAG          OpenSSL tag to use (e.g., openssl-3.5.0)"
-  echo "  WOLFSSL_TAG          wolfSSL tag to use (e.g., v5.8.0-stable)"
-  echo "  WOLFPROV_DEBUG       If set to 1, builds OpenSSL, wolfSSL, and wolfProvider with debug options enabled"
-  echo "  WOLFSSL_FIPS_BUNDLE  Directory containing the wolfSSL FIPS bundle to use instead of cloning from GitHub"
-  echo "  WOLFSSL_FIPS_VERSION Version of wolfSSL FIPS bundle (v5, v6, ready), used as an argument for --enable-fips when configuring wolfSSL"
+  echo "  OPENSSL_TAG            OpenSSL tag to use (e.g., openssl-3.5.0)"
+  echo "  WOLFSSL_TAG            wolfSSL tag to use (e.g., v5.8.0-stable)"
+  echo "  WOLFPROV_DEBUG         If set to 1, builds OpenSSL, wolfSSL, and wolfProvider with debug options enabled"
+  echo "  WOLFSSL_ISFIPS         If set to 1, clones a wolfSSL FIPS bundle from GitHub"
+  echo "  WOLFSSL_FIPS_BUNDLE    Directory containing the wolfSSL FIPS bundle to use instead of cloning from GitHub"
+  echo "  WOLFSSL_FIPS_VERSION   Version of wolfSSL FIPS bundle (v5, v6, ready), used as an argument for --enable-fips when configuring wolfSSL"
+  echo "  WOLFSSL_FIPS_CHECK_TAG Tag for wolfSSL FIPS bundle (linuxv5.2.1, v6.0.0, etc), used as an argument for fips-check.sh when cloning a wolfSSL FIPS version"
+  echo "  WOLFPROV_QUICKTEST     If set to 1, disables some tests in the test suite to increase test speed"
   echo ""
 }
 
-if [[ "$1" == "--help" || "$1" == "-h" || "$1" == "-help" ]]; then
-  show_help
-  exit 0
+args_wrong=""
+args=""
+for arg in "$@"; do
+    args+="$arg, "
+    case "$arg" in
+        --help | -help | -h)
+            show_help
+            exit 0
+            ;;
+        --debug)
+            WOLFPROV_DEBUG=1
+            ;;
+        --openssl-ver=*)
+            IFS='=' read -r trash ossl_ver <<< "$arg"
+            if [ -z "$ossl_ver" ]; then
+                echo "No version given for --openssl-ver"
+                args_wrong+="$arg, "
+            fi
+            OPENSSL_TAG="$ossl_ver"
+            ;;
+        --wolfssl-ver=*)
+            IFS='=' read -r trash wolf_ver <<< "$arg"
+            if [ -z "$wolf_ver" ]; then
+                echo "No version given for --wolfssl-ver"
+                args_wrong+="$arg, "
+            fi
+            WOLFSSL_TAG="$wolf_ver"
+            ;;
+        --enable-fips)
+            unset WOLFSSL_FIPS_BUNDLE
+            WOLFSSL_ISFIPS=1
+            ;;
+        --fips-bundle=*)
+            unset WOLFSSL_ISFIPS
+            unset WOLFSSL_FIPS_CHECK_TAG
+            IFS='=' read -r trash fips_bun <<< "$arg"
+            if [ -z "$fips_bun" ]; then
+                echo "No directory given for --fips-bundle"
+                args_wrong+="$arg, "
+            fi
+            WOLFSSL_FIPS_BUNDLE="$fips_bun"
+            ;;
+        --fips-check=*)
+            unset WOLFSSL_FIPS_BUNDLE
+            IFS='=' read -r trash fips_tag <<< "$arg"
+            if [ -z "$fips_tag" ]; then
+                echo "No tag given for --fips-check"
+                args_wrong+="$arg, "
+            fi
+            WOLFSSL_FIPS_CHECK_TAG="$fips_tag"
+            ;;
+        --fips-version=*)
+            IFS='=' read -r trash fips_ver <<< "$arg"
+            if [ -z "$fips_ver" ]; then
+                echo "No version given for --fips-version"
+                args_wrong+="$arg, "
+            fi
+            WOLFSSL_FIPS_VERSION="$fips_ver"
+            ;;
+        --quicktest)
+            WOLFPROV_QUICKTEST=1
+            ;;
+        *)
+            args_wrong+="$arg "
+            ;;
+    esac
+done
+
+if [ -n "$args_wrong" ]; then
+    args_wrong="`echo $args_wrong | head -c -2 -`"
+    echo "Unrecognized argument(s) provided: $args_wrong"
+    echo "Use --help to see a list of arguments"
+    exit 1
 fi
+
+if [ -n "$args" ]; then
+    args="`echo $args | head -c -2 -`"
+    echo "Building wolfProvider with: $args"
+    echo ""
+fi
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+LOG_FILE=${SCRIPT_DIR}/build-release.log
+source ${SCRIPT_DIR}/utils-wolfprovider.sh
 
 echo "Using openssl: $OPENSSL_TAG, wolfssl: $WOLFSSL_TAG"
 

--- a/scripts/utils-general.sh
+++ b/scripts/utils-general.sh
@@ -27,27 +27,6 @@ if [ "$UTILS_GENERAL_LOADED" != "yes" ]; then # only set once
     export UTILS_GENERAL_LOADED=yes
 fi
 
-check_folder_age() {
-    folderA=$1
-    folderB=$2
-
-    if [[ "$OSTYPE" == "darwin"* ]]; then
-        folderA_age=$(find "$folderA" -type f -exec stat -f '%Dm' {} \; | sort -n | tail -n 1)
-        folderB_age=$(find "$folderB" -type f -exec stat -f '%Dm' {} \; | sort -n | tail -n 1)
-    else
-        folderA_age=$(find "$folderA" -type f -printf '%T@' | sort -n | tail -n 1)
-        folderB_age=$(find "$folderB" -type f -printf '%T@' | sort -n | tail -n 1)
-    fi
-
-    if awk "BEGIN {exit !($folderA_age > $folderB_age)}"; then
-        echo 1
-    elif awk "BEGIN {exit !($folderA_age < $folderB_age)}"; then
-        echo -1
-    else
-        echo 0
-    fi
-}
-
 # Usage: check_git_match <target_ref> [<repo_dir>]
 check_git_match() {
     local target_ref="$1"

--- a/scripts/utils-openssl.sh
+++ b/scripts/utils-openssl.sh
@@ -37,6 +37,22 @@ NUMCPU=${NUMCPU:-8}
 WOLFPROV_DEBUG=${WOLFPROV_DEBUG:-0}
 USE_CUR_TAG=${USE_CUR_TAG:-0}
 
+clean_openssl() {
+    printf "\n"
+
+    if [ "$WOLFPROV_CLEAN" -eq "1" ]; then
+        printf "Cleaning OpenSSL ...\n"
+        if [ -f "${OPENSSL_SOURCE_DIR}/Makefile" ]; then
+            make -C "${OPENSSL_SOURCE_DIR}" clean >>$LOG_FILE 2>&1
+        fi
+        rm -rf "${OPENSSL_INSTALL_DIR}"
+    fi
+    if [ "$WOLFPROV_DISTCLEAN" -eq "1" ]; then
+        printf "Removing OpenSSL source ...\n"
+        rm -rf "${OPENSSL_SOURCE_DIR}"
+    fi
+}
+
 clone_openssl() {
     if [ -d ${OPENSSL_SOURCE_DIR} ] && [ "$USE_CUR_TAG" != "1" ]; then
         check_git_match "${OPENSSL_TAG}" "${OPENSSL_SOURCE_DIR}"
@@ -78,21 +94,7 @@ clone_openssl() {
 }
 
 install_openssl() {
-    printf "\n"
-
-    if [ "$WOLFPROV_CLEAN" -eq "1" ]; then
-        printf "Cleaning OpenSSL ...\n"
-        if [ -f "${OPENSSL_SOURCE_DIR}/Makefile" ]; then
-            make -C "${OPENSSL_SOURCE_DIR}" clean >>$LOG_FILE 2>&1
-        fi
-        rm -rf "${OPENSSL_INSTALL_DIR}"
-    fi
-    if [ -d "${OPENSSL_SOURCE_DIR}" ] && [ "$WOLFPROV_DISTCLEAN" -eq "1" ]; then
-        printf "Removing OpenSSL source ...\n"
-        rm -rf "${OPENSSL_SOURCE_DIR}"
-    fi
-
-    printf "Installing OpenSSL ${OPENSSL_TAG} ...\n"
+    printf "\nInstalling OpenSSL ${OPENSSL_TAG} ...\n"
     clone_openssl
     cd ${OPENSSL_SOURCE_DIR}
 

--- a/scripts/utils-openssl.sh
+++ b/scripts/utils-openssl.sh
@@ -78,7 +78,21 @@ clone_openssl() {
 }
 
 install_openssl() {
-    printf "\nInstalling OpenSSL ${OPENSSL_TAG} ...\n"
+    printf "\n"
+
+    if [ "$WOLFPROV_CLEAN" -eq "1" ]; then
+        printf "Cleaning OpenSSL ...\n"
+        if [ -f "${OPENSSL_SOURCE_DIR}/Makefile" ]; then
+            make -C "${OPENSSL_SOURCE_DIR}" clean >>$LOG_FILE 2>&1
+        fi
+        rm -rf "${OPENSSL_INSTALL_DIR}"
+    fi
+    if [ -d "${OPENSSL_SOURCE_DIR}" ] && [ "$WOLFPROV_DISTCLEAN" -eq "1" ]; then
+        printf "Removing OpenSSL source ...\n"
+        rm -rf "${OPENSSL_SOURCE_DIR}"
+    fi
+
+    printf "Installing OpenSSL ${OPENSSL_TAG} ...\n"
     clone_openssl
     cd ${OPENSSL_SOURCE_DIR}
 

--- a/scripts/utils-wolfprovider.sh
+++ b/scripts/utils-wolfprovider.sh
@@ -43,11 +43,26 @@ WOLFPROV_PATH=$WOLFPROV_INSTALL_DIR/lib
 
 WOLFPROV_DEBUG=${WOLFPROV_DEBUG:-0}
 
+WOLFPROV_CLEAN=${WOLFPROV_CLEAN:-0}
+WOLFPROV_DISTCLEAN=${WOLFPROV_DISTCLEAN:-0}
+
 install_wolfprov() {
     cd ${WOLFPROV_SOURCE_DIR}
 
     init_openssl
     init_wolfssl
+
+    printf "\n"
+
+    if [ "$WOLFPROV_CLEAN" -eq "1" ]; then
+        printf "Cleaning wolfProvider ...\n"
+        if [ -f "Makefile" ]; then
+            make clean >>$LOG_FILE 2>&1
+        fi
+        rm -rf ${WOLFPROV_INSTALL_DIR}
+    fi
+
+    printf "Consolidating wolfProvider ...\n"
     unset OPENSSL_MODULES
     unset OPENSSL_CONF
     printf "LD_LIBRARY_PATH: $LD_LIBRARY_PATH\n"

--- a/scripts/utils-wolfprovider.sh
+++ b/scripts/utils-wolfprovider.sh
@@ -52,57 +52,55 @@ install_wolfprov() {
     unset OPENSSL_CONF
     printf "LD_LIBRARY_PATH: $LD_LIBRARY_PATH\n"
 
-    if [ ! -d ${WOLFPROV_INSTALL_DIR} ] || [ $(check_folder_age "${WOLFPROV_INSTALL_DIR}" "${WOLFSSL_INSTALL_DIR}") -lt 0 ] || [ $(check_folder_age "${WOLFPROV_INSTALL_DIR}" "${OPENSSL_INSTALL_DIR}") -lt 0 ]; then
-        printf "\tConfigure wolfProvider ... "
-        if [ ! -e "${WOLFPROV_SOURCE_DIR}/configure" ]; then
-            ./autogen.sh >>$LOG_FILE 2>&1
-        fi
-
-        if [ "$WOLFPROV_DEBUG" = "1" ]; then
-            WOLFPROV_CONFIG_OPTS+=" --enable-debug"
-        fi
-
-        ./configure ${WOLFPROV_CONFIG_OPTS} CFLAGS="${WOLFPROV_CONFIG_CFLAGS}" >>$LOG_FILE 2>&1
-        RET=$?
-
-        if [ $RET != 0 ]; then
-            printf "\n\n...\n"
-            tail -n 40 $LOG_FILE
-            do_cleanup
-            exit 1
-        fi
-        printf "Done.\n"
-
-        printf "\tBuild wolfProvider ... "
-        make -j$NUMCPU >>$LOG_FILE 2>&1
-        if [ $? != 0 ]; then
-            printf "\n\n...\n"
-            tail -n 40 $LOG_FILE
-            do_cleanup
-            exit 1
-        fi
-        printf "Done.\n"
-
-        printf "\tTest wolfProvider ... "
-        make test >>$LOG_FILE 2>&1
-        if [ $? != 0 ]; then
-            printf "\n\n...\n"
-            tail -n 40 $LOG_FILE
-            do_cleanup
-            exit 1
-        fi
-        printf "Done.\n"
-
-        printf "\tInstall wolfProvider ... "
-        make install >>$LOG_FILE 2>&1
-        if [ $? != 0 ]; then
-            printf "\n\n...\n"
-            tail -n 40 $LOG_FILE
-            do_cleanup
-            exit 1
-        fi
-        printf "Done.\n"
+    printf "\tConfigure wolfProvider ... "
+    if [ ! -e "${WOLFPROV_SOURCE_DIR}/configure" ]; then
+        ./autogen.sh >>$LOG_FILE 2>&1
     fi
+
+    if [ "$WOLFPROV_DEBUG" = "1" ]; then
+        WOLFPROV_CONFIG_OPTS+=" --enable-debug"
+    fi
+
+    ./configure ${WOLFPROV_CONFIG_OPTS} CFLAGS="${WOLFPROV_CONFIG_CFLAGS}" >>$LOG_FILE 2>&1
+    RET=$?
+
+    if [ $RET != 0 ]; then
+        printf "\n\n...\n"
+        tail -n 40 $LOG_FILE
+        do_cleanup
+        exit 1
+    fi
+    printf "Done.\n"
+
+    printf "\tBuild wolfProvider ... "
+    make -j$NUMCPU >>$LOG_FILE 2>&1
+    if [ $? != 0 ]; then
+        printf "\n\n...\n"
+        tail -n 40 $LOG_FILE
+        do_cleanup
+        exit 1
+    fi
+    printf "Done.\n"
+
+    printf "\tTest wolfProvider ... "
+    make test >>$LOG_FILE 2>&1
+    if [ $? != 0 ]; then
+        printf "\n\n...\n"
+        tail -n 40 $LOG_FILE
+        do_cleanup
+        exit 1
+    fi
+    printf "Done.\n"
+
+    printf "\tInstall wolfProvider ... "
+    make install >>$LOG_FILE 2>&1
+    if [ $? != 0 ]; then
+        printf "\n\n...\n"
+        tail -n 40 $LOG_FILE
+        do_cleanup
+        exit 1
+    fi
+    printf "Done.\n"
 }
 
 init_wolfprov() {

--- a/scripts/utils-wolfprovider.sh
+++ b/scripts/utils-wolfprovider.sh
@@ -46,12 +46,7 @@ WOLFPROV_DEBUG=${WOLFPROV_DEBUG:-0}
 WOLFPROV_CLEAN=${WOLFPROV_CLEAN:-0}
 WOLFPROV_DISTCLEAN=${WOLFPROV_DISTCLEAN:-0}
 
-install_wolfprov() {
-    cd ${WOLFPROV_SOURCE_DIR}
-
-    init_openssl
-    init_wolfssl
-
+clean_wolfprov() {
     printf "\n"
 
     if [ "$WOLFPROV_CLEAN" -eq "1" ]; then
@@ -61,8 +56,15 @@ install_wolfprov() {
         fi
         rm -rf ${WOLFPROV_INSTALL_DIR}
     fi
+}
 
-    printf "Consolidating wolfProvider ...\n"
+install_wolfprov() {
+    cd ${WOLFPROV_SOURCE_DIR}
+
+    init_openssl
+    init_wolfssl
+
+    printf "\nConsolidating wolfProvider ...\n"
     unset OPENSSL_MODULES
     unset OPENSSL_CONF
     printf "LD_LIBRARY_PATH: $LD_LIBRARY_PATH\n"
@@ -119,17 +121,23 @@ install_wolfprov() {
 }
 
 init_wolfprov() {
-    # Unset WPFF so we dont fail unit test when building
-    if [ "${WOLFPROV_FORCE_FAIL}" = "1" ]; then
-        unset WOLFPROV_FORCE_FAIL
-        install_wolfprov
-        export WOLFPROV_FORCE_FAIL=1
+    if [ "$WOLFPROV_CLEAN" -eq "1" ] || [ "$WOLFPROV_DISTCLEAN" -eq "1" ]; then
+        clean_openssl
+        clean_wolfssl
+        clean_wolfprov
     else
-        install_wolfprov
-    fi
-    printf "\twolfProvider installed in: ${WOLFPROV_INSTALL_DIR}\n"
+        # Unset WPFF so we dont fail unit test when building
+        if [ "${WOLFPROV_FORCE_FAIL}" = "1" ]; then
+            unset WOLFPROV_FORCE_FAIL
+            install_wolfprov
+            export WOLFPROV_FORCE_FAIL=1
+        else
+            install_wolfprov
+        fi
+        printf "\twolfProvider installed in: ${WOLFPROV_INSTALL_DIR}\n"
 
-    export OPENSSL_MODULES=$WOLFPROV_PATH
-    export OPENSSL_CONF=${WOLFPROV_CONFIG}
+        export OPENSSL_MODULES=$WOLFPROV_PATH
+        export OPENSSL_CONF=${WOLFPROV_CONFIG}
+    fi
 }
 

--- a/scripts/utils-wolfssl.sh
+++ b/scripts/utils-wolfssl.sh
@@ -65,11 +65,28 @@ clone_wolfssl() {
                 exit 1
             fi
             printf "Done.\n"
+        else
+            printf "\twolfSSL source directory exists: ${WOLFSSL_SOURCE_DIR}\n"
         fi
     fi
 }
 
 install_wolfssl() {
+    printf "\n"
+
+    if [ "$WOLFPROV_CLEAN" -eq "1" ]; then
+        printf "Cleaning wolfSSL ...\n"
+        if [ -f "${WOLFSSL_SOURCE_DIR}/Makefile" ]; then
+            make -C "${WOLFSSL_SOURCE_DIR}" clean >>$LOG_FILE 2>&1
+        fi
+        rm -rf "${WOLFSSL_INSTALL_DIR}"
+    fi
+    if [ -d "${WOLFSSL_SOURCE_DIR}" ] && [ "$WOLFPROV_DISTCLEAN" -eq "1" ]; then
+        printf "Removing wolfSSL source ...\n"
+        rm -rf "${WOLFSSL_SOURCE_DIR}"
+    fi
+
+    printf "Installing wolfSSL ${WOLFSSL_TAG} ...\n"
     clone_wolfssl
     cd ${WOLFSSL_SOURCE_DIR}
 

--- a/scripts/utils-wolfssl.sh
+++ b/scripts/utils-wolfssl.sh
@@ -36,6 +36,22 @@ WOLFPROV_DISABLE_ERR_TRACE=${WOLFPROV_DISABLE_ERR_TRACE:-0}
 WOLFPROV_DEBUG=${WOLFPROV_DEBUG:-0}
 USE_CUR_TAG=${USE_CUR_TAG:-0}
 
+clean_wolfssl() {
+    printf "\n"
+
+    if [ "$WOLFPROV_CLEAN" -eq "1" ]; then
+        printf "Cleaning wolfSSL ...\n"
+        if [ -f "${WOLFSSL_SOURCE_DIR}/Makefile" ]; then
+            make -C "${WOLFSSL_SOURCE_DIR}" clean >>$LOG_FILE 2>&1
+        fi
+        rm -rf "${WOLFSSL_INSTALL_DIR}"
+    fi
+    if [ "$WOLFPROV_DISTCLEAN" -eq "1" ]; then
+        printf "Removing wolfSSL source ...\n"
+        rm -rf "${WOLFSSL_SOURCE_DIR}"
+    fi
+}
+
 # Depends on OPENSSL_INSTALL_DIR
 clone_wolfssl() {
     if [ -n "$WOLFSSL_FIPS_BUNDLE" ]; then
@@ -72,21 +88,7 @@ clone_wolfssl() {
 }
 
 install_wolfssl() {
-    printf "\n"
-
-    if [ "$WOLFPROV_CLEAN" -eq "1" ]; then
-        printf "Cleaning wolfSSL ...\n"
-        if [ -f "${WOLFSSL_SOURCE_DIR}/Makefile" ]; then
-            make -C "${WOLFSSL_SOURCE_DIR}" clean >>$LOG_FILE 2>&1
-        fi
-        rm -rf "${WOLFSSL_INSTALL_DIR}"
-    fi
-    if [ -d "${WOLFSSL_SOURCE_DIR}" ] && [ "$WOLFPROV_DISTCLEAN" -eq "1" ]; then
-        printf "Removing wolfSSL source ...\n"
-        rm -rf "${WOLFSSL_SOURCE_DIR}"
-    fi
-
-    printf "Installing wolfSSL ${WOLFSSL_TAG} ...\n"
+    printf "\nInstalling wolfSSL ${WOLFSSL_TAG} ...\n"
     clone_wolfssl
     cd ${WOLFSSL_SOURCE_DIR}
 

--- a/scripts/utils-wolfssl.sh
+++ b/scripts/utils-wolfssl.sh
@@ -104,12 +104,20 @@ install_wolfssl() {
             WOLFSSL_CONFIG_CFLAGS=$WOLFSSL_FIPS_CONFIG_CFLAGS
         elif [ "$WOLFSSL_ISFIPS" = "1" ]; then
             printf "with FIPS ... "
-            CONF_ARGS+=" --enable-fips=v5"
+            if [ -n "$WOLFSSL_FIPS_VERSION" ]; then
+                CONF_ARGS+=" --enable-fips=$WOLFSSL_FIPS_VERSION"
+            else
+                CONF_ARGS+=" --enable-fips=v5"
+            fi
             WOLFSSL_CONFIG_OPTS=$WOLFSSL_FIPS_CONFIG_OPTS
             WOLFSSL_CONFIG_CFLAGS=$WOLFSSL_FIPS_CONFIG_CFLAGS
             if [ ! -e "XXX-fips-test" ]; then
                 # Sometimes the system OpenSSL is different than the one we're using. So for the 'git' commands, we'll just use whatever the system comes with
-                LD_LIBRARY_PATH="" ./fips-check.sh linuxv5.2.1 keep nomakecheck >>$LOG_FILE 2>&1
+                if [ -n "$WOLFSSL_FIPS_CHECK_TAG" ]; then
+                    LD_LIBRARY_PATH="" ./fips-check.sh "$WOLFSSL_FIPS_CHECK_TAG" keep nomakecheck >>$LOG_FILE 2>&1
+                else
+                    LD_LIBRARY_PATH="" ./fips-check.sh linuxv5.2.1 keep nomakecheck >>$LOG_FILE 2>&1
+                fi
                 if [ $? != 0 ]; then
                     printf "ERROR checking out FIPS\n"
                     rm -rf ${WOLFSSL_INSTALL_DIR}


### PR DESCRIPTION
wolfProvider will now always build, no matter what
added -- style script args:
  * --debug -> just sets WOLFPROV_DEBUG during the script
  * --wolfssl-ver=, --openssl-ver= -> set the wolfssl or openssl version to be cloned
  * --enable-fips -> might need to change this name (--clone-fips?). Will clone a FIPS bundle to use for wolfProvider. Allows defaults to be overridden with --fips-check and --fips-version
  * --fips-bundle= -> specify the directory to copy a FIPS bundle from. Will also need to use --fips-version.
  * --fips-check= -> a version of FIPS to clone. Any of the args which can be given to wolfssl/fips-check.sh are valid
  * --fips-version= -> the version of FIPS being used which will be (v5, v6, etc.). Used in ./configure --enable-fips=[VERSION]
  * --quicktest -> disable some tests for quicker test suite

examples:
* ./build-wolfprovider.sh --enable-fips --fips-check=v6.0.0 --fips-version=v6  ->  will clone v6.0.0 FIPS and configure with --enable-fips=v6
* ./build-wolfprovider.sh --enable-fips  ->  default behavior. clone linuxv5.2.1 FIPS and configure with --enable-fips=v5
* ./build-wolfprovider --fips-bundle=/dir/to/fips/bundle --fips-version=bundle_version  ->  copy FIPS bundle over and configure with the provided bundle_version

addendum:
* Added --disable-err-trace and --debug-asn-template for --debug manipulation
* Added --clean and --distclean for purging the *-install and *-source directories respectively. They may be used solo or together.
* Made formatting more consistent when installing OpenSSL, wolfSSL, and wolfProvider.
* Added logging for the --clean and --distclean arguments.

addendum2:
* --clean and --distclean now prevent wolfProvider from building