### PR TITLE
Fix privSz for wp_dh_get_params

### DIFF
--- a/src/wp_dh_kmgmt.c
+++ b/src/wp_dh_kmgmt.c
@@ -807,7 +807,7 @@ static int wp_dh_get_params(wp_Dh* dh, OSSL_PARAM params[])
         p = OSSL_PARAM_locate(params, OSSL_PKEY_PARAM_PRIV_KEY);
         if (p != NULL) {
             if (p->data == NULL) {
-                p->return_size = dh->pubSz;
+                p->return_size = dh->privSz;
             }
             else if (p->data_type == OSSL_PARAM_UNSIGNED_INTEGER) {
                 if (p->data_size < dh->privSz) {


### PR DESCRIPTION
# Description 

- `wp_dh_get_params` was returning the pub key size when it should return the private key size here. Seems like a non issue since the keys are usually the same size. 