### PR TITLE
Macro rename and compiler error fix

### DIFF
--- a/include/wolfprovider/settings.h
+++ b/include/wolfprovider/settings.h
@@ -120,7 +120,7 @@
 #ifndef NO_RSA
     #define WP_HAVE_RSA
     #if defined(WC_RSA_PSS) && LIBWOLFSSL_VERSION_HEX >= 0x05005000
-        #define WOLFSSL_RSA_PSS_ENCODING
+        #define WP_RSA_PSS_ENCODING
     #endif
 #endif
 

--- a/src/wp_wolfprov.c
+++ b/src/wp_wolfprov.c
@@ -736,7 +736,7 @@ static const OSSL_ALGORITHM wolfprov_encoder[] = {
     { WP_NAMES_RSA, WP_ENCODER_PROPERTIES(type-specific, pem),
       wp_rsa_kp_pem_encoder_functions,
       "" },
-#ifdef WOLFSSL_RSA_PSS_ENCODING
+#ifdef WP_RSA_PSS_ENCODING
     { WP_NAMES_RSA_PSS, WP_ENCODER_PROPERTIES(SubjectPublicKeyInfo, der),
       wp_rsapss_spki_der_encoder_functions,
       "" },

--- a/test/test_tls1_prf.c
+++ b/test/test_tls1_prf.c
@@ -28,7 +28,7 @@ static int test_tls1_prf_calc(OSSL_LIB_CTX* libCtx, unsigned char *key,
     int err = 0;
     EVP_PKEY_CTX *ctx = NULL;
     unsigned char secret[32] = { 0, };
-    unsigned char label[5] = "Label";
+    unsigned char label[] = "Label";
     unsigned char seed[32] = { 0, };
     size_t len = keyLen;
 


### PR DESCRIPTION
`WOLFSSL_RSA_PSS_ENCODING` macro is not used in wolfSSL but is prefaced with WOLFSSL instead of WP.

Fixed test case for my compiler as well by updating array length to 6.
associated error:
```
test/test_tls1_prf.c: In function ‘test_tls1_prf_calc’:
test/test_tls1_prf.c:31:30: error: initializer-string for array of ‘unsigned char’ truncates NUL terminator but destination lacks ‘nonstring’ attribute (6 chars into 5 available) [-Werror=unterminated-string-initialization]
   31 |     unsigned char label[5] = "Label";
      |                              ^~~~~~~
```
compiler version: gcc (GCC) 15.1.1 20250521 (Red Hat 15.1.1-2)