### PR TITLE
Update command line tests

### DIFF
--- a/.github/workflows/simple.yml
+++ b/.github/workflows/simple.yml
@@ -13,25 +13,39 @@ concurrency:
 # END OF COMMON SECTION
 
 jobs:
+  build_wolfprovider:
+    uses: ./.github/workflows/build-wolfprovider.yml
+    with:
+      wolfssl_ref: ${{ matrix.wolfssl_ref }}
+      openssl_ref: ${{ matrix.openssl_ref }}
+    strategy:
+      matrix:
+        wolfssl_ref: [ 'master', 'v5.8.0-stable' ]
+        openssl_ref: [ 'master', 'openssl-3.5.0' ]
+        debug: ['WOLFPROV_DEBUG=1', '']
+
   simple_test:
     name: Simple Test
     runs-on: ubuntu-22.04
+    needs: build_wolfprovider
     timeout-minutes: 20
     strategy:
       matrix:
-        openssl_ref: [ 'master', 'openssl-3.5.0' ]
         wolfssl_ref: [ 'master', 'v5.8.0-stable' ]
+        openssl_ref: [ 'master', 'openssl-3.5.0' ]
         force_fail: ['WOLFPROV_FORCE_FAIL=1', '']
-        debug: ['WOLFPROV_DEBUG=1', '']
     steps:
       - name: Checkout wolfProvider
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
 
-      # Check if this version of wolfssl/wolfprovider has already been built,
-      # mark to cache these items on post if we do end up building
-      - name: Checking wolfSSL/wolfProvider in cache
-        uses: actions/cache@v4
-        id: wolfprov-cache
+      - name: Retrieving wolfProvider from cache
+        # Debug builds are not currently supported by build-wolfprovider.yml
+        # so those are manually built as a separate step.
+        if: ${{ matrix.debug == '' }}
+        uses: actions/cache/restore@v4
+        id: wolfprov-cache-restore
         with:
           path: |
             wolfssl-install
@@ -41,21 +55,16 @@ jobs:
             openssl-install/bin
 
           key: wolfprov-${{ matrix.wolfssl_ref }}-${{ matrix.openssl_ref }}-${{ github.sha }}
-          lookup-only: true
+          fail-on-cache-miss: true
 
-      # If not yet built this version, build it now
       - name: Build wolfProvider
-        if: steps.wolfprov-${{ matrix.wolfssl_ref }}-cache.hit != 'true'
+        if: ${{ matrix.debug != '' }}
         run: |
-          ${{ matrix.debug }} OPENSSL_TAG=${{ matrix.openssl_ref }} WOLFSSL_TAG=${{ matrix.wolfssl_ref }} ./scripts/build-wolfprovider.sh
+          ${{ matrix.debug }} \
+            OPENSSL_TAG=${{ matrix.openssl_ref }} \
+            WOLFSSL_TAG=${{ matrix.wolfssl_ref }} \
+            ./scripts/build-wolfprovider.sh
 
       - name: Run simple tests
         run: |
-          ${{ matrix.force_fail }} ${{ matrix.debug }} ./scripts/cmd_test/do-cmd-tests.sh
-
-      - name: Print test logs
-        if: always()
-        run: |
-          if [ -f test-suite.log ] ; then
-            cat test-suite.log
-          fi
+          ${{ matrix.force_fail }} ./scripts/cmd_test/do-cmd-tests.sh

--- a/scripts/cmd_test/aes-cmd-test.sh
+++ b/scripts/cmd_test/aes-cmd-test.sh
@@ -19,62 +19,13 @@
 # You should have received a copy of the GNU General Public License
 # along with wolfProvider. If not, see <http://www.gnu.org/licenses/>.
 
-# Set up environment
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-REPO_ROOT="$( cd "${SCRIPT_DIR}/../.." &> /dev/null && pwd )"
-UTILS_DIR="${REPO_ROOT}/scripts"
-export LOG_FILE="${SCRIPT_DIR}/aes-test.log"
-touch "$LOG_FILE"
-
-# Source wolfProvider utilities
-source "${UTILS_DIR}/utils-general.sh"
-source "${UTILS_DIR}/utils-openssl.sh"
-source "${UTILS_DIR}/utils-wolfssl.sh"
-source "${UTILS_DIR}/utils-wolfprovider.sh"
-
-# Initialize wolfProvider
-init_wolfprov
-
-# Fail flags
-FAIL=0
-FORCE_FAIL_PASSED=0
-
-# Check environment variables directly
-if [ "${WOLFPROV_FORCE_FAIL}" = "1" ]; then
-    echo "Force fail mode enabled for AES tests"
-fi
-if [ "${WOLFSSL_ISFIPS}" = "1" ]; then
-    echo "FIPS mode enabled for AES tests"
-fi
-
-# Verify wolfProvider is properly loaded
-echo -e "\nVerifying wolfProvider configuration:"
-if ! $OPENSSL_BIN list -providers | grep -q "wolf"; then
-    echo "[FAIL] wolfProvider not found in OpenSSL providers!"
-    echo "Current provider list:"
-    $OPENSSL_BIN list -providers
-    FAIL=1
-else
-    echo "wolfProvider is properly configured"
-fi
-
-# Print environment for verification
-echo "Environment variables:"
-echo "OPENSSL_MODULES: ${OPENSSL_MODULES}"
-echo "LD_LIBRARY_PATH: ${LD_LIBRARY_PATH}"
-echo "OPENSSL_BIN: ${OPENSSL_BIN}"
+source "${SCRIPT_DIR}/cmd-test-common.sh"
+cmd_test_env_setup "aes-test.log"
 
 # Create test data and output directories
 mkdir -p aes_outputs
 echo "This is test data for AES encryption testing." > test.txt
-
-# Helper function to handle force fail checks
-check_force_fail() {
-    if [ "${WOLFPROV_FORCE_FAIL}" = "1" ]; then
-        echo "[PASS] Test passed when force fail was enabled"
-        FORCE_FAIL_PASSED=1
-    fi
-}
 
 # Arrays for test configurations
 KEY_SIZES=("128" "192" "256")

--- a/scripts/cmd_test/clean-cmd-test.sh
+++ b/scripts/cmd_test/clean-cmd-test.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+#
+# Copyright (C) 2006-2025 wolfSSL Inc.
+#
+# This file is part of wolfProvider.
+#
+# wolfProvider is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# wolfProvider is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with wolfProvider. If not, see <http://www.gnu.org/licenses/>.
+
+# Clean up command test artifacts
+rm -rf ./scripts/cmd_test/*.log
+rm -rf ./aes_outputs
+rm -rf ./ecc_outputs
+rm -rf ./hash_outputs
+rm -rf ./rsa_outputs
+rm -rf ./test.txt

--- a/scripts/cmd_test/cmd-test-common.sh
+++ b/scripts/cmd_test/cmd-test-common.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+#
+# Copyright (C) 2006-2025 wolfSSL Inc.
+#
+# This file is part of wolfProvider.
+#
+# wolfProvider is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# wolfProvider is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with wolfProvider. If not, see <http://www.gnu.org/licenses/>.
+
+cmd_test_env_setup() {
+    local log_file_name=$1
+    SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+    # Set up environment
+    export LOG_FILE="${SCRIPT_DIR}/${log_file_name}"
+    touch "$LOG_FILE"
+
+    # OPENSSL_BIN must be set by the caller
+    if [ -z "${OPENSSL_BIN:-}" ]; then
+        echo "Error: OPENSSL_BIN environment variable is not set" | tee -a "$LOG_FILE"
+        exit 1
+    fi
+
+    # Fail flags
+    FAIL=0
+    FORCE_FAIL_PASSED=0
+
+    # Get the force fail parameter
+    if [ "${WOLFPROV_FORCE_FAIL}" = "1" ]; then
+        echo "Force fail mode enabled"
+    fi
+    if [ "${WOLFSSL_ISFIPS}" = "1" ]; then
+        echo "FIPS mode enabled"
+    fi
+
+    # Print environment for verification
+    echo "Environment variables:"
+    echo "OPENSSL_MODULES: ${OPENSSL_MODULES}"
+    echo "OPENSSL_BIN: ${OPENSSL_BIN}"
+}
+
+# Function to use default provider only
+use_default_provider() {
+    unset OPENSSL_MODULES
+    unset OPENSSL_CONF
+
+    # Verify that we are using the default provider
+    if ${OPENSSL_BIN} list -providers | grep -q "wolfprov"; then
+        echo "FAIL: unable to switch to default provider, wolfProvider is still active"
+        exit 1
+    fi
+    echo "Switched to default provider"
+}
+
+# Function to use wolf provider only
+use_wolf_provider() {
+    export OPENSSL_MODULES=$WOLFPROV_PATH
+    export OPENSSL_CONF=${WOLFPROV_CONFIG}
+
+    # Verify that we are using wolfProvider
+    if ! ${OPENSSL_BIN} list -providers | grep -q "wolfprov"; then
+        echo "FAIL: unable to switch to wolfProvider, default provider is still active"
+        exit 1
+    fi
+    echo "Switched to wolfProvider"
+}
+
+# Helper function to handle force fail checks
+check_force_fail() {
+    if [ "${WOLFPROV_FORCE_FAIL}" = "1" ]; then
+        echo "[PASS] Test passed when force fail was enabled"
+        FORCE_FAIL_PASSED=1
+    fi
+}

--- a/scripts/cmd_test/ecc-cmd-test.sh
+++ b/scripts/cmd_test/ecc-cmd-test.sh
@@ -19,77 +19,15 @@
 # You should have received a copy of the GNU General Public License
 # along with wolfProvider. If not, see <http://www.gnu.org/licenses/>.
 
-# Set up environment
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-REPO_ROOT="$( cd "${SCRIPT_DIR}/../.." &> /dev/null && pwd )"
-UTILS_DIR="${REPO_ROOT}/scripts"
-export LOG_FILE="${SCRIPT_DIR}/ecc-test.log"
-touch "$LOG_FILE"
-
-# Source wolfProvider utilities
-source "${UTILS_DIR}/utils-general.sh"
-source "${UTILS_DIR}/utils-openssl.sh"
-source "${UTILS_DIR}/utils-wolfssl.sh"
-source "${UTILS_DIR}/utils-wolfprovider.sh"
-
-# Initialize wolfProvider
-init_wolfprov
-
-# Fail flags
-FAIL=0
-FORCE_FAIL_PASSED=0
-
-# Get the force fail parameter
-if [ "${WOLFPROV_FORCE_FAIL}" = "1" ]; then
-    echo "Force fail mode enabled for ECC tests"
-fi
-if [ "${WOLFSSL_ISFIPS}" = "1" ]; then
-    echo "FIPS mode enabled for ECC tests"
-fi
-
-# Verify wolfProvider is properly loaded
-echo -e "\nVerifying wolfProvider configuration:"
-if ! $OPENSSL_BIN list -providers | grep -q "libwolfprov"; then
-    echo "[FAIL] wolfProvider not found in OpenSSL providers!"
-    echo "Current provider list:"
-    $OPENSSL_BIN list -providers
-    FAIL=1
-fi
-echo "wolfProvider is properly configured"
-
-# Print environment for verification
-echo "Environment variables:"
-echo "OPENSSL_MODULES: ${OPENSSL_MODULES}"
-echo "LD_LIBRARY_PATH: ${LD_LIBRARY_PATH}"
-echo "OPENSSL_BIN: ${OPENSSL_BIN}"
+source "${SCRIPT_DIR}/cmd-test-common.sh"
+cmd_test_env_setup "ecc-test.log"
 
 # Create test directories
 mkdir -p ecc_outputs
 
 # Create test data for signing
 echo "This is test data for ECC signing and verification." > ecc_outputs/test_data.txt
-
-# Function to use default provider only
-use_default_provider() {
-    unset OPENSSL_MODULES
-    unset OPENSSL_CONF
-    echo "Switched to default provider"
-}
-
-# Function to use wolf provider only
-use_wolf_provider() {
-    export OPENSSL_MODULES=$WOLFPROV_PATH
-    export OPENSSL_CONF=${WOLFPROV_CONFIG}
-    echo "Switched to wolfProvider"
-}
-
-# Helper function to handle force fail checks
-check_force_fail() {
-    if [ "${WOLFPROV_FORCE_FAIL}" = "1" ]; then
-        echo "[PASS] Test passed when force fail was enabled"
-        FORCE_FAIL_PASSED=1
-    fi
-}
 
 # Array of ECC curves and providers to test
 CURVES=("prime256v1" "secp384r1" "secp521r1")

--- a/scripts/cmd_test/hash-cmd-test.sh
+++ b/scripts/cmd_test/hash-cmd-test.sh
@@ -19,62 +19,13 @@
 # You should have received a copy of the GNU General Public License
 # along with wolfProvider. If not, see <http://www.gnu.org/licenses/>.
 
-# Set up environment
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-REPO_ROOT="$( cd "${SCRIPT_DIR}/../.." &> /dev/null && pwd )"
-UTILS_DIR="${REPO_ROOT}/scripts"
-export LOG_FILE="${SCRIPT_DIR}/hash-test.log"
-touch "$LOG_FILE"
-
-# Source wolfProvider utilities
-source "${UTILS_DIR}/utils-general.sh"
-source "${UTILS_DIR}/utils-openssl.sh"
-source "${UTILS_DIR}/utils-wolfssl.sh"
-source "${UTILS_DIR}/utils-wolfprovider.sh"
-
-# Initialize wolfProvider
-init_wolfprov
-
-# Fail flags
-FAIL=0
-FORCE_FAIL_PASSED=0
-
-# Get the force fail parameter
-if [ "${WOLFPROV_FORCE_FAIL}" = "1" ]; then
-    echo "Force fail mode enabled for Hash tests"
-fi
-if [ "${WOLFSSL_ISFIPS}" = "1" ]; then
-    echo "FIPS mode enabled for Hash tests"
-fi
-
-# Verify wolfProvider is properly loaded
-echo -e "\nVerifying wolfProvider configuration:"
-if ! $OPENSSL_BIN list -providers | grep -q "wolf"; then
-    echo "[FAIL] wolfProvider not found in OpenSSL providers!"
-    echo "Current provider list:"
-    $OPENSSL_BIN list -providers
-    FAIL=1
-else
-    echo "wolfProvider is properly configured"
-fi
-
-# Print environment for verification
-echo "Environment variables:"
-echo "OPENSSL_MODULES: ${OPENSSL_MODULES}"
-echo "LD_LIBRARY_PATH: ${LD_LIBRARY_PATH}"
-echo "OPENSSL_BIN: ${OPENSSL_BIN}"
+source "${SCRIPT_DIR}/cmd-test-common.sh"
+cmd_test_env_setup "hash-test.log"
 
 # Create test data and output directories
 mkdir -p hash_outputs
 echo "This is test data for hash algorithm testing." > test.txt
-
-# Helper function to handle force fail checks
-check_force_fail() {
-    if [ "${WOLFPROV_FORCE_FAIL}" = "1" ]; then
-        echo "[PASS] Test passed when force fail was enabled"
-        FORCE_FAIL_PASSED=1
-    fi
-}
 
 # Array of hash algorithms to test
 HASH_ALGOS=("sha1" "sha224" "sha256" "sha384" "sha512")

--- a/scripts/cmd_test/rsa-cmd-test.sh
+++ b/scripts/cmd_test/rsa-cmd-test.sh
@@ -19,77 +19,15 @@
 # You should have received a copy of the GNU General Public License
 # along with wolfProvider. If not, see <http://www.gnu.org/licenses/>.
 
-# Set up environment
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-REPO_ROOT="$( cd "${SCRIPT_DIR}/../.." &> /dev/null && pwd )"
-UTILS_DIR="${REPO_ROOT}/scripts"
-export LOG_FILE="${SCRIPT_DIR}/rsa-test.log"
-touch "$LOG_FILE"
-
-# Source wolfProvider utilities
-source "${UTILS_DIR}/utils-general.sh"
-source "${UTILS_DIR}/utils-openssl.sh"
-source "${UTILS_DIR}/utils-wolfssl.sh"
-source "${UTILS_DIR}/utils-wolfprovider.sh"
-
-# Initialize wolfProvider
-init_wolfprov
-
-# Fail flags
-FAIL=0
-FORCE_FAIL_PASSED=0
-
-# Get the force fail parameter
-if [ "${WOLFPROV_FORCE_FAIL}" = "1" ]; then
-    echo "Force fail mode enabled for RSA tests"
-fi
-if [ "${WOLFSSL_ISFIPS}" = "1" ]; then
-    echo "FIPS mode enabled for RSA tests"
-fi
-
-# Verify wolfProvider is properly loaded
-echo -e "\nVerifying wolfProvider configuration:"
-if ! $OPENSSL_BIN list -providers | grep -q "libwolfprov"; then
-    echo "[FAIL] wolfProvider not found in OpenSSL providers!"
-    echo "Current provider list:"
-    $OPENSSL_BIN list -providers
-    FAIL=1
-fi
-echo "wolfProvider is properly configured"
-
-# Print environment for verification
-echo "Environment variables:"
-echo "OPENSSL_MODULES: ${OPENSSL_MODULES}"
-echo "LD_LIBRARY_PATH: ${LD_LIBRARY_PATH}"
-echo "OPENSSL_BIN: ${OPENSSL_BIN}"
+source "${SCRIPT_DIR}/cmd-test-common.sh"
+cmd_test_env_setup "rsa-test.log"
 
 # Create test directories
 mkdir -p rsa_outputs
 
 # Create test data for signing
 echo "This is test data for RSA signing and verification." > rsa_outputs/test_data.txt
-
-# Function to use default provider only
-use_default_provider() {
-    unset OPENSSL_MODULES
-    unset OPENSSL_CONF
-    echo "Switched to default provider"
-}
-
-# Function to use wolf provider only
-use_wolf_provider() {
-    export OPENSSL_MODULES=$WOLFPROV_PATH
-    export OPENSSL_CONF=${WOLFPROV_CONFIG}
-    echo "Switched to wolfProvider"
-}
-
-# Helper function to handle force fail checks
-check_force_fail() {
-    if [ "${WOLFPROV_FORCE_FAIL}" = "1" ]; then
-        echo "[PASS] Test passed when force fail was enabled"
-        FORCE_FAIL_PASSED=1
-    fi
-}
 
 # Array of RSA key types, sizes, and providers to test
 KEY_TYPES=("RSA" "RSA-PSS")

--- a/scripts/env-setup
+++ b/scripts/env-setup
@@ -56,6 +56,11 @@ export OPENSSL_CONF="${OPENSSL_CONF:=$DEFAULT_PROVIDER_CONF}"
 export OPENSSL_MODULES="${OPENSSL_MODULES:=$REPO_ROOT/wolfprov-install/lib}"
 export PKG_CONFIG_PATH="${PKG_CONFIG_PATH:=$OPENSSL_LIB_PATH/pkgconfig}"
 
+# Other variables used by test scripts
+export WOLFPROV_PATH="${REPO_ROOT}/wolfprov-install/lib"
+export WOLFPROV_CONFIG="${DEFAULT_PROVIDER_CONF}"
+export OPENSSL_BIN="${REPO_ROOT}/openssl-install/bin/openssl"
+
 # If openssl-install does not exist, exit with failure status to terminate 
 # any workflows which depend on the result.
 # For normal interactive command line usage, this result is fine to ignore.
@@ -69,7 +74,7 @@ fi
 
 echo "Checking OpenSSL providers:"
 PROVIDER_LIST=$(mktemp -t provider-list.XXXXXX)
-$REPO_ROOT/openssl-install/bin/openssl list -providers | tee $PROVIDER_LIST
+$OPENSSL_BIN list -providers | tee $PROVIDER_LIST
 if grep -q libwolfprov $PROVIDER_LIST; then
   echo "libwolfprov found in OpenSSL providers"
 else


### PR DESCRIPTION
This update is needed for PR #234 

- Update simple.yml to use newer WP build process
- Remove build step from the `scripts/cmd_test` test suite to speed things up (by removing calls to `init_openssl` and `init_wolfssl`)
- Allow caller to provide their own openssl binary
- DRY out several blocks of repeated code