### PR TITLE
disables MD5 on FIPS builds and adds WP_ALLOW_NON_FIPS flag

### DIFF
--- a/src/wp_des.c
+++ b/src/wp_des.c
@@ -31,7 +31,7 @@
 
 
 #if defined(WP_HAVE_DES3CBC)
-
+#if !defined(HAVE_FIPS) || defined(WP_ALLOW_NON_FIPS)
 /**
  * Data structure for DES3 ciphers that are block based.
  */
@@ -283,7 +283,6 @@ static int wp_des3_block_init(wp_Des3BlockCtx *ctx, const unsigned char *key,
     if (!wolfssl_prov_is_running()) {
         ok = 0;
     }
-
     if (ok && (iv != NULL) && (ctx->mode != EVP_CIPH_ECB_MODE) &&
             (!wp_des3_init_iv(ctx, iv, ivLen))) {
         ok = 0;
@@ -866,6 +865,33 @@ IMPLEMENT_DES3_BLOCK_DISPATCH(lcmode, kBits, ivBits)
 /** wp_des3cbc_functions_functions */
 IMPLEMENT_DES3_BLOCK(cbc, CBC, 192, 64)
 
+#else /* defined(HAVE_FIPS) && !defined(WP_ALLOW_NON_FIPS */
 
-#endif /* WP_HAVE_AESCBC || WP_HAVE_AESECB */
+#define IMPLEMENT_DES3_BLOCK_NULL(mode)                                        \
+const OSSL_DISPATCH wp_des3##mode##_functions[] = {                            \
+    { OSSL_FUNC_CIPHER_NEWCTX,          (DFUNC)wp_des3_null                 }, \
+    { OSSL_FUNC_CIPHER_FREECTX,         (DFUNC)wp_des3_void                 }, \
+    { OSSL_FUNC_CIPHER_DUPCTX,          (DFUNC)wp_des3_null                 }, \
+    { OSSL_FUNC_CIPHER_ENCRYPT_INIT,    (DFUNC)wp_des3_null                 }, \
+    { OSSL_FUNC_CIPHER_DECRYPT_INIT,    (DFUNC)wp_des3_null                 }, \
+    { OSSL_FUNC_CIPHER_UPDATE,          (DFUNC)wp_des3_null                 }, \
+    { OSSL_FUNC_CIPHER_FINAL,           (DFUNC)wp_des3_null                 }, \
+    { OSSL_FUNC_CIPHER_CIPHER,          (DFUNC)wp_des3_null                 }, \
+    { OSSL_FUNC_CIPHER_GET_PARAMS,      (DFUNC)wp_des3_null                 }, \
+    { OSSL_FUNC_CIPHER_GET_CTX_PARAMS,  (DFUNC)wp_des3_null                 }, \
+    { OSSL_FUNC_CIPHER_SET_CTX_PARAMS,  (DFUNC)wp_des3_null                 }, \
+    { OSSL_FUNC_CIPHER_GETTABLE_PARAMS, (DFUNC)wp_des3_null                 }, \
+    { OSSL_FUNC_CIPHER_GETTABLE_CTX_PARAMS,                                    \
+                              (DFUNC)wp_des3_null                           }, \
+    { OSSL_FUNC_CIPHER_SETTABLE_CTX_PARAMS,                                    \
+                              (DFUNC)wp_des3_null                           }, \
+    { 0, NULL }                                                                \
+};
+static int wp_des3_null(void) { return 0; }
+static void wp_des3_void(void) {}
+
+IMPLEMENT_DES3_BLOCK_NULL(cbc)
+
+#endif
+#endif /* WP_HAVE_DES3CBC */
 

--- a/test/unit.c
+++ b/test/unit.c
@@ -103,8 +103,10 @@ TEST_CASE test_case[] = {
     TEST_DECL(test_krb5kdf, NULL),
 #endif
 #ifdef WP_HAVE_DES3CBC
-    TEST_DECL(test_des3_cbc, NULL),
-    TEST_DECL(test_des3_cbc_stream, NULL),
+    #if !defined(HAVE_FIPS) || defined(WP_ALLOW_NON_FIPS)
+        TEST_DECL(test_des3_cbc, NULL),
+        TEST_DECL(test_des3_cbc_stream, NULL),
+    #endif
 #endif
 #ifdef WP_HAVE_AESECB
     TEST_DECL(test_aes128_ecb, NULL),
@@ -293,7 +295,9 @@ TEST_CASE test_case[] = {
 #endif /* WP_HAVE_ECDSA */
 
 #ifdef WP_HAVE_PBE
-    TEST_DECL(test_pbe, NULL),
+    #if !defined(HAVE_FIPS) || defined(WP_ALLOW_NON_FIPS)
+        TEST_DECL(test_pbe, NULL),
+    #endif
 #endif
 
 #if defined(WP_HAVE_ED25519) || defined(WP_HAVE_ED448)


### PR DESCRIPTION
MD5 was getting enabled on FIPS builds which shouldn't be happening. Added `WP_ALLOW_NON_FIPS` flag to allow usage of DES3 or MD5 if they are enabled in the FIPS build.