### PR TITLE
Add kmod CI Workflow

### DIFF
--- a/.github/workflows/kmod.yml
+++ b/.github/workflows/kmod.yml
@@ -1,0 +1,113 @@
+name: kmod Tests
+
+on:
+  push:
+    branches: [ 'master', 'main', 'release/**' ]
+  pull_request:
+    branches: [ '*' ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build_wolfprovider:
+    uses: ./.github/workflows/build-wolfprovider.yml
+    with:
+      wolfssl_ref: ${{ matrix.wolfssl_ref }}
+      openssl_ref: ${{ matrix.openssl_ref }}
+    strategy:
+      matrix:
+        wolfssl_ref: [ 'master', 'v5.8.0-stable' ]
+        openssl_ref: [ 'openssl-3.5.0' ]
+
+  test_kmod:
+    runs-on: ubuntu-22.04
+    needs: build_wolfprovider
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        kmod_ref: [ 'v33' ]
+        wolfssl_ref: [ 'master', 'v5.8.0-stable' ]
+        openssl_ref: [ 'openssl-3.5.0' ]
+        # Note: No WOLFPROV_FORCE_FAIL needed - kmod is only a signature parser,
+        # not a crypto verification tool. The signature tests only extract metadata
+        # (hash algo, signer name, key ID) but don't perform crypto operations.
+    steps:
+      - name: Checkout wolfProvider
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Retrieving wolfSSL/wolfProvider from cache
+        uses: actions/cache/restore@v4
+        id: wolfprov-cache
+        with:
+          path: |
+            wolfssl-install
+            wolfprov-install
+            openssl-install/lib64
+            openssl-install/include
+            openssl-install/bin
+
+          key: wolfprov-${{ matrix.wolfssl_ref }}-${{ matrix.openssl_ref }}-${{ github.sha }}
+          fail-on-cache-miss: true
+
+      - name: Install kmod test dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential meson ninja-build pkg-config \
+            python3-pip python3-setuptools python3-wheel python3-meson \
+            zlib1g-dev liblzma-dev libzstd-dev
+
+      - name: Install kernel headers for kmod tests
+        run: |
+          sudo apt-get update
+          AVAILABLE_HEADERS=$(apt-cache search linux-headers | grep -E "^linux-headers-[0-9]" | head -1 | cut -d' ' -f1)
+          if [ -n "$AVAILABLE_HEADERS" ]; then
+            sudo apt-get install -y "$AVAILABLE_HEADERS"
+            KERNEL_VERSION=$(uname -r)
+            HEADERS_PATH=$(echo $AVAILABLE_HEADERS | sed 's/linux-headers-//')
+            sudo mkdir -p /lib/modules/$KERNEL_VERSION
+            sudo ln -sf /usr/src/linux-headers-$HEADERS_PATH /lib/modules/$KERNEL_VERSION/build
+          else
+            sudo apt-get install -y linux-headers-generic || echo "No generic headers available"
+          fi
+
+      - name: Download kmod
+        uses: actions/checkout@v4
+        with:
+          repository: kmod-project/kmod
+          ref: ${{ matrix.kmod_ref }}
+          path: kmod
+          fetch-depth: 1
+
+      - name: Checkout OSP
+        uses: actions/checkout@v4
+        with:
+          repository: wolfssl/osp
+          path: osp
+          fetch-depth: 1
+      - run: |
+          cd kmod
+          patch -p1 < $GITHUB_WORKSPACE/osp/wolfProvider/kmod/kmod-${{ matrix.kmod_ref }}-wolfprov.patch
+
+      - name: Build and install kmod
+        working-directory: kmod
+        run: |
+          ./autogen.sh
+          ./configure --prefix="$GITHUB_WORKSPACE/kmod-install" \
+            --disable-manpages \
+            --with-openssl \
+            CPPFLAGS="-I$GITHUB_WORKSPACE/openssl-install/include" \
+            LDFLAGS="-L$GITHUB_WORKSPACE/openssl-install/lib64 -lcrypto" \
+            PKG_CONFIG_PATH="$PKG_CONFIG_PATH"
+          make -j$(nproc)
+          sudo make install
+
+      - name: Run kmod tests
+        working-directory: kmod
+        run: |
+          source $GITHUB_WORKSPACE/scripts/env-setup
+          KMOD_LOG=debug TESTSUITE_VERBOSE=1 make check V=1


### PR DESCRIPTION
# Description 

- Add kmod workflow for `v33` 
- WPFF doesn't do anything since we only parse so no need for WPFF in this case
- [ ] needs patch [here](https://github.com/wolfSSL/osp/pull/275)