### PR TITLE
Fix hang with rsa cmd test and other bugs

### DIFF
--- a/scripts/cmd_test/aes-cmd-test.sh
+++ b/scripts/cmd_test/aes-cmd-test.sh
@@ -21,6 +21,7 @@
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 source "${SCRIPT_DIR}/cmd-test-common.sh"
+source "${SCRIPT_DIR}/clean-cmd-test.sh"
 cmd_test_env_setup "aes-test.log"
 
 # Create test data and output directories

--- a/scripts/cmd_test/aes-cmd-test.sh
+++ b/scripts/cmd_test/aes-cmd-test.sh
@@ -23,10 +23,14 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 source "${SCRIPT_DIR}/cmd-test-common.sh"
 source "${SCRIPT_DIR}/clean-cmd-test.sh"
 cmd_test_env_setup "aes-test.log"
+clean_cmd_test "aes"
+
+# Redirect all output to log file
+exec > >(tee -a "$LOG_FILE") 2>&1
 
 # Create test data and output directories
 mkdir -p aes_outputs
-echo "This is test data for AES encryption testing." > test.txt
+echo "This is test data for AES encryption testing." > aes_outputs/test_data.txt
 
 # Arrays for test configurations
 KEY_SIZES=("128" "192" "256")
@@ -64,7 +68,7 @@ for key_size in "${KEY_SIZES[@]}"; do
         
         # Encryption with OpenSSL default provider
         if ! $OPENSSL_BIN enc -aes-${key_size}-${mode} -K "$key" $iv -provider default \
-            -in test.txt -out "$enc_file" -p; then
+            -in aes_outputs/test_data.txt -out "$enc_file" -p; then
             echo "[FAIL] Interop AES-${key_size}-${mode}: OpenSSL encrypt failed"
             FAIL=1
         fi
@@ -77,7 +81,7 @@ for key_size in "${KEY_SIZES[@]}"; do
         fi
         
         if [ $FAIL -eq 0 ]; then
-            if cmp -s "test.txt" "$dec_file"; then
+            if cmp -s "aes_outputs/test_data.txt" "$dec_file"; then
                 echo "[PASS] Interop AES-${key_size}-${mode}: OpenSSL encrypt, wolfProvider decrypt"
                 check_force_fail
             else
@@ -93,7 +97,7 @@ for key_size in "${KEY_SIZES[@]}"; do
         
         # Encryption with wolfProvider
         if ! $OPENSSL_BIN enc -aes-${key_size}-${mode} -K "$key" $iv -provider-path "$WOLFPROV_PATH" -provider libwolfprov \
-            -in test.txt -out "$enc_file" -p; then
+            -in aes_outputs/test_data.txt -out "$enc_file" -p; then
             echo "[FAIL] Interop AES-${key_size}-${mode}: wolfProvider encrypt failed"
             FAIL=1
         fi
@@ -106,7 +110,7 @@ for key_size in "${KEY_SIZES[@]}"; do
         fi
         
         if [ $FAIL -eq 0 ]; then
-            if cmp -s "test.txt" "$dec_file"; then
+            if cmp -s "aes_outputs/test_data.txt" "$dec_file"; then
                 echo "[PASS] Interop AES-${key_size}-${mode}: wolfProvider encrypt, OpenSSL decrypt"
                 check_force_fail
             else

--- a/scripts/cmd_test/clean-cmd-test.sh
+++ b/scripts/cmd_test/clean-cmd-test.sh
@@ -30,10 +30,8 @@ clean_cmd_test() {
 
 # Function to clean up all command test artifacts
 clean_all_cmd_tests() {
-    rm -rf ./scripts/cmd_test/*.log
-    rm -rf ./aes_outputs
-    rm -rf ./ecc_outputs
-    rm -rf ./hash_outputs
-    rm -rf ./rsa_outputs
-    rm -rf ./test.txt
+    clean_cmd_test "aes"
+    clean_cmd_test "ecc"
+    clean_cmd_test "hash"
+    clean_cmd_test "rsa"
 }

--- a/scripts/cmd_test/clean-cmd-test.sh
+++ b/scripts/cmd_test/clean-cmd-test.sh
@@ -17,10 +17,23 @@
 # You should have received a copy of the GNU General Public License
 # along with wolfProvider. If not, see <http://www.gnu.org/licenses/>.
 
-# Clean up command test artifacts
-rm -rf ./scripts/cmd_test/*.log
-rm -rf ./aes_outputs
-rm -rf ./ecc_outputs
-rm -rf ./hash_outputs
-rm -rf ./rsa_outputs
-rm -rf ./test.txt
+# Function to clean up specific command test artifacts
+clean_cmd_test() {
+    local test_type=$1
+
+    # Clean up specific log file
+    rm -f "./scripts/cmd_test/${test_type}-test.log"
+
+    # Clean up corresponding output directory
+    rm -rf "./${test_type}_outputs"
+}
+
+# Function to clean up all command test artifacts
+clean_all_cmd_tests() {
+    rm -rf ./scripts/cmd_test/*.log
+    rm -rf ./aes_outputs
+    rm -rf ./ecc_outputs
+    rm -rf ./hash_outputs
+    rm -rf ./rsa_outputs
+    rm -rf ./test.txt
+}

--- a/scripts/cmd_test/cmd-test-common.sh
+++ b/scripts/cmd_test/cmd-test-common.sh
@@ -81,3 +81,13 @@ check_force_fail() {
         FORCE_FAIL_PASSED=1
     fi
 }
+
+# Helper function to get provider name from provider arguments
+get_provider_name() {
+    local provider_args=$1
+    if [ "$provider_args" = "-provider default" ]; then
+        echo "default"
+    else
+        echo "libwolfprov"
+    fi
+}

--- a/scripts/cmd_test/ecc-cmd-test.sh
+++ b/scripts/cmd_test/ecc-cmd-test.sh
@@ -23,11 +23,13 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 source "${SCRIPT_DIR}/cmd-test-common.sh"
 source "${SCRIPT_DIR}/clean-cmd-test.sh"
 cmd_test_env_setup "ecc-test.log"
+clean_cmd_test "ecc"
 
-# Create test directories
+# Redirect all output to log file
+exec > >(tee -a "$LOG_FILE") 2>&1
+
+# Create test data and output directories
 mkdir -p ecc_outputs
-
-# Create test data for signing
 echo "This is test data for ECC signing and verification." > ecc_outputs/test_data.txt
 
 # Array of ECC curves and providers to test
@@ -107,12 +109,8 @@ test_sign_verify_pkeyutl() {
     local curve=$1
     local provider_args=$2
     
-    # Print the provider args
-    if [ "$provider_args" = "-provider default" ]; then
-        provider_name="default"
-    else
-        provider_name="wolfProvider"
-    fi
+    # Get the provider name
+    provider_name=$(get_provider_name "$provider_args")
     
     local key_file="ecc_outputs/ecc_${curve}.pem"
     local pub_key_file="ecc_outputs/ecc_${curve}_pub.pem"
@@ -190,8 +188,11 @@ generate_and_test_key() {
     local curve=$1
     local provider_args=$2
     local output_file="ecc_outputs/ecc_${curve}.pem"
+
+    # Get the provider name
+    provider_name=$(get_provider_name "$provider_args")
     
-    echo -e "\n=== Testing ECC Key Generation (${curve}) with provider default ==="
+    echo -e "\n=== Testing ECC Key Generation (${curve}) with ${provider_name} ==="
     echo "Generating ECC key (${curve})..."
     
     if $OPENSSL_BIN genpkey -algorithm EC \
@@ -217,29 +218,28 @@ generate_and_test_key() {
     # Validate key
     validate_key "$curve" "$output_file" "$provider_args"
 
-    # Try to use the key with provider default
-    echo -e "\n=== Testing ECC Key (${curve}) with provider default ==="
-    echo "Checking if provider default can use the key..."
+    # Try to use the key with different providers
+    echo -e "\n=== Testing ECC Key (${curve}) with ${provider_name} ==="
+    echo "Checking if ${provider_name} can use the key..."
     
     # Try to use the key with wolfProvider (just check if it loads)
     if $OPENSSL_BIN pkey -in "$output_file" -check \
         ${provider_args} -passin pass: >/dev/null; then
-        echo "[PASS] provider default can use ECC key (${curve})"
+        echo "[PASS] ${provider_name} can use ECC key (${curve})"
         check_force_fail
     else
-        echo "[FAIL] provider default cannot use ECC key (${curve})"
+        echo "[FAIL] ${provider_name} cannot use ECC key (${curve})"
         FAIL=1
     fi
 }
 
 # Test key generation for each curve and provider
 for curve in "${CURVES[@]}"; do
-    # Generate with default provider
-    test_provider="-provider default"
-    generate_and_test_key "$curve" "$test_provider"
-
-    # Test sign/verify interoperability with appropriate function
     for test_provider in "${PROVIDER_ARGS[@]}"; do
+        # Generate key with current provider
+        generate_and_test_key "$curve" "$test_provider"
+
+        # Test sign/verify interoperability
         test_sign_verify_pkeyutl "$curve" "$test_provider"
     done
 done

--- a/scripts/cmd_test/ecc-cmd-test.sh
+++ b/scripts/cmd_test/ecc-cmd-test.sh
@@ -21,6 +21,7 @@
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 source "${SCRIPT_DIR}/cmd-test-common.sh"
+source "${SCRIPT_DIR}/clean-cmd-test.sh"
 cmd_test_env_setup "ecc-test.log"
 
 # Create test directories

--- a/scripts/cmd_test/hash-cmd-test.sh
+++ b/scripts/cmd_test/hash-cmd-test.sh
@@ -23,10 +23,14 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 source "${SCRIPT_DIR}/cmd-test-common.sh"
 source "${SCRIPT_DIR}/clean-cmd-test.sh"
 cmd_test_env_setup "hash-test.log"
+clean_cmd_test "hash"
+
+# Redirect all output to log file
+exec > >(tee -a "$LOG_FILE") 2>&1
 
 # Create test data and output directories
 mkdir -p hash_outputs
-echo "This is test data for hash algorithm testing." > test.txt
+echo "This is test data for hash cmd test." > hash_outputs/test_data.txt
 
 # Array of hash algorithms to test
 HASH_ALGOS=("sha1" "sha224" "sha256" "sha384" "sha512")
@@ -40,7 +44,7 @@ run_hash_test() {
     local output_file="$3"
     
     # Run the hash algorithm with specified provider options
-    if ! $OPENSSL_BIN dgst -$algo $provider_opts -out "$output_file" test.txt; then
+    if ! $OPENSSL_BIN dgst -$algo $provider_opts -out "$output_file" hash_outputs/test_data.txt; then
         echo "[FAIL] Hash generation failed for ${algo}"
         FAIL=1
     fi

--- a/scripts/cmd_test/hash-cmd-test.sh
+++ b/scripts/cmd_test/hash-cmd-test.sh
@@ -21,6 +21,7 @@
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 source "${SCRIPT_DIR}/cmd-test-common.sh"
+source "${SCRIPT_DIR}/clean-cmd-test.sh"
 cmd_test_env_setup "hash-test.log"
 
 # Create test data and output directories

--- a/scripts/cmd_test/rsa-cmd-test.sh
+++ b/scripts/cmd_test/rsa-cmd-test.sh
@@ -21,6 +21,7 @@
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 source "${SCRIPT_DIR}/cmd-test-common.sh"
+source "${SCRIPT_DIR}/clean-cmd-test.sh"
 cmd_test_env_setup "rsa-test.log"
 
 # Create test directories


### PR DESCRIPTION
# Description 

- Fix the hang we where experiencing locally with rsa cmd test. Needed to clean old test artifacts before running the test again. Fix ensures we wont have any test artifacts if we do the `do-cmd-tests.sh` or if we do single test like `rsa-cmd-test.sh`
- Fix bug to Actually test wolfprov keygen and not just default 
- Fix output to test log files wasn't propagating them correctly we where just getting blank log files before.