### PR TITLE
fixed uninitialized variable

### DIFF
--- a/src/wp_rsa_kmgmt.c
+++ b/src/wp_rsa_kmgmt.c
@@ -3940,7 +3940,7 @@ static int wp_rsa_encode_text_format_hex(const mp_int* num, char* textData,
 {
     unsigned char* binData = NULL;
     size_t binLen = 0;
-    size_t printAmt;
+    size_t printAmt = 0;
     size_t dPos = *pos;
     int bytes = 0;
     int i;
@@ -4036,7 +4036,7 @@ static int wp_rsa_encode_text(wp_RsaEncDecCtx* ctx, OSSL_CORE_BIO* cBio,
     char* textData = NULL;
     size_t textLen = 0;
     size_t pos = 0;
-    size_t printAmt;
+    size_t printAmt = 0;
     char* expStr;
     int expLen;
 


### PR DESCRIPTION
printAmt was not initialized to 0.

This never showed up before so I assume it is related to my configuration. `printAmt` is only uninitialized when there is no public or private key specified (hasPub, hasPriv). Which are set like this:
```
int hasPriv = (selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY) != 0;           
int hasPub = (selection & OSSL_KEYMGMT_SELECT_PUBLIC_KEY) != 0; 
```

I found this while building with the configuration specified in the documentation (Section 3.3.1 - 3.3.3)

OpenSSL:
```
git clone https://github.com/openssl/openssl.git
cd openssl
./config no-fips -shared
make
sudo make install
```

wolfSSL:
```
./configure --enable-opensslcoexist --enable-cmac --enable-keygen --enable-sha --enable-des3 --enable-aesctr --enable-aesccm --enable-x963kdf --enable-compkey CPPFLAGS="-DHAVE_AES_ECB -DWOLFSSL_AES_DIRECT -DWC_RSA_NO_PADDING -DWOLFSSL_PUBLIC_MP -DHAVE_PUBLIC_FFDHE -DWOLFSSL_DH_EXTRA -DWOLFSSL_PSS_LONG_SALT -DWOLFSSL_PSS_SALT_LEN_DISCOVER -DRSA_MIN_SIZE=1024" --enable-certgen --enable-aeskeywrap --enable-enckeys --enable-base16 --with-eccminsz=192
make
sudo make install
```

wolfProvider:
```
./configure
make
make check
```