### PR TITLE
Fix WPFF runtime checks for key managment functions

### DIFF
--- a/src/wp_dh_kmgmt.c
+++ b/src/wp_dh_kmgmt.c
@@ -490,14 +490,12 @@ static int wp_dh_copy_params(const wp_Dh *src, wp_Dh *dst)
  */
 static wp_Dh* wp_dh_dup(const wp_Dh *src, int selection)
 {
-    wp_Dh* dst;
+    wp_Dh* dst = NULL;
 
-    if (!wolfssl_prov_is_running()) {
-        return NULL;
+    if (wolfssl_prov_is_running()) {
+        /* Create a new dh object. */
+        dst = wp_dh_new(src->provCtx);
     }
-
-    /* Create a new DH key object to return. */
-    dst = wp_dh_new(src->provCtx);
     if (dst != NULL) {
         int ok = 1;
 
@@ -2202,9 +2200,11 @@ static int wp_dh_decode(wp_DhEncDecCtx* ctx, OSSL_CORE_BIO *cBio,
 
     ctx->selection = selection;
 
-    dh = wp_dh_new(ctx->provCtx);
-    if (dh == NULL) {
-        ok = 0;
+    if (ok) {
+        dh = wp_dh_new(ctx->provCtx);
+        if (dh == NULL) {
+            ok = 0;
+        }
     }
     if (ok && (!wp_read_der_bio(ctx->provCtx, cBio, &data, &len))) {
         ok = 0;

--- a/src/wp_dh_kmgmt.c
+++ b/src/wp_dh_kmgmt.c
@@ -492,6 +492,10 @@ static wp_Dh* wp_dh_dup(const wp_Dh *src, int selection)
 {
     wp_Dh* dst;
 
+    if (!wolfssl_prov_is_running()) {
+        return NULL;
+    }
+
     /* Create a new DH key object to return. */
     dst = wp_dh_new(src->provCtx);
     if (dst != NULL) {
@@ -2189,6 +2193,10 @@ static int wp_dh_decode(wp_DhEncDecCtx* ctx, OSSL_CORE_BIO *cBio,
     unsigned char* data = NULL;
     word32 len = 0;
 
+    if (!wolfssl_prov_is_running()) {
+        ok = 0;
+    }
+
     (void)pwCb;
     (void)pwCbArg;
 
@@ -2529,6 +2537,11 @@ static int wp_dh_encode(wp_DhEncDecCtx* ctx, OSSL_CORE_BIO *cBio,
     OSSL_PASSPHRASE_CALLBACK *pwCb, void *pwCbArg)
 {
     int ok = 1;
+
+    if (!wolfssl_prov_is_running()) {
+        ok = 0;
+    }
+
 #if (LIBWOLFSSL_VERSION_HEX >= 0x05000000 && defined(WOLFSSL_DH_EXTRA))
     int rc;
     BIO* out = wp_corebio_get_bio(ctx->provCtx, cBio);

--- a/src/wp_ecc_kmgmt.c
+++ b/src/wp_ecc_kmgmt.c
@@ -2037,6 +2037,10 @@ static int wp_ecc_decode_spki(wp_Ecc* ecc, unsigned char* data, word32 len)
     int rc;
     word32 idx = 0;
 
+    if (!wolfssl_prov_is_running()) {
+        ok = 0;
+    }
+
     rc = wc_EccPublicKeyDecode(data, &idx, &ecc->key, len);
     if (rc != 0) {
         ok = 0;
@@ -2068,6 +2072,10 @@ static int wp_ecc_decode_pki(wp_Ecc* ecc, unsigned char* data, word32 len)
     int ok = 1;
     int rc;
     word32 idx = 0;
+
+    if (!wolfssl_prov_is_running()) {
+        ok = 0;
+    }
 
     rc = wc_EccPrivateKeyDecode(data, &idx, &ecc->key, len);
     if (rc != 0) {

--- a/src/wp_ecc_kmgmt.c
+++ b/src/wp_ecc_kmgmt.c
@@ -416,9 +416,12 @@ void wp_ecc_free(wp_Ecc* ecc)
  */
 static wp_Ecc* wp_ecc_dup(const wp_Ecc *src, int selection)
 {
-    wp_Ecc* dst;
+    wp_Ecc* dst = NULL;
 
-    dst = wp_ecc_new(src->provCtx);
+    if (wolfssl_prov_is_running()) {
+        /* Create a new ecc object. */
+        dst = wp_ecc_new(src->provCtx);
+    }
     if (dst != NULL) {
         int ok = 1;
         int rc;
@@ -2040,10 +2043,11 @@ static int wp_ecc_decode_spki(wp_Ecc* ecc, unsigned char* data, word32 len)
     if (!wolfssl_prov_is_running()) {
         ok = 0;
     }
-
-    rc = wc_EccPublicKeyDecode(data, &idx, &ecc->key, len);
-    if (rc != 0) {
-        ok = 0;
+    if (ok) {
+        rc = wc_EccPublicKeyDecode(data, &idx, &ecc->key, len);
+        if (rc != 0) {
+            ok = 0;
+        }
     }
     if (ok) {
         ecc->curveId = ecc->key.dp->id;
@@ -2076,10 +2080,11 @@ static int wp_ecc_decode_pki(wp_Ecc* ecc, unsigned char* data, word32 len)
     if (!wolfssl_prov_is_running()) {
         ok = 0;
     }
-
-    rc = wc_EccPrivateKeyDecode(data, &idx, &ecc->key, len);
-    if (rc != 0) {
-        ok = 0;
+    if (ok) {
+        rc = wc_EccPrivateKeyDecode(data, &idx, &ecc->key, len);
+        if (rc != 0) {
+            ok = 0;
+        }
     }
 #if LIBWOLFSSL_VERSION_HEX < 0x05000000
     if (!ok) {

--- a/src/wp_ecx_kmgmt.c
+++ b/src/wp_ecx_kmgmt.c
@@ -347,6 +347,10 @@ static wp_Ecx* wp_ecx_dup(const wp_Ecx* src, int selection)
 {
     wp_Ecx* dst;
 
+    if (!wolfssl_prov_is_running()) {
+        return NULL;
+    }
+
     (void)selection;
 
     dst = wp_ecx_new(src->provCtx, src->data);
@@ -1072,6 +1076,10 @@ static int wp_ecx_export(wp_Ecx* ecx, int selection, OSSL_CALLBACK* paramCb,
     unsigned char* data = NULL;
     size_t len = 0;
     int expPriv = (selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY) != 0;
+
+    if (!wolfssl_prov_is_running()) {
+        ok = 0;
+    }
 
     XMEMSET(params, 0, sizeof(params));
     data = OPENSSL_malloc(wp_ecx_export_keypair_alloc_size(ecx, expPriv));
@@ -1928,6 +1936,10 @@ static int wp_ecx_decode(wp_EcxEncDecCtx* ctx, OSSL_CORE_BIO* cBio,
     wp_Ecx* ecx;
     const char* dataType = NULL;
 
+    if (!wolfssl_prov_is_running()) {
+        ok = 0;
+    }
+
     (void)pwCb;
     (void)pwCbArg;
 
@@ -2021,6 +2033,10 @@ static int wp_ecx_encode(wp_EcxEncDecCtx* ctx, OSSL_CORE_BIO *cBio,
     int ok = 1;
     int rc;
     BIO* out = wp_corebio_get_bio(ctx->provCtx, cBio);
+
+    if (!wolfssl_prov_is_running()) {
+        ok = 0;
+    }
     unsigned char* keyData = NULL;
     size_t keyLen = 0;
     unsigned char derData[160];

--- a/src/wp_mac_kmgmt.c
+++ b/src/wp_mac_kmgmt.c
@@ -246,15 +246,13 @@ void wp_mac_free(wp_Mac* mac)
  */
 static wp_Mac* wp_mac_dup(const wp_Mac *src, int selection)
 {
-    wp_Mac* dst;
-
-    if (!wolfssl_prov_is_running()) {
-        return NULL;
-    }
+    wp_Mac* dst = NULL;
 
     (void)selection;
-
-    dst = wp_mac_new(src->provCtx, src->type);
+    if (wolfssl_prov_is_running()) {
+        /* Create a new mac object. */
+        dst = wp_mac_new(src->provCtx, src->type);
+    }
     if (dst != NULL) {
         int ok = 1;
 
@@ -471,7 +469,7 @@ static int wp_mac_export(wp_Mac *mac, int selection, OSSL_CALLBACK *paramCb,
 
     XMEMSET(params, 0, sizeof(params));
 
-    if ((selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY) != 0) {
+    if (ok && (selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY) != 0) {
         size_t idx = 0;
 
         len = wp_mac_export_priv_key_alloc_size(mac);
@@ -514,10 +512,12 @@ static wp_MacGenCtx* wp_mac_gen_init(WOLFPROV_CTX* provCtx,
     wp_MacGenCtx* ctx;
 
     if (!wolfssl_prov_is_running()) {
-        return NULL;
+        ctx = NULL;
     }
 
-    ctx = OPENSSL_zalloc(sizeof(*ctx));
+    if (ctx != NULL) {
+        ctx = OPENSSL_zalloc(sizeof(*ctx));
+    }
     if (ctx != NULL) {
         ctx->provCtx = provCtx;
         ctx->selection = selection;

--- a/src/wp_mac_kmgmt.c
+++ b/src/wp_mac_kmgmt.c
@@ -509,13 +509,9 @@ static int wp_mac_export(wp_Mac *mac, int selection, OSSL_CALLBACK *paramCb,
 static wp_MacGenCtx* wp_mac_gen_init(WOLFPROV_CTX* provCtx,
     int selection, const OSSL_PARAM params[], int type)
 {
-    wp_MacGenCtx* ctx;
+    wp_MacGenCtx* ctx = NULL;
 
-    if (!wolfssl_prov_is_running()) {
-        ctx = NULL;
-    }
-
-    if (ctx != NULL) {
+    if (wolfssl_prov_is_running()) {
         ctx = OPENSSL_zalloc(sizeof(*ctx));
     }
     if (ctx != NULL) {

--- a/src/wp_mac_kmgmt.c
+++ b/src/wp_mac_kmgmt.c
@@ -248,6 +248,10 @@ static wp_Mac* wp_mac_dup(const wp_Mac *src, int selection)
 {
     wp_Mac* dst;
 
+    if (!wolfssl_prov_is_running()) {
+        return NULL;
+    }
+
     (void)selection;
 
     dst = wp_mac_new(src->provCtx, src->type);
@@ -461,6 +465,10 @@ static int wp_mac_export(wp_Mac *mac, int selection, OSSL_CALLBACK *paramCb,
     unsigned char* data = NULL;
     size_t len = 0;
 
+    if (!wolfssl_prov_is_running()) {
+        ok = 0;
+    }
+
     XMEMSET(params, 0, sizeof(params));
 
     if ((selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY) != 0) {
@@ -504,6 +512,10 @@ static wp_MacGenCtx* wp_mac_gen_init(WOLFPROV_CTX* provCtx,
     int selection, const OSSL_PARAM params[], int type)
 {
     wp_MacGenCtx* ctx;
+
+    if (!wolfssl_prov_is_running()) {
+        return NULL;
+    }
 
     ctx = OPENSSL_zalloc(sizeof(*ctx));
     if (ctx != NULL) {

--- a/src/wp_rsa_kmgmt.c
+++ b/src/wp_rsa_kmgmt.c
@@ -2198,10 +2198,10 @@ static int wp_rsa_decode_pki(wp_Rsa* rsa, unsigned char* data, word32 len)
     }
 
     if (ok) {
-    rc = wc_RsaPrivateKeyDecode(data, &idx, &rsa->key, len);
-    if (rc != 0) {
-        ok = 0;
-    }
+        rc = wc_RsaPrivateKeyDecode(data, &idx, &rsa->key, len);
+        if (rc != 0) {
+            ok = 0;
+        }
     }
 #if LIBWOLFSSL_VERSION_HEX < 0x05000000 || defined(HAVE_FIPS)
     if (!ok) {

--- a/src/wp_rsa_kmgmt.c
+++ b/src/wp_rsa_kmgmt.c
@@ -2154,10 +2154,10 @@ static int wp_rsa_decode_spki(wp_Rsa* rsa, unsigned char* data, word32 len)
     }
 
     if (ok) {
-    rc = wc_RsaPublicKeyDecode(data, &idx, &rsa->key, len);
-    if (rc != 0) {
-        ok = 0;
-    }
+        rc = wc_RsaPublicKeyDecode(data, &idx, &rsa->key, len);
+        if (rc != 0) {
+            ok = 0;
+        }
     }
     if (ok && !wp_rsa_determine_type(rsa, data, len)) {
         ok = 0;

--- a/src/wp_rsa_kmgmt.c
+++ b/src/wp_rsa_kmgmt.c
@@ -523,6 +523,10 @@ static wp_Rsa* wp_rsa_dup(const wp_Rsa* src, int selection)
 {
     wp_Rsa* dst = NULL;
 
+    if (!wolfssl_prov_is_running()) {
+        return NULL;
+    }
+
     if ((selection & OSSL_KEYMGMT_SELECT_KEYPAIR) != 0) {
         dst = wp_rsa_base_new(src->provCtx, src->type);
     }
@@ -2147,6 +2151,10 @@ static int wp_rsa_decode_spki(wp_Rsa* rsa, unsigned char* data, word32 len)
     int rc;
     word32 idx = 0;
 
+    if (!wolfssl_prov_is_running()) {
+        ok = 0;
+    }
+
     rc = wc_RsaPublicKeyDecode(data, &idx, &rsa->key, len);
     if (rc != 0) {
         ok = 0;
@@ -2184,6 +2192,10 @@ static int wp_rsa_decode_pki(wp_Rsa* rsa, unsigned char* data, word32 len)
     int ok = 1;
     int rc;
     word32 idx = 0;
+
+    if (!wolfssl_prov_is_running()) {
+        ok = 0;
+    }
 
     rc = wc_RsaPrivateKeyDecode(data, &idx, &rsa->key, len);
     if (rc != 0) {
@@ -2268,6 +2280,10 @@ static int wp_rsa_decode_enc_pki(wp_Rsa* rsa, unsigned char* data, word32 len,
     int ok = 1;
     char password[1024];
     size_t passwordSz = sizeof(password);
+
+    if (!wolfssl_prov_is_running()) {
+        ok = 0;
+    }
 
     /* Look for the PBKDF2 OID to know we have an encrypted key. */
     if (!wp_rsa_find_pbkdf2_oid(data, len)) {
@@ -3098,6 +3114,10 @@ static int wp_rsa_encode(wp_RsaEncDecCtx* ctx, OSSL_CORE_BIO* cBio,
     int ok = 1;
     int rc;
     BIO *out = wp_corebio_get_bio(ctx->provCtx, cBio);
+
+    if (!wolfssl_prov_is_running()) {
+        ok = 0;
+    }
     unsigned char* keyData = NULL;
     size_t keyLen;
     unsigned char* derData = NULL;
@@ -4031,6 +4051,10 @@ static int wp_rsa_encode_text(wp_RsaEncDecCtx* ctx, OSSL_CORE_BIO* cBio,
 {
     int ok = 1;
     BIO *out = wp_corebio_get_bio(ctx->provCtx, cBio);
+
+    if (!wolfssl_prov_is_running()) {
+        ok = 0;
+    }
     int hasPriv = (selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY) != 0;
     int hasPub = (selection & OSSL_KEYMGMT_SELECT_PUBLIC_KEY) != 0;
     char* textData = NULL;


### PR DESCRIPTION
# Description

Added runtime validation and WPFF check in 
- DH - `wp_dh_dup()`, `wp_dh_decode()`, and `wp_dh_encode()`
- ECC  - `wp_ecc_decode_spki()`, `wp_ecc_decode_pki()`
- ECX  - `wp_ecx_dup()`, `wp_ecx_export()`, `wp_ecx_decode()`, `wp_ecx_encode()`
- MAC - `wp_mac_dup()`, `wp_mac_export()`, `wp_mac_gen_init()`
- RSA - `wp_rsa_dup()`, `wp_rsa_decode_spki()`, `wp_rsa_decode_pki()`, `wp_rsa_decode_enc_pki()`, `wp_rsa_encode()`, `wp_rsa_encode_text()`