### PR TITLE
removed libssl-dev from x11vnc and systemd

### DIFF
--- a/.github/workflows/systemd.yml
+++ b/.github/workflows/systemd.yml
@@ -42,8 +42,7 @@ jobs:
           sudo apt-get install -y build-essential meson ninja-build \
             libmount-dev gperf python3-pytest libuv1-dev libnghttp2-dev \
             libcap-dev uuid-dev libdevmapper-dev libpopt-dev libjson-c-dev \
-            libssh-dev libargon2-dev libblkid-dev asciidoctor pkgconf \
-            zlib1g-dev
+            libargon2-dev libblkid-dev asciidoctor pkgconf zlib1g-dev
 
       - name: Checkout wolfProvider
         uses: actions/checkout@v4

--- a/.github/workflows/x11vnc.yml
+++ b/.github/workflows/x11vnc.yml
@@ -58,8 +58,17 @@ jobs:
         run: |
           sudo apt-get update
 
-          sudo apt-get install -y build-essential autoconf automake libtool pkg-config gcc make ca-certificates
-          sudo apt-get install -y libc6-dev libjpeg-dev x11proto-core-dev libxss-dev zlib1g-dev libavahi-client-dev libssl-dev libvncserver-dev libx11-dev libxdamage-dev libxext-dev libxfixes-dev libxi-dev libxinerama-dev libxrandr-dev libxtst-dev
+          # common build dependencies
+          sudo apt-get install -y build-essential autoconf automake libtool \
+              pkg-config gcc make ca-certificates
+
+          # x11vnc dependencies
+          sudo apt-get install -y libc6-dev libjpeg-dev x11proto-core-dev \
+              libxss-dev zlib1g-dev libavahi-client-dev libvncserver-dev \
+              libx11-dev libxdamage-dev libxext-dev libxfixes-dev libxi-dev \
+              libxinerama-dev libxrandr-dev libxtst-dev
+
+          # packages for testing script
           sudo apt-get install -y xvfb tigervnc-viewer psmisc expect curl
 
       - name: Download x11vnc
@@ -81,8 +90,12 @@ jobs:
           # change encryption for cert keys from des3 to aes256
           perl -pi -e 's/-des3/-aes256/' src/ssltools.h
 
+          source $GITHUB_WORKSPACE/scripts/env-setup
+
           autoreconf -vfi
-          ./configure --with-ssl="$GITHUB_WORKSPACE/openssl-install/lib64"
+          ./configure --with-ssl="$GITHUB_WORKSPACE/openssl-install/lib64" \
+              CPPFLAGS="-I$GITHUB_WORKSPACE/openssl-install/include" \
+              LDFLAGS="-L$GITHUB_WORKSPACE/openssl-install/lib64"
           make -j $(nproc)
           sudo make install
 


### PR DESCRIPTION
x11vnc was directly installing libssl-dev
 * Prevented libssl-dev from being installed
 * Updated configure

systemd was installing libssl-dev through libssh-dev
 * libssh-dev seems to be unnecessary so I removed it