### PR TITLE
Revamp Debug Selection and Output in wolfProvider

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,12 @@ It will retrieve the dependencies and compile them as necessary. To use other th
 OPENSSL_TAG=openssl-3.5.0 WOLFSSL_TAG=v5.8.0-stable WOLFPROV_DEBUG=1 scripts/build-wolfprovider.sh
 ```
 
+Or you can set them with variables like so:
+
+```
+./scripts/build-wolfprovider.sh --debug --openssl-ver=openssl-3.5.0 --wolfssl-ver=v5.8.0-stable
+```
+
 To clean the build, use the following:
 ```
 ./scripts/build-wolfprovider.sh --clean
@@ -152,4 +158,9 @@ To run the command tests:
 
 To run the cipher suite testing:
 * `./scripts/test-wp-cs.sh`
+
+
+## Debugging
+
+To enable wolfProvider debug logging, build with `--debug`. If you want to filter logging a certain way, set `WOLFPROV_LOG_LEVEL_FILTER` and `WOLFPROV_LOG_COMPONENTS_FILTER` in `include/wolfprovider/wp_logging.h` as needed. See comments in that file for examples.
 

--- a/README.md
+++ b/README.md
@@ -162,5 +162,5 @@ To run the cipher suite testing:
 
 ## Debugging
 
-To enable wolfProvider debug logging, build with `--debug`. If you want to filter logging a certain way, set `WOLFPROV_LOG_LEVEL_FILTER` and `WOLFPROV_LOG_COMPONENTS_FILTER` in `include/wolfprovider/wp_logging.h` as needed. See comments in that file for examples.
+To enable wolfProvider debug logging, build with `--debug` which enables exit messages, error messages, and informational messages. If you want to filter logging a certain way or increase detail level, set `WOLFPROV_LOG_LEVEL_FILTER` and `WOLFPROV_LOG_COMPONENTS_FILTER` in `include/wolfprovider/wp_logging.h` as needed. See comments in that file for examples.
 

--- a/include/wolfprovider/wp_logging.h
+++ b/include/wolfprovider/wp_logging.h
@@ -67,37 +67,91 @@
  * WOLFPROV_LOG_PRINTF  Define to Use printf instead of fprintf (to stderr)
  *                        for logs. Not applicable if using WOLFPROV_USER_LOG
  *                        or custom logging callback.
+ *
+ * COMPILE-TIME MACRO CONFIGURATIONS:
+ * Define these macros in this header to control logging at compile time:
+ * NOTE: wolfProvider needs to be built with --debug to enable the logging first
+ * before we can set the log level and components.
+ * 
+ * WOLFPROV_LOG_LEVEL_FILTER Sets the log level. Use WP_LOG_* constants from enum below.
+ *                        Examples:
+ *                        - WP_LOG_ERROR (only errors)
+ *                        - (WP_LOG_ERROR | WP_LOG_ENTER) (errors and function enter)
+ *                        - (WP_LOG_ERROR | WP_LOG_LEAVE) (errors and function leave)
+ *                        - (WP_LOG_LEVEL_ALL) (all levels)
+ *
+ * WOLFPROV_LOG_COMPONENTS_FILTER  Set component bitmask to filter specific
+ *                        algorithms. Use WP_LOG_* constants from enum below.
+ *                        Examples:
+ *                        - WP_LOG_HKDF (HKDF only)
+ *                        - (WP_LOG_AES | WP_LOG_DES) (ciphers only)
+ *                        - (WP_LOG_ECC | WP_LOG_RSA | WP_LOG_HKDF) (multiple algorithms)
+ *                        - WP_LOG_CIPHER (all cipher operations)
+ *
+ * EXAMPLES:
+ * #define WOLFPROV_LOG_LEVEL_FILTER (WP_LOG_ERROR | WP_LOG_ENTER | WP_LOG_LEAVE | WP_LOG_INFO)
+ * #define WOLFPROV_LOG_COMPONENTS_FILTER WP_LOG_HKDF
+ * // Shows level (ERROR + ENTER/LEAVE + INFO) for HKDF operations only
+ *
+ * #define WOLFPROV_LOG_LEVEL_FILTER (WP_LOG_LEVEL_ALL)
+ * #define WOLFPROV_LOG_COMPONENTS_FILTER (WP_LOG_ECC | WP_LOG_RSA | WP_LOG_HKDF)
+ * // Shows level (ERROR + ENTER/LEAVE + INFO + VERBOSE + DEBUG + TRACE) for ECC, RSA, and HKDF only
  */
 enum wolfProv_LogType {
-    WP_LOG_ERROR   = 0x0001,  /* logs errors */
-    WP_LOG_ENTER   = 0x0002,  /* logs function enter*/
-    WP_LOG_LEAVE   = 0x0004,  /* logs function leave */
-    WP_LOG_INFO    = 0x0008,  /* logs informative messages */
-    WP_LOG_VERBOSE = 0x0010,  /* logs encrypted/decrypted/digested data */
+    WP_LOG_ERROR   = 0x0001,   /* logs errors */
+    WP_LOG_ENTER   = 0x0002,   /* logs function enter*/
+    WP_LOG_LEAVE   = 0x0004,   /* logs function leave */
+    WP_LOG_INFO    = 0x0008,   /* logs informative messages */
+    WP_LOG_VERBOSE = 0x0010,   /* logs encrypted/decrypted/digested data */
+    WP_LOG_DEBUG   = 0x0020,   /* logs debug-level detailed information */
+    WP_LOG_TRACE   = 0x0040,   /* logs trace-level ultra-detailed information */
 
-    /* default log level when logging is turned on, all but verbose */
-    WP_LOG_LEVEL_DEFAULT = (WP_LOG_ERROR
-                          | WP_LOG_ENTER
-                          | WP_LOG_LEAVE
-                          | WP_LOG_INFO),
+    /* default log level when logging is turned on */
+    WP_LOG_LEVEL_DEFAULT = (WP_LOG_ERROR | WP_LOG_LEAVE | WP_LOG_INFO),
 
     /* log all, including verbose */
     WP_LOG_LEVEL_ALL = (WP_LOG_ERROR
                       | WP_LOG_ENTER
                       | WP_LOG_LEAVE
                       | WP_LOG_INFO
-                      | WP_LOG_VERBOSE)
+                      | WP_LOG_VERBOSE
+                      | WP_LOG_DEBUG
+                      | WP_LOG_TRACE)
 };
 
 enum wolfProv_LogComponents {
-    WP_LOG_RNG      = 0x0001,  /* random number generation */
-    WP_LOG_DIGEST   = 0x0002,  /* digest (SHA-1/2/3) */
-    WP_LOG_MAC      = 0x0004,  /* mac functions: HMAC, CMAC */
-    WP_LOG_CIPHER   = 0x0008,  /* cipher (AES, 3DES) */
-    WP_LOG_PK       = 0x0010,  /* public key algorithms (RSA, ECC) */
-    WP_LOG_KE       = 0x0020,  /* key agreement (DH, ECDH) */
-    WP_LOG_KDF      = 0x0040,  /* password base key derivation algorithms */
-    WP_LOG_PROVIDER = 0x0080,  /* all provider specific logs */
+    /* Legacy component categories */
+    WP_LOG_RNG      = 0x0001,   /* random number generation */
+    WP_LOG_DIGEST   = 0x0002,   /* digest (SHA-1/2/3) */
+    WP_LOG_MAC      = 0x0004,   /* mac functions: HMAC, CMAC */
+    WP_LOG_CIPHER   = 0x0008,   /* cipher (AES, 3DES) */
+    WP_LOG_PK       = 0x0010,   /* public key algorithms (RSA, ECC) */
+    WP_LOG_KE       = 0x0020,   /* key agreement (DH, ECDH) */
+    WP_LOG_KDF      = 0x0040,   /* password base key derivation algorithms */
+    WP_LOG_PROVIDER = 0x0080,   /* all provider specific logs */
+    
+    /* Granular algorithm family categories */
+    WP_LOG_RSA      = 0x0001,   /* RSA operations */
+    WP_LOG_ECC      = 0x0002,   /* ECC operations */
+    WP_LOG_DH       = 0x0004,   /* Diffie-Hellman operations */
+    WP_LOG_AES      = 0x0008,   /* AES cipher operations */
+    WP_LOG_DES      = 0x0010,   /* 3DES cipher operations */
+    WP_LOG_SHA      = 0x0020,   /* SHA digest operations */
+    WP_LOG_MD5      = 0x0040,   /* MD5 digest operations */
+    WP_LOG_HMAC     = 0x0080,   /* HMAC operations */
+    WP_LOG_CMAC     = 0x0100,   /* CMAC operations */
+    WP_LOG_HKDF     = 0x0200,   /* HKDF operations */
+    WP_LOG_PBKDF2   = 0x0400,   /* PBKDF2 operations */
+    WP_LOG_KRB5KDF  = 0x0800,   /* KRB5KDF operations */
+    WP_LOG_DRBG     = 0x1000,   /* DRBG operations */
+    WP_LOG_ECDSA    = 0x2000,   /* ECDSA signature operations */
+    WP_LOG_ECDH     = 0x4000,   /* ECDH key exchange operations */
+    WP_LOG_ED25519  = 0x8000,   /* Ed25519 operations */
+    WP_LOG_ED448    = 0x10000,  /* Ed448 operations */
+    WP_LOG_X25519   = 0x20000,  /* X25519 operations */
+    WP_LOG_X448     = 0x40000,  /* X448 operations */
+    WP_LOG_QUERY    = 0x80000,  /* wolfprov_query operations */
+    WP_LOG_TLS1_PRF = 0x100000, /* TLS1 PRF operations */
 
     /* log all compoenents */
     WP_LOG_COMPONENTS_ALL = (WP_LOG_RNG
@@ -107,11 +161,51 @@ enum wolfProv_LogComponents {
                            | WP_LOG_PK
                            | WP_LOG_KE
                            | WP_LOG_KDF
-                           | WP_LOG_PROVIDER),
+                           | WP_LOG_PROVIDER
+                           | WP_LOG_RSA
+                           | WP_LOG_ECC
+                           | WP_LOG_DH
+                           | WP_LOG_AES
+                           | WP_LOG_DES
+                           | WP_LOG_SHA
+                           | WP_LOG_MD5
+                           | WP_LOG_HMAC
+                           | WP_LOG_CMAC
+                           | WP_LOG_HKDF
+                           | WP_LOG_PBKDF2
+                           | WP_LOG_KRB5KDF
+                           | WP_LOG_DRBG
+                           | WP_LOG_ECDSA
+                           | WP_LOG_ECDH
+                           | WP_LOG_ED25519
+                           | WP_LOG_ED448
+                           | WP_LOG_X25519
+                           | WP_LOG_X448
+                           | WP_LOG_QUERY
+                           | WP_LOG_TLS1_PRF),
 
     /* default compoenents logged */
     WP_LOG_COMPONENTS_DEFAULT = WP_LOG_COMPONENTS_ALL
 };
+
+/* Manually set the log level */
+#ifndef WOLFPROV_LOG_LEVEL_FILTER
+#define WOLFPROV_LOG_LEVEL_FILTER WP_LOG_LEVEL_DEFAULT
+#endif
+
+/* Manually set the components */
+#ifndef WOLFPROV_LOG_COMPONENTS_FILTER
+#define WOLFPROV_LOG_COMPONENTS_FILTER WP_LOG_COMPONENTS_DEFAULT
+#endif
+
+/* Conditional logging macro that checks compile-time configuration */
+#ifdef WOLFPROV_DEBUG
+    #define WOLFPROV_COMPILE_TIME_CHECK(component, level) \
+        ((WOLFPROV_LOG_LEVEL_FILTER & (level)) && \
+         (WOLFPROV_LOG_COMPONENTS_FILTER & (component)))
+#else
+    #define WOLFPROV_COMPILE_TIME_CHECK(component, level) 0
+#endif
 
 typedef void (*wolfProv_Logging_cb)(const int logLevel, const int component,
     const char *const logMessage);
@@ -156,6 +250,8 @@ void WOLFPROV_ENTER(int type, const char* msg);
 void WOLFPROV_LEAVE_EX(int type, const char* func, const char* msg, int ret);
 void WOLFPROV_MSG(int type, const char* fmt, ...);
 void WOLFPROV_MSG_VERBOSE(int type, const char* fmt, ...);
+void WOLFPROV_MSG_DEBUG(int type, const char* fmt, ...);
+void WOLFPROV_MSG_TRACE(int type, const char* fmt, ...);
 void WOLFPROV_ERROR_LINE(int type, int err, const char* file, int line);
 void WOLFPROV_ERROR_MSG_LINE(int type, const char* msg, const char* file,
     int line);
@@ -172,6 +268,8 @@ void WOLFPROV_BUFFER(int type, const unsigned char* buffer,
 #define WOLFPROV_LEAVE(t, m, r)
 #define WOLFPROV_MSG(t, m, ...)
 #define WOLFPROV_MSG_VERBOSE(t, m, ...)
+#define WOLFPROV_MSG_DEBUG(t, m, ...)
+#define WOLFPROV_MSG_TRACE(t, m, ...)
 #define WOLFPROV_ERROR(t, e)
 #define WOLFPROV_ERROR_MSG(t, e)
 #define WOLFPROV_ERROR_FUNC(t, f, r)

--- a/include/wolfprovider/wp_logging.h
+++ b/include/wolfprovider/wp_logging.h
@@ -262,7 +262,7 @@ void WOLFPROV_ERROR_FUNC_NULL_LINE(int type, const char* funcName,
 void WOLFPROV_BUFFER(int type, const unsigned char* buffer,
     unsigned int length);
 
-#else
+#else /* WOLFPROV_DEBUG */
 
 #define WOLFPROV_ENTER(t, m)
 #define WOLFPROV_LEAVE(t, m, r)

--- a/src/wp_aes_aead.c
+++ b/src/wp_aes_aead.c
@@ -287,6 +287,8 @@ static int wp_aead_cache_aad(wp_AeadCtx *ctx, const unsigned char *in,
     int ok = 1;
     unsigned char *p;
 
+    WOLFPROV_ENTER(WP_LOG_AES, "wp_aead_cache_aad");
+
     if (inLen > 0) {
         p = (unsigned char*)OPENSSL_realloc(ctx->aad, ctx->aadLen + inLen);
         if (p == NULL) {
@@ -302,7 +304,7 @@ static int wp_aead_cache_aad(wp_AeadCtx *ctx, const unsigned char *in,
         ctx->aadSet = 1;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_AES, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 #endif
@@ -322,6 +324,8 @@ static int wp_aead_cache_in(wp_AeadCtx *ctx, const unsigned char *in,
 {
     int ok = 1;
     unsigned char *p;
+
+    WOLFPROV_ENTER(WP_LOG_AES, "wp_aead_cache_in");
 
     if (inLen > 0) {
         if (inLen < (ctx->bufSize - ctx->inLen)) {
@@ -344,7 +348,7 @@ static int wp_aead_cache_in(wp_AeadCtx *ctx, const unsigned char *in,
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_AES, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 #endif
@@ -361,6 +365,8 @@ static int wp_aead_get_ctx_params(wp_AeadCtx* ctx, OSSL_PARAM params[])
 {
     int ok = 1;
     OSSL_PARAM* p;
+
+    WOLFPROV_ENTER(WP_LOG_AES, "wp_aead_get_ctx_params");
 
     p = OSSL_PARAM_locate(params, OSSL_CIPHER_PARAM_IVLEN);
     if (p != NULL && !OSSL_PARAM_set_size_t(p, ctx->ivLen)) {
@@ -448,7 +454,7 @@ static int wp_aead_get_ctx_params(wp_AeadCtx* ctx, OSSL_PARAM params[])
     }
 #endif
 
-    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_AES, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -464,6 +470,9 @@ static int wp_aead_set_param_tag(wp_AeadCtx* ctx,
     const OSSL_PARAM params[])
 {
     int ok = 1;
+
+    WOLFPROV_ENTER(WP_LOG_AES, "wp_aead_set_param_tag");
+
     const OSSL_PARAM* p = params;
     size_t sz;
     void* vp = ctx->buf;
@@ -481,7 +490,7 @@ static int wp_aead_set_param_tag(wp_AeadCtx* ctx,
     }
     ctx->tagLen = sz;
 
-    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_AES, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -500,6 +509,8 @@ static int wp_aead_set_param_iv_len(wp_AeadCtx* ctx,
     const OSSL_PARAM* p = params;
     size_t sz;
 
+    WOLFPROV_ENTER(WP_LOG_AES, "wp_aead_set_param_iv_len");
+
     if (!OSSL_PARAM_get_size_t(p, &sz)) {
         ok = 0;
     }
@@ -510,7 +521,7 @@ static int wp_aead_set_param_iv_len(wp_AeadCtx* ctx,
         ctx->ivLen = sz;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_AES, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -526,6 +537,9 @@ static int wp_aead_set_param_tls1_aad(wp_AeadCtx* ctx,
     const OSSL_PARAM params[])
 {
     int ok = 1;
+
+    WOLFPROV_ENTER(WP_LOG_AES, "wp_aead_set_param_tls1_aad");
+
     const OSSL_PARAM* p = params;
     size_t sz;
 
@@ -540,7 +554,7 @@ static int wp_aead_set_param_tls1_aad(wp_AeadCtx* ctx,
         ctx->tlsAadPadSz = sz;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_AES, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -556,6 +570,9 @@ static int wp_aead_set_param_tls1_iv_fixed(wp_AeadCtx* ctx,
     const OSSL_PARAM params[])
 {
     int ok = 1;
+
+    WOLFPROV_ENTER(WP_LOG_AES, "wp_aead_set_param_tls1_iv_fixed");
+
     const OSSL_PARAM* p = params;
 
     if (p->data_type != OSSL_PARAM_OCTET_STRING) {
@@ -576,7 +593,7 @@ static int wp_aead_set_param_tls1_iv_fixed(wp_AeadCtx* ctx,
     }
 #endif
 
-    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_AES, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -595,6 +612,8 @@ static int wp_aead_set_param_tls1_iv_rand(wp_AeadCtx* ctx,
     int ok = 1;
     const OSSL_PARAM* p = params;
 
+    WOLFPROV_ENTER(WP_LOG_AES, "wp_aead_set_param_tls1_iv_rand");
+
     if (p->data == NULL) {
         ok = 0;
     }
@@ -605,12 +624,12 @@ static int wp_aead_set_param_tls1_iv_rand(wp_AeadCtx* ctx,
         ok = 0;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_AES, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 #else
     (void)ctx;
     (void)params;
-    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), 1);
+    WOLFPROV_LEAVE(WP_LOG_AES, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), 1);
     return 1;
 #endif
 }
@@ -626,6 +645,8 @@ static int wp_aead_set_param_tls1_iv_rand(wp_AeadCtx* ctx,
 static int wp_aead_set_ctx_params(wp_AeadCtx* ctx, const OSSL_PARAM params[])
 {
     int ok = 1;
+
+    WOLFPROV_ENTER(WP_LOG_AES, "wp_aead_set_ctx_params");
 
     while ((params != NULL) && (params->key != NULL)) {
         if (XMEMCMP(params->key, OSSL_CIPHER_PARAM_AEAD_TAG,
@@ -653,7 +674,7 @@ static int wp_aead_set_ctx_params(wp_AeadCtx* ctx, const OSSL_PARAM params[])
         params++;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_AES, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -699,6 +720,8 @@ static int wp_aead_get_params(OSSL_PARAM params[], unsigned int md,
 {
     int ok = 1;
     OSSL_PARAM* p;
+    
+    WOLFPROV_ENTER(WP_LOG_AES, "wp_aead_get_params");
 
     p = OSSL_PARAM_locate(params, OSSL_CIPHER_PARAM_MODE);
     if ((p != NULL) && (!OSSL_PARAM_set_uint(p, md))) {
@@ -744,7 +767,7 @@ static int wp_aead_get_params(OSSL_PARAM params[], unsigned int md,
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_AES, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -834,6 +857,8 @@ static int wp_aesgcm_get_rand_iv(wp_AeadCtx* ctx, unsigned char* out,
 {
     int ok = 1;
 
+    WOLFPROV_ENTER(WP_LOG_AES, "wp_aesgcm_get_rand_iv");
+
     /* Ensure that an IV/nonce has not been generated or a key set. */
     if ((!ctx->ivGen) || (!ctx->keySet)) {
         ok = 0;
@@ -868,7 +893,7 @@ static int wp_aesgcm_get_rand_iv(wp_AeadCtx* ctx, unsigned char* out,
         ctx->ivState = IV_STATE_COPIED;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_AES, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -886,6 +911,8 @@ static int wp_aesgcm_set_rand_iv(wp_AeadCtx *ctx, unsigned char *in,
 {
     int ok = 1;
 
+    WOLFPROV_ENTER(WP_LOG_AES, "wp_aesgcm_set_rand_iv");
+
     /* Ensure that an IV/nonce has not been generated or a key set and this
      * is the decrypt side.
      */
@@ -900,7 +927,7 @@ static int wp_aesgcm_set_rand_iv(wp_AeadCtx *ctx, unsigned char *in,
         ctx->ivState = IV_STATE_COPIED;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_AES, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -917,6 +944,8 @@ static int wp_aesgcm_tls_iv_set_fixed(wp_AeadCtx* ctx, unsigned char* iv,
     size_t len)
 {
     int ok = 1;
+
+    WOLFPROV_ENTER(WP_LOG_AES, "wp_aesgcm_tls_iv_set_fixed");
 
     /* Special case: -1 length restores whole IV */
     if (len == (size_t)-1) {
@@ -961,7 +990,7 @@ static int wp_aesgcm_tls_iv_set_fixed(wp_AeadCtx* ctx, unsigned char* iv,
         ctx->ivState = IV_STATE_BUFFERED;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_AES, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -985,6 +1014,8 @@ static int wp_aesgcm_einit(wp_AeadCtx* ctx, const unsigned char *key,
 {
     Aes *aes = &ctx->aes;
     int ok = 1;
+
+    WOLFPROV_ENTER(WP_LOG_AES, "wp_aesgcm_einit");
 
     if (!wolfssl_prov_is_running()) {
         ok = 0;
@@ -1042,7 +1073,7 @@ static int wp_aesgcm_einit(wp_AeadCtx* ctx, const unsigned char *key,
         ok = wp_aead_set_ctx_params(ctx, params);
     }
 
-    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_AES, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1066,6 +1097,8 @@ static int wp_aesgcm_dinit(wp_AeadCtx *ctx, const unsigned char *key,
 {
     Aes *aes = &ctx->aes;
     int ok = 1;
+
+    WOLFPROV_ENTER(WP_LOG_AES, "wp_aesgcm_dinit");
 
     if (!wolfssl_prov_is_running()) {
         ok = 0;
@@ -1106,7 +1139,7 @@ static int wp_aesgcm_dinit(wp_AeadCtx *ctx, const unsigned char *key,
         ok = wp_aead_set_ctx_params(ctx, params);
     }
 
-    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_AES, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1126,6 +1159,8 @@ static int wp_aesgcm_tls_cipher(wp_AeadCtx* ctx, unsigned char* out,
 {
     int ok = 1;
     size_t oLen = 0;
+
+    WOLFPROV_ENTER(WP_LOG_AES, "wp_aesgcm_tls_cipher");
 
     if (!wolfssl_prov_is_running() || !ctx->keySet) {
         ok = 0;
@@ -1189,7 +1224,7 @@ static int wp_aesgcm_tls_cipher(wp_AeadCtx* ctx, unsigned char* out,
     ctx->ivState = IV_STATE_FINISHED;
     ctx->tlsAadLen = UNINITIALISED_SIZET;
     *outLen = oLen;
-    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_AES, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1214,6 +1249,8 @@ static int wp_aesgcm_stream_update(wp_AeadCtx *ctx, unsigned char *out,
     int done = 0;
     size_t oLen = 0;
     int rc;
+
+    WOLFPROV_ENTER(WP_LOG_AES, "wp_aesgcm_stream_update");
 
     if (ctx->tlsAadLen != UNINITIALISED_SIZET) {
         ok = wp_aesgcm_tls_cipher(ctx, out, outLen, in, inLen);
@@ -1267,7 +1304,7 @@ static int wp_aesgcm_stream_update(wp_AeadCtx *ctx, unsigned char *out,
         *outLen = oLen;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_AES, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1288,6 +1325,8 @@ static int wp_aesgcm_stream_final(wp_AeadCtx *ctx, unsigned char *out,
     int ok = 1;
     int done = 0;
     int rc;
+
+    WOLFPROV_ENTER(WP_LOG_AES, "wp_aesgcm_stream_final");
 
     if (!wolfssl_prov_is_running()) {
         ok = 0;
@@ -1325,7 +1364,7 @@ static int wp_aesgcm_stream_final(wp_AeadCtx *ctx, unsigned char *out,
         *outLen = 0;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_AES, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1350,6 +1389,8 @@ static int wp_aesgcm_encdec(wp_AeadCtx *ctx, unsigned char *out, size_t* outLen,
     int rc;
     unsigned char *tmp = NULL;
     byte *iv = NULL;
+
+    WOLFPROV_ENTER(WP_LOG_AES, "wp_aesgcm_encdec");
 
     if (ctx->tagLen == UNINITIALISED_SIZET) {
         ctx->tagLen = EVP_GCM_TLS_TAG_LEN;
@@ -1443,7 +1484,7 @@ static int wp_aesgcm_encdec(wp_AeadCtx *ctx, unsigned char *out, size_t* outLen,
         ctx->inLen = 0;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_AES, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1465,6 +1506,8 @@ static int wp_aesgcm_stream_update(wp_AeadCtx *ctx, unsigned char *out,
     int ok = 1;
     int process = 0;
     size_t curLen = 0;
+
+    WOLFPROV_ENTER(WP_LOG_AES, "wp_aesgcm_stream_update");
 
     if (ctx->tlsAadLen != UNINITIALISED_SIZET) {
         ok = wp_aesgcm_tls_cipher(ctx, out, outLen, in, inLen);
@@ -1505,7 +1548,7 @@ static int wp_aesgcm_stream_update(wp_AeadCtx *ctx, unsigned char *out,
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_AES, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1525,6 +1568,8 @@ static int wp_aesgcm_stream_final(wp_AeadCtx *ctx, unsigned char *out,
     int ok = 1;
     (void)outSize;
 
+    WOLFPROV_ENTER(WP_LOG_AES, "wp_aesgcm_stream_final");
+
     if (ctx->tlsAadLen != UNINITIALISED_SIZET) {
         ok = wp_aesgcm_tls_cipher(ctx, out, outLen, NULL, 0);
     }
@@ -1536,7 +1581,7 @@ static int wp_aesgcm_stream_final(wp_AeadCtx *ctx, unsigned char *out,
         ctx->ivSet = 0;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_AES, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1560,6 +1605,8 @@ static int wp_aesgcm_cipher(wp_AeadCtx *ctx, unsigned char *out,
     int ok = 1;
     size_t finalLen = 0;
 
+    WOLFPROV_ENTER(WP_LOG_AES, "wp_aesgcm_cipher");
+
     if (!wolfssl_prov_is_running()) {
         ok = 0;
     }
@@ -1577,7 +1624,7 @@ static int wp_aesgcm_cipher(wp_AeadCtx *ctx, unsigned char *out,
         *outLen += finalLen;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_AES, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1650,6 +1697,8 @@ static int wp_aesccm_tls_iv_set_fixed(wp_AeadCtx* ctx, unsigned char* iv,
 {
     int ok = 1;
 
+    WOLFPROV_ENTER(WP_LOG_AES, "wp_aesccm_tls_iv_set_fixed");
+
     if (len != EVP_CCM_TLS_FIXED_IV_LEN) {
         ok = 0;
     }
@@ -1658,7 +1707,7 @@ static int wp_aesccm_tls_iv_set_fixed(wp_AeadCtx* ctx, unsigned char* iv,
         memcpy(ctx->iv, iv, len);
     }
 
-    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_AES, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1682,6 +1731,8 @@ static int wp_aesccm_init(wp_AeadCtx* ctx, const unsigned char *key,
 {
     int ok = 1;
     int rc;
+
+    WOLFPROV_ENTER(WP_LOG_AES, "wp_aesccm_init");
 
     if (!wolfssl_prov_is_running()) {
         ok = 0;
@@ -1707,7 +1758,7 @@ static int wp_aesccm_init(wp_AeadCtx* ctx, const unsigned char *key,
         ok = wp_aead_set_ctx_params(ctx, params);
     }
 
-    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_AES, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1771,6 +1822,8 @@ static int wp_aesccm_tls_cipher(wp_AeadCtx* ctx, unsigned char* out,
     int ok = 1;
     size_t olen = 0;
 
+    WOLFPROV_ENTER(WP_LOG_AES, "wp_aesccm_tls_cipher");
+
     if (!wolfssl_prov_is_running()) {
         ok = 0;
     }
@@ -1824,7 +1877,7 @@ static int wp_aesccm_tls_cipher(wp_AeadCtx* ctx, unsigned char* out,
     }
 
     *outLen = olen;
-    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_AES, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1843,6 +1896,8 @@ static int wp_aesccm_encdec(wp_AeadCtx *ctx, unsigned char *out,
 {
     int ok = 1;
     int rc;
+
+    WOLFPROV_ENTER(WP_LOG_AES, "wp_aesccm_encdec");
 
     if (ctx->tagLen == UNINITIALISED_SIZET) {
         ctx->tagLen = EVP_CCM_TLS_TAG_LEN;
@@ -1886,7 +1941,7 @@ static int wp_aesccm_encdec(wp_AeadCtx *ctx, unsigned char *out,
     ctx->aadLen = 0;
     ctx->aadSet = 0;
 
-    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_AES, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 /**
@@ -1905,6 +1960,8 @@ static int wp_aesccm_stream_update(wp_AeadCtx *ctx, unsigned char *out,
     size_t *outLen, size_t outSize, const unsigned char *in, size_t inLen)
 {
     int ok = 1;
+
+    WOLFPROV_ENTER(WP_LOG_AES, "wp_aesccm_stream_update");
 
     if (ctx->tlsAadLen != UNINITIALISED_SIZET) {
         ok = wp_aesccm_tls_cipher(ctx, out, outLen, in, inLen);
@@ -1942,7 +1999,7 @@ static int wp_aesccm_stream_update(wp_AeadCtx *ctx, unsigned char *out,
         *outLen = (size_t)oLen;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_AES, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1962,6 +2019,8 @@ static int wp_aesccm_stream_final(wp_AeadCtx *ctx, unsigned char *out,
     int ok = 1;
     (void)outSize;
 
+    WOLFPROV_ENTER(WP_LOG_AES, "wp_aesccm_stream_final");
+
     if (ctx->tlsAadLen != UNINITIALISED_SIZET) {
         ok = wp_aesccm_tls_cipher(ctx, out, outLen, NULL, 0);
     }
@@ -1978,7 +2037,7 @@ static int wp_aesccm_stream_final(wp_AeadCtx *ctx, unsigned char *out,
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_AES, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -2000,6 +2059,8 @@ static int wp_aesccm_cipher(wp_AeadCtx *ctx, unsigned char *out,
     int ok = 1;
     size_t finalLen;
 
+    WOLFPROV_ENTER(WP_LOG_AES, "wp_aesccm_cipher");
+
     if (!wolfssl_prov_is_running()) {
         ok = 0;
     }
@@ -2014,7 +2075,7 @@ static int wp_aesccm_cipher(wp_AeadCtx *ctx, unsigned char *out,
         *outLen += finalLen;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_AES, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 

--- a/src/wp_aes_block.c
+++ b/src/wp_aes_block.c
@@ -146,6 +146,8 @@ static int wp_aes_block_get_params(OSSL_PARAM params[], unsigned int mode,
     int ok = 1;
     OSSL_PARAM *p;
 
+    WOLFPROV_ENTER(WP_LOG_AES, "wp_aes_block_get_params");
+
     p = OSSL_PARAM_locate(params, OSSL_CIPHER_PARAM_MODE);
     if ((p != NULL) && (!OSSL_PARAM_set_uint(p, mode))) {
         ok = 0;
@@ -181,7 +183,7 @@ static int wp_aes_block_get_params(OSSL_PARAM params[], unsigned int mode,
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_AES, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -252,6 +254,8 @@ static int wp_aes_init_iv(wp_AesBlockCtx *ctx, const unsigned char *iv,
 {
     int ok = 1;
 
+    WOLFPROV_ENTER(WP_LOG_AES, "wp_aes_init_iv");
+
     if (ivLen != ctx->ivLen) {
         ok = 0;
     }
@@ -267,7 +271,7 @@ static int wp_aes_init_iv(wp_AesBlockCtx *ctx, const unsigned char *iv,
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_AES, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 #endif
@@ -292,6 +296,8 @@ static int wp_aes_block_init(wp_AesBlockCtx *ctx, const unsigned char *key,
     const OSSL_PARAM params[], int enc)
 {
     int ok = 1;
+
+    WOLFPROV_ENTER(WP_LOG_AES, "wp_aes_block_init");
 
     ctx->bufSz = 0;
     ctx->enc = enc;
@@ -333,7 +339,7 @@ static int wp_aes_block_init(wp_AesBlockCtx *ctx, const unsigned char *key,
         ok = wp_aes_block_set_ctx_params(ctx, params);
     }
 
-    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_AES, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -442,6 +448,8 @@ static int wp_aes_block_update(wp_AesBlockCtx *ctx, unsigned char *out,
     size_t oLen = 0;
     size_t nextBlocks;
 
+    WOLFPROV_ENTER(WP_LOG_AES, "wp_aes_block_update");
+
     if ((ctx->tls_version > 0) && (ctx->enc)) {
         int i;
         unsigned char off = inLen % AES_BLOCK_SIZE;
@@ -521,7 +529,7 @@ static int wp_aes_block_update(wp_AesBlockCtx *ctx, unsigned char *out,
         ok = invalid == 0;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_AES, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -535,11 +543,13 @@ static int wp_aes_block_update(wp_AesBlockCtx *ctx, unsigned char *out,
  * @return  1 on success.
  * @return  0 on failure.
  */
-static int wp_aes_block_final_enc(wp_AesBlockCtx* ctx, unsigned char *out,
+static int wp_aes_block_final_enc(wp_AesBlockCtx *ctx, unsigned char *out,
     size_t *outLen, size_t outSize)
 {
     int ok = 1;
     size_t oLen = 0;
+
+    WOLFPROV_ENTER(WP_LOG_AES, "wp_aes_block_final_enc");
 
     if (ctx->pad) {
         size_t i;
@@ -570,7 +580,7 @@ static int wp_aes_block_final_enc(wp_AesBlockCtx* ctx, unsigned char *out,
         ctx->bufSz = 0;
         *outLen = oLen;
     }
-    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_AES, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -588,6 +598,8 @@ static int wp_aes_block_final_dec(wp_AesBlockCtx* ctx, unsigned char *out,
     size_t *outLen, size_t outSize)
 {
     int ok = 1;
+
+    WOLFPROV_ENTER(WP_LOG_AES, "wp_aes_block_final_dec");
 
     if (ctx->pad) {
         if (ctx->bufSz != AES_BLOCK_SIZE) {
@@ -636,7 +648,7 @@ static int wp_aes_block_final_dec(wp_AesBlockCtx* ctx, unsigned char *out,
         *outLen = 0;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_AES, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -655,6 +667,8 @@ static int wp_aes_block_final(wp_AesBlockCtx* ctx, unsigned char *out,
 {
     int ok = 1;
 
+    WOLFPROV_ENTER(WP_LOG_AES, "wp_aes_block_final");
+
     if (!wolfssl_prov_is_running()) {
         ok = 0;
     }
@@ -668,7 +682,7 @@ static int wp_aes_block_final(wp_AesBlockCtx* ctx, unsigned char *out,
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_AES, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -689,6 +703,8 @@ static int wp_aes_block_cipher(wp_AesBlockCtx* ctx, unsigned char* out,
 {
     int ok = 1;
 
+    WOLFPROV_ENTER(WP_LOG_AES, "wp_aes_block_cipher");
+
     if (!wolfssl_prov_is_running()) {
         ok = 0;
     }
@@ -704,7 +720,7 @@ static int wp_aes_block_cipher(wp_AesBlockCtx* ctx, unsigned char* out,
         *outLen = inLen;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_AES, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -720,6 +736,8 @@ static int wp_aes_block_get_ctx_params(wp_AesBlockCtx* ctx, OSSL_PARAM params[])
 {
     int ok = 1;
     OSSL_PARAM* p;
+
+    WOLFPROV_ENTER(WP_LOG_AES, "wp_aes_block_get_ctx_params");
 
     p = OSSL_PARAM_locate(params, OSSL_CIPHER_PARAM_IVLEN);
     if ((p != NULL) && (!OSSL_PARAM_set_size_t(p, ctx->ivLen))) {
@@ -760,7 +778,7 @@ static int wp_aes_block_get_ctx_params(wp_AesBlockCtx* ctx, OSSL_PARAM params[])
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_AES, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -776,6 +794,8 @@ static int wp_aes_block_set_ctx_params(wp_AesBlockCtx *ctx,
     const OSSL_PARAM params[])
 {
     int ok = 1;
+
+    WOLFPROV_ENTER(WP_LOG_AES, "wp_aes_block_set_ctx_params");
 
     if (params != NULL) {
         unsigned int val;
@@ -807,7 +827,7 @@ static int wp_aes_block_set_ctx_params(wp_AesBlockCtx *ctx,
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_AES, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 

--- a/src/wp_aes_stream.c
+++ b/src/wp_aes_stream.c
@@ -142,6 +142,8 @@ static int wp_aes_stream_get_params(OSSL_PARAM params[], unsigned int mode,
     int ok = 1;
     OSSL_PARAM *p;
 
+    WOLFPROV_ENTER(WP_LOG_AES, "wp_aes_stream_get_params");
+
     p = OSSL_PARAM_locate(params, OSSL_CIPHER_PARAM_MODE);
     if ((p != NULL) && (!OSSL_PARAM_set_uint(p, mode))) {
         ok = 0;
@@ -185,7 +187,7 @@ static int wp_aes_stream_get_params(OSSL_PARAM params[], unsigned int mode,
     }
 #endif /* WP_HAVE_AESCTS */
 
-    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_AES, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -258,6 +260,8 @@ static int wp_aes_init_iv(wp_AesStreamCtx *ctx, const unsigned char *iv,
 {
     int ok = 1;
 
+    WOLFPROV_ENTER(WP_LOG_AES, "wp_aes_init_iv");
+
     if (ivLen != ctx->ivLen) {
         ok = 0;
     }
@@ -266,7 +270,7 @@ static int wp_aes_init_iv(wp_AesStreamCtx *ctx, const unsigned char *iv,
         XMEMCPY(ctx->oiv, iv, ivLen);
     }
 
-    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_AES, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -292,6 +296,8 @@ static int wp_aes_stream_init(wp_AesStreamCtx *ctx, const unsigned char *key,
     int ok = 1;
     /* Decryption is the same as encryption with CTR mode. */
     int dir = AES_ENCRYPTION;
+
+    WOLFPROV_ENTER(WP_LOG_AES, "wp_aes_stream_init");
 
     ctx->enc = enc;
 
@@ -335,7 +341,7 @@ static int wp_aes_stream_init(wp_AesStreamCtx *ctx, const unsigned char *key,
         ok = wp_aes_stream_set_ctx_params(ctx, params);
     }
 
-    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_AES, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -510,6 +516,8 @@ static int wp_aes_stream_doit(wp_AesStreamCtx *ctx, unsigned char *out,
 {
     int ok = 1;
 
+    WOLFPROV_ENTER(WP_LOG_AES, "wp_aes_stream_doit");
+
 #ifdef WP_HAVE_AESCTR
     if (ctx->mode == EVP_CIPH_CTR_MODE) {
         int rc;
@@ -568,7 +576,7 @@ static int wp_aes_stream_doit(wp_AesStreamCtx *ctx, unsigned char *out,
 #endif
     {}
 
-    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_AES, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -589,6 +597,8 @@ static int wp_aes_stream_update(wp_AesStreamCtx *ctx, unsigned char *out,
 {
     int ok = 1;
 
+    WOLFPROV_ENTER(WP_LOG_AES, "wp_aes_stream_update");
+
     if (outSize < inLen) {
         ok = 0;
     }
@@ -599,7 +609,7 @@ static int wp_aes_stream_update(wp_AesStreamCtx *ctx, unsigned char *out,
         *outLen = inLen;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_AES, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -620,8 +630,10 @@ static int wp_aes_stream_final(wp_AesStreamCtx* ctx, unsigned char *out,
     (void)ctx;
     (void)out;
     (void)outSize;
+
+    WOLFPROV_ENTER(WP_LOG_AES, "wp_aes_stream_final");
     *outLen = 0;
-    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), 1);
+    WOLFPROV_LEAVE(WP_LOG_AES, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), 1);
     return 1;
 }
 
@@ -642,6 +654,8 @@ static int wp_aes_stream_cipher(wp_AesStreamCtx* ctx, unsigned char* out,
 {
     int ok = 1;
 
+    WOLFPROV_ENTER(WP_LOG_AES, "wp_aes_stream_cipher");
+
     if (!wolfssl_prov_is_running()) {
         ok = 0;
     }
@@ -655,7 +669,7 @@ static int wp_aes_stream_cipher(wp_AesStreamCtx* ctx, unsigned char* out,
     }
 
     *outLen = inLen;
-    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_AES, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -672,6 +686,8 @@ static int wp_aes_stream_get_ctx_params(wp_AesStreamCtx* ctx,
 {
     int ok = 1;
     OSSL_PARAM* p;
+
+    WOLFPROV_ENTER(WP_LOG_AES, "wp_aes_stream_get_ctx_params");
 
     p = OSSL_PARAM_locate(params, OSSL_CIPHER_PARAM_IVLEN);
     if ((p != NULL) && (!OSSL_PARAM_set_size_t(p, ctx->ivLen))) {
@@ -714,7 +730,7 @@ static int wp_aes_stream_get_ctx_params(wp_AesStreamCtx* ctx,
     }
 #endif
 
-    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_AES, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -730,6 +746,8 @@ static int wp_aes_stream_set_ctx_params(wp_AesStreamCtx *ctx,
     const OSSL_PARAM params[])
 {
     int ok = 1;
+
+    WOLFPROV_ENTER(WP_LOG_AES, "wp_aes_stream_set_ctx_params");
 
     (void)ctx;
 
@@ -768,7 +786,7 @@ static int wp_aes_stream_set_ctx_params(wp_AesStreamCtx *ctx,
 #endif
     }
 
-    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_AES, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 

--- a/src/wp_aes_wrap.c
+++ b/src/wp_aes_wrap.c
@@ -133,6 +133,8 @@ static int wp_aes_wrap_get_params(OSSL_PARAM params[], unsigned int mode,
     int ok = 1;
     OSSL_PARAM *p;
 
+    WOLFPROV_ENTER(WP_LOG_AES, "wp_aes_wrap_get_params");
+
     p = OSSL_PARAM_locate(params, OSSL_CIPHER_PARAM_MODE);
     if ((p != NULL) && (!OSSL_PARAM_set_uint(p, mode))) {
         ok = 0;
@@ -168,7 +170,7 @@ static int wp_aes_wrap_get_params(OSSL_PARAM params[], unsigned int mode,
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_AES, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -241,6 +243,8 @@ static int wp_aes_wrap_init(wp_AesWrapCtx *ctx, const unsigned char *key,
 {
     int ok = 1;
 
+    WOLFPROV_ENTER(WP_LOG_AES, "wp_aes_wrap_init");
+
     ctx->wrap = wrap;
 
     if (!wolfssl_prov_is_running()) {
@@ -277,7 +281,7 @@ static int wp_aes_wrap_init(wp_AesWrapCtx *ctx, const unsigned char *key,
         ok = wp_aes_wrap_set_ctx_params(ctx, params);
     }
 
-    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_AES, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -336,6 +340,8 @@ static int wp_aes_wrap_update(wp_AesWrapCtx *ctx, unsigned char *out,
 {
     int ok = 1;
 
+    WOLFPROV_ENTER(WP_LOG_AES, "wp_aes_wrap_update");
+
     if (!wolfssl_prov_is_running()) {
         ok = 0;
     }
@@ -390,7 +396,7 @@ static int wp_aes_wrap_update(wp_AesWrapCtx *ctx, unsigned char *out,
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_AES, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -409,6 +415,8 @@ static int wp_aes_wrap_final(wp_AesWrapCtx* ctx, unsigned char *out,
 {
     int ok = 1;
 
+    WOLFPROV_ENTER(WP_LOG_AES, "wp_aes_wrap_final");
+
     (void)ctx;
     (void)out;
     (void)outSize;
@@ -420,7 +428,7 @@ static int wp_aes_wrap_final(wp_AesWrapCtx* ctx, unsigned char *out,
         *outLen = 0;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_AES, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -436,6 +444,8 @@ static int wp_aes_wrap_get_ctx_params(wp_AesWrapCtx* ctx, OSSL_PARAM params[])
 {
     int ok = 1;
     OSSL_PARAM* p;
+
+    WOLFPROV_ENTER(WP_LOG_AES, "wp_aes_wrap_get_ctx_params");
 
     p = OSSL_PARAM_locate(params, OSSL_CIPHER_PARAM_IVLEN);
     if ((p != NULL) && (!OSSL_PARAM_set_size_t(p, ctx->ivLen))) {
@@ -463,7 +473,7 @@ static int wp_aes_wrap_get_ctx_params(wp_AesWrapCtx* ctx, OSSL_PARAM params[])
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_AES, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -479,6 +489,8 @@ static int wp_aes_wrap_set_ctx_params(wp_AesWrapCtx *ctx,
     const OSSL_PARAM params[])
 {
     int ok = 1;
+
+    WOLFPROV_ENTER(WP_LOG_AES, "wp_aes_wrap_set_ctx_params");
 
     if (params != NULL) {
         size_t keyLen = ctx->keyLen;
@@ -501,7 +513,7 @@ static int wp_aes_wrap_set_ctx_params(wp_AesWrapCtx *ctx,
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_AES, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 

--- a/src/wp_cmac.c
+++ b/src/wp_cmac.c
@@ -112,6 +112,8 @@ static int wp_cmac_set_key(wp_CmacCtx* macCtx, const unsigned char* key,
 {
     int ok = 1;
 
+    WOLFPROV_ENTER(WP_LOG_MAC, "wp_cmac_set_key");
+
     if (keyLen > AES_256_KEY_SIZE) {
         ok = 0;
     }
@@ -187,6 +189,8 @@ static int wp_cmac_init(wp_CmacCtx* macCtx, const unsigned char* key,
 {
     int ok = 1;
 
+    WOLFPROV_ENTER(WP_LOG_MAC, "wp_cmac_init");
+
     if (!wolfssl_prov_is_running()) {
         ok = 0;
     }
@@ -219,6 +223,8 @@ static int wp_cmac_update(wp_CmacCtx* macCtx, const unsigned char* data,
     int ok = 1;
     int rc;
 
+    WOLFPROV_ENTER(WP_LOG_MAC, "wp_cmac_update");
+
     rc = wc_CmacUpdate(&macCtx->cmac, data, (word32)dataLen);
     if (rc != 0) {
         ok = 0;
@@ -244,6 +250,8 @@ static int wp_cmac_final(wp_CmacCtx* macCtx, unsigned char* out, size_t* outl,
     int ok = 1;
     int rc;
     word32 outSz;
+
+    WOLFPROV_ENTER(WP_LOG_MAC, "wp_cmac_final");
 
     if (!wolfssl_prov_is_running()) {
         ok = 0;
@@ -302,6 +310,8 @@ static int wp_cmac_get_ctx_params(wp_CmacCtx* macCtx, OSSL_PARAM params[])
 {
     int ok = 1;
     OSSL_PARAM* p;
+
+    WOLFPROV_ENTER(WP_LOG_MAC, "wp_cmac_get_ctx_params");
 
     p = OSSL_PARAM_locate(params, OSSL_MAC_PARAM_SIZE);
     if ((p != NULL) && (!OSSL_PARAM_set_size_t(p, macCtx->size))) {
@@ -379,6 +389,8 @@ static int wp_cmac_setup_cipher(wp_CmacCtx* macCtx, const OSSL_PARAM params[])
     int ok = 1;
     const OSSL_PARAM* p;
 
+    WOLFPROV_ENTER(WP_LOG_MAC, "wp_cmac_setup_cipher");
+
     p = OSSL_PARAM_locate_const(params, OSSL_ALG_PARAM_CIPHER);
     if (p != NULL) {
         if (p->data_type != OSSL_PARAM_UTF8_STRING) {
@@ -421,6 +433,8 @@ static int wp_cmac_set_param_key(wp_CmacCtx* macCtx, const OSSL_PARAM params[])
     unsigned char* data = NULL;
     size_t len;
 
+    WOLFPROV_ENTER(WP_LOG_MAC, "wp_cmac_set_param_key");
+
     if (!wp_params_get_octet_string_ptr(params, OSSL_MAC_PARAM_KEY, &data,
             &len)) {
         ok = 0;
@@ -444,6 +458,8 @@ static int wp_cmac_set_param_key(wp_CmacCtx* macCtx, const OSSL_PARAM params[])
 static int wp_cmac_set_ctx_params(wp_CmacCtx* macCtx, const OSSL_PARAM params[])
 {
     int ok = 1;
+
+    WOLFPROV_ENTER(WP_LOG_MAC, "wp_cmac_set_ctx_params");
 
     if (params != NULL) {
         if (!wp_cmac_setup_cipher(macCtx, params)) {

--- a/src/wp_dec_epki2pki.c
+++ b/src/wp_dec_epki2pki.c
@@ -194,6 +194,8 @@ static int wp_epki2pki_decode(wp_Epki2Pki* ctx, OSSL_CORE_BIO* coreBio,
     size_t passwordLen;
     word32 tradIdx = 0;
 
+    WOLFPROV_ENTER(WP_LOG_PK, "wp_epki2pki_decode");
+
     (void)ctx;
     (void)selection;
 

--- a/src/wp_dec_pem2der.c
+++ b/src/wp_dec_pem2der.c
@@ -154,6 +154,8 @@ static int wp_pem2der_convert(const char* data, word32 len, DerBuffer** pDer,
     const char* base64Data;
     size_t base64Len;
 
+    WOLFPROV_ENTER(WP_LOG_PK, "wp_pem2der_convert");
+
     /* Skip '-----BEGIN <name>-----\n'. */
     base64Data = data + 16 + nameLen + 1;
     base64Len = len - 16 + nameLen + 1;
@@ -216,6 +218,8 @@ static int wp_pem2der_decode_data(const unsigned char* data, word32 len,
 #ifdef WOLFSSL_ENCRYPTED_KEYS
     wp_PasswordCbData wpPwCb = { pwCb, pwCbArg };
 #endif
+
+    WOLFPROV_ENTER(WP_LOG_PK, "wp_pem2der_decode_data");
 
     (void)pwCb;
     (void)pwCbArg;
@@ -406,6 +410,8 @@ static int wp_pem2der_decode(wp_Pem2Der* ctx, OSSL_CORE_BIO* coreBio,
     unsigned char* data = NULL;
     word32 len = 0;
     word32 idx = 0;
+
+    WOLFPROV_ENTER(WP_LOG_PK, "wp_pem2der_decode");
 
     (void)ctx;
     (void)selection;

--- a/src/wp_des.c
+++ b/src/wp_des.c
@@ -144,6 +144,8 @@ static int wp_des3_block_get_params(OSSL_PARAM params[], unsigned int mode,
     int ok = 1;
     OSSL_PARAM *p;
 
+    WOLFPROV_ENTER(WP_LOG_DES, "wp_des3_block_get_params");
+
     p = OSSL_PARAM_locate(params, OSSL_CIPHER_PARAM_MODE);
     if ((p != NULL) && (!OSSL_PARAM_set_uint(p, mode))) {
         ok = 0;
@@ -167,7 +169,7 @@ static int wp_des3_block_get_params(OSSL_PARAM params[], unsigned int mode,
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_DES, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -237,6 +239,8 @@ static int wp_des3_init_iv(wp_Des3BlockCtx *ctx, const unsigned char *iv,
 {
     int ok = 1;
 
+    WOLFPROV_ENTER(WP_LOG_DES, "wp_des3_init_iv");
+
     if (ivLen != ctx->ivLen) {
         ok = 0;
     }
@@ -252,7 +256,7 @@ static int wp_des3_init_iv(wp_Des3BlockCtx *ctx, const unsigned char *iv,
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_DES, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -276,6 +280,8 @@ static int wp_des3_block_init(wp_Des3BlockCtx *ctx, const unsigned char *key,
     const OSSL_PARAM params[], int enc)
 {
     int ok = 1;
+
+    WOLFPROV_ENTER(WP_LOG_DES, "wp_des3_block_init");
 
     ctx->bufSz = 0;
     ctx->enc = enc;
@@ -308,7 +314,7 @@ static int wp_des3_block_init(wp_Des3BlockCtx *ctx, const unsigned char *key,
         ok = wp_des3_block_set_ctx_params(ctx, params);
     }
 
-    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_DES, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -404,6 +410,8 @@ static int wp_des3_block_update(wp_Des3BlockCtx *ctx, unsigned char *out,
     size_t oLen = 0;
     size_t nextBlocks;
 
+    WOLFPROV_ENTER(WP_LOG_DES, "wp_des3_block_update");
+
     if ((ctx->tls_version > 0) && (ctx->enc)) {
         int i;
         unsigned char off = inLen % DES_BLOCK_SIZE;
@@ -483,7 +491,7 @@ static int wp_des3_block_update(wp_Des3BlockCtx *ctx, unsigned char *out,
         ok = invalid == 0;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_DES, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -502,6 +510,8 @@ static int wp_des3_block_final_enc(wp_Des3BlockCtx* ctx, unsigned char *out,
 {
     int ok = 1;
     size_t oLen = 0;
+
+    WOLFPROV_ENTER(WP_LOG_DES, "wp_des3_block_final_enc");
 
     if (ctx->pad) {
         size_t i;
@@ -532,7 +542,7 @@ static int wp_des3_block_final_enc(wp_Des3BlockCtx* ctx, unsigned char *out,
         ctx->bufSz = 0;
         *outLen = oLen;
     }
-    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_DES, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -550,6 +560,8 @@ static int wp_des3_block_final_dec(wp_Des3BlockCtx* ctx, unsigned char *out,
     size_t *outLen, size_t outSize)
 {
     int ok = 1;
+
+    WOLFPROV_ENTER(WP_LOG_DES, "wp_des3_block_final_dec");
 
     if (ctx->pad) {
         if (ctx->bufSz != DES_BLOCK_SIZE) {
@@ -598,7 +610,7 @@ static int wp_des3_block_final_dec(wp_Des3BlockCtx* ctx, unsigned char *out,
         *outLen = 0;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_DES, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -617,6 +629,8 @@ static int wp_des3_block_final(wp_Des3BlockCtx* ctx, unsigned char *out,
 {
     int ok = 1;
 
+    WOLFPROV_ENTER(WP_LOG_DES, "wp_des3_block_final");
+
     if (!wolfssl_prov_is_running()) {
         ok = 0;
     }
@@ -630,7 +644,7 @@ static int wp_des3_block_final(wp_Des3BlockCtx* ctx, unsigned char *out,
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_DES, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -651,6 +665,8 @@ static int wp_des3_block_cipher(wp_Des3BlockCtx* ctx, unsigned char* out,
 {
     int ok = 1;
 
+    WOLFPROV_ENTER(WP_LOG_DES, "wp_des3_block_cipher");
+
     if (!wolfssl_prov_is_running()) {
         ok = 0;
     }
@@ -664,7 +680,7 @@ static int wp_des3_block_cipher(wp_Des3BlockCtx* ctx, unsigned char* out,
         *outLen = inLen;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_DES, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -680,6 +696,8 @@ static int wp_des3_block_get_ctx_params(wp_Des3BlockCtx* ctx, OSSL_PARAM params[
 {
     int ok = 1;
     OSSL_PARAM* p;
+
+    WOLFPROV_ENTER(WP_LOG_DES, "wp_des3_block_get_ctx_params");
 
     p = OSSL_PARAM_locate(params, OSSL_CIPHER_PARAM_IVLEN);
     if ((p != NULL) && (!OSSL_PARAM_set_size_t(p, ctx->ivLen))) {
@@ -720,7 +738,7 @@ static int wp_des3_block_get_ctx_params(wp_Des3BlockCtx* ctx, OSSL_PARAM params[
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_DES, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -736,6 +754,8 @@ static int wp_des3_block_set_ctx_params(wp_Des3BlockCtx *ctx,
     const OSSL_PARAM params[])
 {
     int ok = 1;
+
+    WOLFPROV_ENTER(WP_LOG_DES, "wp_des3_block_set_ctx_params");
 
     if (params != NULL) {
         unsigned int val;
@@ -767,7 +787,7 @@ static int wp_des3_block_set_ctx_params(wp_Des3BlockCtx *ctx,
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_CIPHER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_DES, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 

--- a/src/wp_dh_exch.c
+++ b/src/wp_dh_exch.c
@@ -177,6 +177,8 @@ static int wp_dh_init(wp_DhCtx* ctx, wp_Dh* dh, const OSSL_PARAM params[])
 {
     int ok = 1;
 
+    WOLFPROV_ENTER(WP_LOG_DH, "wp_dh_init");
+
     if (!wolfssl_prov_is_running()) {
         ok = 0;
     }
@@ -195,7 +197,7 @@ static int wp_dh_init(wp_DhCtx* ctx, wp_Dh* dh, const OSSL_PARAM params[])
         ok = wp_dh_set_ctx_params(ctx, params);
     }
 
-    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_DH, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -215,6 +217,8 @@ static int wp_dh_kdf_derive(wp_DhCtx* ctx, unsigned char* key,
     size_t* keyLen, size_t keySize, unsigned char* sec, size_t secLen)
 {
     int ok = 1;
+
+    WOLFPROV_ENTER(WP_LOG_DH, "wp_dh_kdf_derive");
 
     if (keySize < ctx->keyLen) {
         ok = 0;
@@ -240,7 +244,7 @@ static int wp_dh_kdf_derive(wp_DhCtx* ctx, unsigned char* key,
 #endif
     }
 
-    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_DH, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -264,6 +268,8 @@ static int wp_dh_derive_secret(wp_DhCtx* ctx, unsigned char* secret,
     word32 privSz;
     unsigned char* pub;
     word32 pubSz;
+
+    WOLFPROV_ENTER(WP_LOG_DH, "wp_dh_derive_secret");
 
     /* Get our private key data. */
     if (!wp_dh_get_priv(ctx->key, &priv, &privSz)) {
@@ -296,7 +302,7 @@ static int wp_dh_derive_secret(wp_DhCtx* ctx, unsigned char* secret,
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_DH, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -321,6 +327,8 @@ static int wp_dh_derive(wp_DhCtx* ctx, unsigned char* secret,
     size_t outLen = 0;
     unsigned char* tmp = NULL;
     size_t maxLen = 0;
+
+    WOLFPROV_ENTER(WP_LOG_DH, "wp_dh_derive");
 
     if (!wolfssl_prov_is_running()) {
         ok = 0;
@@ -376,7 +384,7 @@ static int wp_dh_derive(wp_DhCtx* ctx, unsigned char* secret,
 
     OPENSSL_clear_free(tmp, maxLen);
 
-    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_DH, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -419,6 +427,8 @@ static int wp_dh_set_peer(wp_DhCtx* ctx, wp_Dh* peer)
 {
     int ok = 1;
 
+    WOLFPROV_ENTER(WP_LOG_DH, "wp_dh_set_peer");
+
     if (!wolfssl_prov_is_running()) {
         ok = 0;
     }
@@ -438,7 +448,7 @@ static int wp_dh_set_peer(wp_DhCtx* ctx, wp_Dh* peer)
         ctx->peer = peer;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_DH, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -454,6 +464,8 @@ static int wp_dh_set_param_kdf(wp_DhCtx* ctx, const OSSL_PARAM params[])
 {
     int ok = 1;
     const char* kdf = NULL;
+
+    WOLFPROV_ENTER(WP_LOG_DH, "wp_dh_set_param_kdf");
 
     if (!wp_params_get_utf8_string_ptr(params, OSSL_EXCHANGE_PARAM_KDF_TYPE,
             &kdf)) {
@@ -472,7 +484,7 @@ static int wp_dh_set_param_kdf(wp_DhCtx* ctx, const OSSL_PARAM params[])
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_DH, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -488,6 +500,8 @@ static int wp_dh_set_param_kdf_digest(wp_DhCtx* ctx, const OSSL_PARAM params[])
 {
     int ok = 1;
     const char* mdName = NULL;
+
+    WOLFPROV_ENTER(WP_LOG_DH, "wp_dh_set_param_kdf_digest");
 
     if (!wp_params_get_utf8_string_ptr(params, OSSL_EXCHANGE_PARAM_KDF_DIGEST,
             &mdName)) {
@@ -510,7 +524,7 @@ static int wp_dh_set_param_kdf_digest(wp_DhCtx* ctx, const OSSL_PARAM params[])
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_DH, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -525,6 +539,8 @@ static int wp_dh_set_param_kdf_digest(wp_DhCtx* ctx, const OSSL_PARAM params[])
 static int wp_dh_set_ctx_params(wp_DhCtx* ctx, const OSSL_PARAM params[])
 {
     int ok = 1;
+
+    WOLFPROV_ENTER(WP_LOG_DH, "wp_dh_set_ctx_params");
 
     if (params != NULL) {
         if (!wp_params_get_int(params, OSSL_EXCHANGE_PARAM_PAD, &ctx->pad)) {
@@ -546,7 +562,7 @@ static int wp_dh_set_ctx_params(wp_DhCtx* ctx, const OSSL_PARAM params[])
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_DH, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -587,8 +603,10 @@ static const OSSL_PARAM* wp_dh_gettable_ctx_params(wp_DhCtx* ctx,
  */
 static int wp_dh_get_params_kdf(wp_DhCtx* ctx, OSSL_PARAM params[])
 {
-     int ok = 1;
-     OSSL_PARAM* p;
+    int ok = 1;
+    OSSL_PARAM* p;
+
+    WOLFPROV_ENTER(WP_LOG_DH, "wp_dh_get_params_kdf");
 
      p = OSSL_PARAM_locate(params, OSSL_EXCHANGE_PARAM_KDF_TYPE);
      if (p != NULL) {
@@ -601,7 +619,7 @@ static int wp_dh_get_params_kdf(wp_DhCtx* ctx, OSSL_PARAM params[])
          }
      }
 
-     WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+     WOLFPROV_LEAVE(WP_LOG_DH, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
      return ok;
 }
 
@@ -615,38 +633,40 @@ static int wp_dh_get_params_kdf(wp_DhCtx* ctx, OSSL_PARAM params[])
  */
 static int wp_dh_get_ctx_params(wp_DhCtx* ctx, OSSL_PARAM params[])
 {
-     int ok = 1;
-     OSSL_PARAM* p;
+    int ok = 1;
+    OSSL_PARAM* p;
 
-     p = OSSL_PARAM_locate(params, OSSL_EXCHANGE_PARAM_PAD);
-     if ((p != NULL) && (!OSSL_PARAM_set_int(p, ctx->pad))) {
-         ok = 0;
-     }
-     if (ok && (!wp_dh_get_params_kdf(ctx, params))) {
-         ok = 0;
-     }
-     if (ok) {
-         p = OSSL_PARAM_locate(params, OSSL_EXCHANGE_PARAM_KDF_DIGEST);
-         if ((p != NULL) && (!OSSL_PARAM_set_utf8_string(p, ctx->kdfMdName))) {
-             ok = 0;
-         }
-     }
-     if (ok) {
-         p = OSSL_PARAM_locate(params, OSSL_EXCHANGE_PARAM_KDF_OUTLEN);
-         if ((p != NULL) && (!OSSL_PARAM_set_size_t(p, ctx->keyLen))) {
-             ok = 0;
-         }
-     }
-     if (ok) {
-         p = OSSL_PARAM_locate(params, OSSL_EXCHANGE_PARAM_KDF_UKM);
-         if ((p != NULL) && (!OSSL_PARAM_set_octet_ptr(p, ctx->ukm,
-                 ctx->ukmLen))) {
-             ok = 0;
-         }
-     }
+    WOLFPROV_ENTER(WP_LOG_DH, "wp_dh_get_ctx_params");
 
-     WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
-     return ok;
+    p = OSSL_PARAM_locate(params, OSSL_EXCHANGE_PARAM_PAD);
+    if ((p != NULL) && (!OSSL_PARAM_set_int(p, ctx->pad))) {
+        ok = 0;
+    }
+    if (ok && (!wp_dh_get_params_kdf(ctx, params))) {
+        ok = 0;
+    }
+    if (ok) {
+        p = OSSL_PARAM_locate(params, OSSL_EXCHANGE_PARAM_KDF_DIGEST);
+        if ((p != NULL) && (!OSSL_PARAM_set_utf8_string(p, ctx->kdfMdName))) {
+            ok = 0;
+        }
+    }
+    if (ok) {
+        p = OSSL_PARAM_locate(params, OSSL_EXCHANGE_PARAM_KDF_OUTLEN);
+        if ((p != NULL) && (!OSSL_PARAM_set_size_t(p, ctx->keyLen))) {
+            ok = 0;
+        }
+    }
+    if (ok) {
+        p = OSSL_PARAM_locate(params, OSSL_EXCHANGE_PARAM_KDF_UKM);
+        if ((p != NULL) && (!OSSL_PARAM_set_octet_ptr(p, ctx->ukm,
+                ctx->ukmLen))) {
+            ok = 0;
+        }
+    }
+
+    WOLFPROV_LEAVE(WP_LOG_DH, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    return ok;
 }
 
 /** Dispatch table for DH key exchange. */

--- a/src/wp_dh_kmgmt.c
+++ b/src/wp_dh_kmgmt.c
@@ -174,6 +174,8 @@ static int wp_dh_map_group_name(wp_Dh* dh, const char* name)
     int ok = 1;
     size_t i;
 
+    WOLFPROV_ENTER(WP_LOG_DH, "wp_dh_map_group_name");
+
     for (i = 0; i < WP_DH_GROUP_MAP_SZ; i++) {
         if (strcasecmp(wp_dh_group_map[i].name, name) == 0) {
     #ifdef HAVE_PUBLIC_FFDHE
@@ -217,7 +219,7 @@ static int wp_dh_map_group_name(wp_Dh* dh, const char* name)
         ok = 0;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_DH, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -263,6 +265,8 @@ int wp_dh_up_ref(wp_Dh* dh)
     int ok = 1;
     int rc;
 
+    WOLFPROV_ENTER(WP_LOG_DH, "wp_dh_up_ref");
+
     rc = wc_LockMutex(&dh->mutex);
     if (rc < 0) {
         ok = 0;
@@ -272,11 +276,11 @@ int wp_dh_up_ref(wp_Dh* dh)
         wc_UnLockMutex(&dh->mutex);
     }
 
-    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_DH, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 #else
     dh->refCnt++;
-    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), 1);
+    WOLFPROV_LEAVE(WP_LOG_DH, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), 1);
     return 1;
 #endif
 }
@@ -319,6 +323,8 @@ int wp_dh_get_priv(wp_Dh* dh, unsigned char** priv, word32* privSz)
 {
     int ok = 1;
 
+    WOLFPROV_ENTER(WP_LOG_DH, "wp_dh_get_priv");
+
     if (privSz == 0) {
         ok = 0;
     }
@@ -327,7 +333,7 @@ int wp_dh_get_priv(wp_Dh* dh, unsigned char** priv, word32* privSz)
         *privSz = (word32)dh->privSz;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_DH, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -347,6 +353,8 @@ int wp_dh_get_pub(wp_Dh* dh, unsigned char** pub, word32* pubSz)
 {
     int ok = 1;
 
+    WOLFPROV_ENTER(WP_LOG_DH, "wp_dh_get_pub");
+
     if (pubSz == 0) {
         ok = 0;
     }
@@ -355,7 +363,7 @@ int wp_dh_get_pub(wp_Dh* dh, unsigned char** pub, word32* pubSz)
         *pubSz = (word32)dh->pubSz;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_DH, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -452,6 +460,8 @@ static int wp_dh_copy_params(const wp_Dh *src, wp_Dh *dst)
     int ok = 1;
     int rc;
 
+    WOLFPROV_ENTER(WP_LOG_DH, "wp_dh_copy_params");
+
     /* Copy prime in wolfSSL object. */
     rc = mp_copy((mp_int*)&src->key.p, &dst->key.p);
     if (rc != 0) {
@@ -476,7 +486,7 @@ static int wp_dh_copy_params(const wp_Dh *src, wp_Dh *dst)
         dst->bits = src->bits;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_DH, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -607,13 +617,15 @@ static int wp_dh_set_params(wp_Dh *dh, const OSSL_PARAM params[])
 {
     int ok = 1;
 
+    WOLFPROV_ENTER(WP_LOG_DH, "wp_dh_set_params");
+
     /* Encoded public key is a big-endian byte array of the number. */
     if ((params != NULL) && (!wp_params_get_octet_string(params,
             OSSL_PKEY_PARAM_ENCODED_PUBLIC_KEY, &dh->pub, &dh->pubSz, 0))) {
         ok = 0;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_DH, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -685,6 +697,8 @@ static int wp_dh_get_params_encoded_public_key(wp_Dh* dh, OSSL_PARAM params[])
     int ok = 1;
     OSSL_PARAM* p;
 
+    WOLFPROV_ENTER(WP_LOG_DH, "wp_dh_get_params_encoded_public_key");
+
     p = OSSL_PARAM_locate(params, OSSL_PKEY_PARAM_ENCODED_PUBLIC_KEY);
     if (p != NULL) {
         if (p->data_type != OSSL_PARAM_OCTET_STRING) {
@@ -709,7 +723,7 @@ static int wp_dh_get_params_encoded_public_key(wp_Dh* dh, OSSL_PARAM params[])
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_DH, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -725,6 +739,8 @@ static int wp_dh_get_params(wp_Dh* dh, OSSL_PARAM params[])
 {
     int ok = 1;
     OSSL_PARAM* p;
+
+    WOLFPROV_ENTER(WP_LOG_DH, "wp_dh_get_params");
 
     if (ok) {
         p = OSSL_PARAM_locate(params, OSSL_PKEY_PARAM_MAX_SIZE);
@@ -842,7 +858,7 @@ static int wp_dh_get_params(wp_Dh* dh, OSSL_PARAM params[])
         ok = 0;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_DH, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -857,6 +873,8 @@ static int wp_dh_get_params(wp_Dh* dh, OSSL_PARAM params[])
 static int wp_dh_has(const wp_Dh* dh, int selection)
 {
     int ok = 1;
+
+    WOLFPROV_ENTER(WP_LOG_DH, "wp_dh_has");
 
     if (!wolfssl_prov_is_running()) {
         ok = 0;
@@ -874,7 +892,7 @@ static int wp_dh_has(const wp_Dh* dh, int selection)
         ok &= (dh->id != 0) || (!mp_iszero((mp_int*)&dh->key.p));
     }
 
-    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_DH, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -890,6 +908,8 @@ static int wp_dh_has(const wp_Dh* dh, int selection)
 int wp_dh_match(const wp_Dh* dh1, const wp_Dh* dh2, int selection)
 {
     int ok = 1;
+
+    WOLFPROV_ENTER(WP_LOG_DH, "wp_dh_match");
 
     if (!wolfssl_prov_is_running()) {
         ok = 0;
@@ -917,7 +937,7 @@ int wp_dh_match(const wp_Dh* dh1, const wp_Dh* dh2, int selection)
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_DH, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -935,6 +955,8 @@ static int wp_dh_validate_pub_key_quick(const wp_Dh* dh)
     int rc;
     word32 primeSz = mp_unsigned_bin_size((mp_int*)&dh->key.p);
     unsigned char* prime;
+
+    WOLFPROV_ENTER(WP_LOG_DH, "wp_dh_validate_pub_key_quick");
 
     prime = OPENSSL_malloc(primeSz);
     if (prime == NULL) {
@@ -954,7 +976,7 @@ static int wp_dh_validate_pub_key_quick(const wp_Dh* dh)
     }
     OPENSSL_free(prime);
 
-    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_DH, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 #endif
@@ -974,6 +996,8 @@ static int wp_dh_validate(const wp_Dh* dh, int selection, int checkType)
 {
     int ok = 1;
     int rc;
+
+    WOLFPROV_ENTER(WP_LOG_DH, "wp_dh_validate");
 
     if (((selection & OSSL_KEYMGMT_SELECT_DOMAIN_PARAMETERS) != 0) &&
         (dh->id == 0)) {
@@ -1003,7 +1027,7 @@ static int wp_dh_validate(const wp_Dh* dh, int selection, int checkType)
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_DH, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1020,6 +1044,8 @@ static int wp_dh_import_group(wp_Dh* dh, const OSSL_PARAM params[])
     int ok = 1;
     const OSSL_PARAM* p;
     const char* name = NULL;
+
+    WOLFPROV_ENTER(WP_LOG_DH, "wp_dh_import_group");
 
     /* Look for the group name first. */
     if (!wp_params_get_utf8_string_ptr(params, OSSL_PKEY_PARAM_GROUP_NAME,
@@ -1056,7 +1082,7 @@ static int wp_dh_import_group(wp_Dh* dh, const OSSL_PARAM params[])
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_DH, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1074,6 +1100,8 @@ static int wp_dh_import_keypair(wp_Dh* dh, const OSSL_PARAM params[],
 {
     int ok = 1;
 
+    WOLFPROV_ENTER(WP_LOG_DH, "wp_dh_import_keypair");
+
     if (!wp_params_get_bn_be(params, OSSL_PKEY_PARAM_PUB_KEY, &dh->pub,
             &dh->pubSz, 0)) {
         ok = 0;
@@ -1083,7 +1111,7 @@ static int wp_dh_import_keypair(wp_Dh* dh, const OSSL_PARAM params[],
         ok = 0;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_DH, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1099,6 +1127,8 @@ static int wp_dh_import_keypair(wp_Dh* dh, const OSSL_PARAM params[],
 static int wp_dh_import(wp_Dh* dh, int selection, const OSSL_PARAM params[])
 {
     int ok = 1;
+
+    WOLFPROV_ENTER(WP_LOG_DH, "wp_dh_import");
 
     if (!wolfssl_prov_is_running()) {
         ok = 0;
@@ -1119,7 +1149,7 @@ static int wp_dh_import(wp_Dh* dh, int selection, const OSSL_PARAM params[])
         ok = 0;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_DH, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1258,6 +1288,8 @@ static int wp_dh_export_group(wp_Dh* dh, OSSL_PARAM params[], int* pIdx,
     const char* name;
     int i = *pIdx;
 
+    WOLFPROV_ENTER(WP_LOG_DH, "wp_dh_export_group");
+
     name = wp_dh_get_group_name(dh);
     if (name != NULL) {
         wp_param_set_utf8_string_ptr(&params[i++], OSSL_PKEY_PARAM_GROUP_NAME,
@@ -1279,7 +1311,7 @@ static int wp_dh_export_group(wp_Dh* dh, OSSL_PARAM params[], int* pIdx,
     }
 
     *pIdx = i;
-    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_DH, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1315,6 +1347,8 @@ static int wp_dh_export_keypair(wp_Dh* dh, OSSL_PARAM params[], int* pIdx,
     int ok = 1;
     int i = *pIdx;
 
+    WOLFPROV_ENTER(WP_LOG_DH, "wp_dh_export_keypair");
+
     if (dh->pubSz > 0) {
         wp_param_set_mp_buf(&params[i++], OSSL_PKEY_PARAM_PUB_KEY, dh->pub,
             dh->pubSz, data, idx);
@@ -1325,7 +1359,7 @@ static int wp_dh_export_keypair(wp_Dh* dh, OSSL_PARAM params[], int* pIdx,
     }
 
     *pIdx = i;
-    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_DH, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1350,6 +1384,8 @@ static int wp_dh_export(wp_Dh *dh, int selection, OSSL_CALLBACK *paramCb,
     unsigned char* data = NULL;
     size_t sz = 0;
     size_t idx = 0;
+
+    WOLFPROV_ENTER(WP_LOG_DH, "wp_dh_export");
 
     if (!wolfssl_prov_is_running()) {
         ok = 0;
@@ -1381,7 +1417,7 @@ static int wp_dh_export(wp_Dh *dh, int selection, OSSL_CALLBACK *paramCb,
     }
     OPENSSL_secure_clear_free(data, sz);
 
-    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_DH, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1476,6 +1512,8 @@ static int wp_dh_gen_set_template(wp_DhGenCtx* ctx, const wp_Dh* dh)
 {
     int ok = 1;
 
+    WOLFPROV_ENTER(WP_LOG_DH, "wp_dh_gen_set_template");
+
     if (!wolfssl_prov_is_running()) {
         ok = 0;
     }
@@ -1491,7 +1529,7 @@ static int wp_dh_gen_set_template(wp_DhGenCtx* ctx, const wp_Dh* dh)
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_DH, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1507,6 +1545,8 @@ static int wp_dh_gen_set_params(wp_DhGenCtx* ctx, const OSSL_PARAM params[])
 {
     int ok = 1;
     const OSSL_PARAM* p;
+
+    WOLFPROV_ENTER(WP_LOG_DH, "wp_dh_gen_set_params");
 
     p = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_FFC_PBITS);
     if ((p != NULL) && (!OSSL_PARAM_get_int(p, &ctx->bits))) {
@@ -1529,7 +1569,7 @@ static int wp_dh_gen_set_params(wp_DhGenCtx* ctx, const OSSL_PARAM params[])
         ok = 0;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_DH, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1546,12 +1586,14 @@ static int wp_dh_gen_parameters(wp_DhGenCtx *ctx, wp_Dh* dh)
     int ok = 1;
     int rc;
 
+    WOLFPROV_ENTER(WP_LOG_DH, "wp_dh_gen_parameters");
+
     rc = wc_DhGenerateParams(&ctx->rng, ctx->bits, &dh->key);
     if (rc != 0) {
         ok = 0;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_DH, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1568,6 +1610,8 @@ static int wp_dh_gen_parameters(wp_DhGenCtx *ctx, wp_Dh* dh)
 static int wp_dh_gen_copy_parameters(wp_DhGenCtx *ctx, wp_Dh* dh)
 {
     int ok = 1;
+
+    WOLFPROV_ENTER(WP_LOG_DH, "wp_dh_gen_copy_parameters");
 
     if (ctx->dh != NULL) {
         int rc;
@@ -1599,7 +1643,7 @@ static int wp_dh_gen_copy_parameters(wp_DhGenCtx *ctx, wp_Dh* dh)
         ok = 0;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_DH, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1619,6 +1663,8 @@ static int wp_dh_gen_keypair(wp_DhGenCtx *ctx, wp_Dh* dh)
     word32 sz;
     word32 pubSz;
     word32 privSz;
+
+    WOLFPROV_ENTER(WP_LOG_DH, "wp_dh_gen_keypair");
 
     /* The size of the generated private key will be the size of the small
      * prime 'q'. When not available, just use the size of the prime 'p'.
@@ -1677,7 +1723,7 @@ static int wp_dh_gen_keypair(wp_DhGenCtx *ctx, wp_Dh* dh)
         dh->privSz = privSz;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_DH, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1695,6 +1741,8 @@ static int wp_dh_params_validate(wp_Dh* dh)
     word32 sz;
     mp_int t;
     mp_int one;
+
+    WOLFPROV_ENTER(WP_LOG_DH, "wp_dh_params_validate");
 
     rc = mp_init_multi(&t, &one, NULL, NULL, NULL, NULL);
     if (rc != 0) {
@@ -1732,7 +1780,7 @@ static int wp_dh_params_validate(wp_Dh* dh)
         mp_clear(&t);
     }
 
-    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_DH, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1953,11 +2001,13 @@ static int wp_dh_enc_dec_set_ctx_params(wp_DhEncDecCtx* ctx,
 {
     int ok = 1;
 
+    WOLFPROV_ENTER(WP_LOG_DH, "wp_dh_enc_dec_set_ctx_params");
+
     if (!wp_cipher_from_params(params, &ctx->cipher, &ctx->cipherName)) {
         ok = 0;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_DH, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1980,6 +2030,8 @@ static int wp_dh_decode_spki(wp_Dh* dh, unsigned char* data, word32 len)
     int rc;
     word32 idx = 0;
 
+    WOLFPROV_ENTER(WP_LOG_DH, "wp_dh_decode_spki");
+
     rc = wc_DhPublicKeyDecode(data, &idx, &dh->key, len);
     if (rc != 0) {
         ok = 0;
@@ -2001,7 +2053,7 @@ static int wp_dh_decode_spki(wp_Dh* dh, unsigned char* data, word32 len)
         dh->bits = mp_count_bits(&dh->key.p);
     }
 
-    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_DH, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 #else
@@ -2039,6 +2091,8 @@ static int wp_dh_decode_pki(wp_Dh* dh, unsigned char* data, word32 len)
     int rc;
     word32 idx = 0;
     unsigned char* base = NULL;
+
+    WOLFPROV_ENTER(WP_LOG_DH, "wp_dh_decode_pki");
 
     rc = wc_DhKeyDecode(data, &idx, &dh->key, len);
     if (rc != 0) {
@@ -2089,7 +2143,7 @@ static int wp_dh_decode_pki(wp_Dh* dh, unsigned char* data, word32 len)
     }
 
     OPENSSL_free(base);
-    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_DH, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 #else
@@ -2126,6 +2180,8 @@ static int wp_dh_decode_params(wp_Dh* dh, unsigned char* data, word32 len)
     int rc;
     word32 idx = 0;
 
+    WOLFPROV_ENTER(WP_LOG_DH, "wp_dh_decode_params");
+
     rc = wc_DhKeyDecode(data, &idx, &dh->key, len);
     if (rc != 0) {
         ok = 0;
@@ -2134,7 +2190,7 @@ static int wp_dh_decode_params(wp_Dh* dh, unsigned char* data, word32 len)
         dh->bits = mp_count_bits(&dh->key.p);
     }
 
-    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_DH, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -2152,6 +2208,8 @@ static int wp_dh_dec_send_params(wp_Dh* dh, OSSL_CALLBACK *dataCb,
 {
     int ok = 1;
 
+    WOLFPROV_ENTER(WP_LOG_DH, "wp_dh_dec_send_params");
+
     OSSL_PARAM params[4];
     int object_type = OSSL_OBJECT_PKEY;
 
@@ -2168,7 +2226,7 @@ static int wp_dh_dec_send_params(wp_Dh* dh, OSSL_CALLBACK *dataCb,
         ok = 0;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_DH, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -2196,6 +2254,8 @@ static int wp_dh_decode(wp_DhEncDecCtx* ctx, OSSL_CORE_BIO *cBio,
     wp_Dh* dh = NULL;
     unsigned char* data = NULL;
     word32 len = 0;
+
+    WOLFPROV_ENTER(WP_LOG_DH, "wp_dh_decode");
 
     if (!wolfssl_prov_is_running()) {
         ok = 0;
@@ -2261,7 +2321,7 @@ static int wp_dh_decode(wp_DhEncDecCtx* ctx, OSSL_CORE_BIO *cBio,
             ok = 1;
         }
     }
-    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_DH, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -2280,6 +2340,8 @@ static int wp_dh_encode_params_size(const wp_Dh *dh, size_t* keyLen)
     int ret;
     word32 len;
 
+    WOLFPROV_ENTER(WP_LOG_DH, "wp_dh_encode_params_size");
+
     ret = wc_DhParamsToDer((DhKey*)&dh->key, NULL, &len);
     if (ret != LENGTH_ONLY_E) {
         ok = 0;
@@ -2288,7 +2350,7 @@ static int wp_dh_encode_params_size(const wp_Dh *dh, size_t* keyLen)
         *keyLen = len;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_DH, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -2309,6 +2371,8 @@ static int wp_dh_encode_params(const wp_Dh *dh, unsigned char* keyData,
     int ret;
     word32 len = (word32)*keyLen;
 
+    WOLFPROV_ENTER(WP_LOG_DH, "wp_dh_encode_params");
+
     ret = wc_DhParamsToDer((DhKey*)&dh->key, keyData, &len);
     if (ret <= 0) {
         ok = 0;
@@ -2317,7 +2381,7 @@ static int wp_dh_encode_params(const wp_Dh *dh, unsigned char* keyData,
         *keyLen = len;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_DH, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -2334,6 +2398,8 @@ static int wp_dh_encode_spki_size(const wp_Dh *dh, size_t* keyLen)
     int ok = 1;
     int ret;
     word32 len;
+
+    WOLFPROV_ENTER(WP_LOG_DH, "wp_dh_encode_spki_size");
 
     /* If we have a generated public key that is not set in the inner key,
      * set it now */
@@ -2353,7 +2419,7 @@ static int wp_dh_encode_spki_size(const wp_Dh *dh, size_t* keyLen)
         *keyLen = len;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_DH, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -2374,6 +2440,8 @@ static int wp_dh_encode_spki(const wp_Dh *dh, unsigned char* keyData,
     int ret;
     word32 len = (word32)*keyLen;
 
+    WOLFPROV_ENTER(WP_LOG_DH, "wp_dh_encode_spki");
+
     ret = wc_DhPubKeyToDer((DhKey*)&dh->key, keyData, &len);
     if (ret <= 0) {
         ok = 0;
@@ -2386,7 +2454,7 @@ static int wp_dh_encode_spki(const wp_Dh *dh, unsigned char* keyData,
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_DH, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -2403,6 +2471,8 @@ static int wp_dh_encode_pki_size(const wp_Dh *dh, size_t* keyLen)
     int ok = 1;
     int ret;
     word32 len;
+
+    WOLFPROV_ENTER(WP_LOG_DH, "wp_dh_encode_pki_size");
 
     /* If we have a generated private key that is not set in the inner key,
      * set it now */
@@ -2422,7 +2492,7 @@ static int wp_dh_encode_pki_size(const wp_Dh *dh, size_t* keyLen)
         *keyLen = len;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_DH, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -2443,6 +2513,8 @@ static int wp_dh_encode_pki(const wp_Dh *dh, unsigned char* keyData,
     int ret;
     word32 len = (word32)*keyLen;
 
+    WOLFPROV_ENTER(WP_LOG_DH, "wp_dh_encode_pki");
+
     ret = wc_DhPrivKeyToDer((DhKey*)&dh->key, keyData, &len);
     if (ret <= 0) {
         ok = 0;
@@ -2455,7 +2527,7 @@ static int wp_dh_encode_pki(const wp_Dh *dh, unsigned char* keyData,
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_DH, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -2475,6 +2547,8 @@ static int wp_dh_encode_epki_size(const wp_Dh *dh, size_t* keyLen)
     int ret;
     word32 len;
 
+    WOLFPROV_ENTER(WP_LOG_DH, "wp_dh_encode_epki_size");
+
     ret = wc_DhPrivKeyToDer((DhKey*)&dh->key, NULL, &len);
     if (ret != LENGTH_ONLY_E) {
         ok = 0;
@@ -2483,7 +2557,7 @@ static int wp_dh_encode_epki_size(const wp_Dh *dh, size_t* keyLen)
         *keyLen = ((len + 15) / 16) * 16;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_DH, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -2509,6 +2583,8 @@ static int wp_dh_encode_epki(const wp_DhEncDecCtx* ctx, const wp_Dh *dh,
     int rc;
     word32 pkcs8Len = (word32)*keyLen;
 
+    WOLFPROV_ENTER(WP_LOG_DH, "wp_dh_encode_epki");
+
     /* Encode key. */
     rc = wc_DhPrivKeyToDer((DhKey*)&dh->key, keyData, &pkcs8Len);
     if (rc <= 0) {
@@ -2519,7 +2595,7 @@ static int wp_dh_encode_epki(const wp_DhEncDecCtx* ctx, const wp_Dh *dh,
         ok = 0;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_DH, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 #endif
@@ -2543,6 +2619,8 @@ static int wp_dh_encode(wp_DhEncDecCtx* ctx, OSSL_CORE_BIO *cBio,
     OSSL_PASSPHRASE_CALLBACK *pwCb, void *pwCbArg)
 {
     int ok = 1;
+
+    WOLFPROV_ENTER(WP_LOG_DH, "wp_dh_encode");
 
     if (!wolfssl_prov_is_running()) {
         ok = 0;
@@ -2688,7 +2766,7 @@ static int wp_dh_encode(wp_DhEncDecCtx* ctx, OSSL_CORE_BIO *cBio,
     (void)pwCbArg;
 #endif
 
-    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_DH, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -2706,6 +2784,8 @@ static int wp_dh_encode(wp_DhEncDecCtx* ctx, OSSL_CORE_BIO *cBio,
 static int wp_dh_export_object(wp_DhEncDecCtx* ctx, wp_Dh* dh, size_t size,
     OSSL_CALLBACK *exportCb, void *exportCbArg)
 {
+    WOLFPROV_ENTER(WP_LOG_DH, "wp_dh_export_object");
+
     /* TODO: check size to ensure it really is a wc_Dh object.  */
     (void)size;
     return wp_dh_export(dh, ctx->selection, exportCb, exportCbArg);
@@ -2741,6 +2821,8 @@ static int wp_dh_type_specific_does_selection(WOLFPROV_CTX* provCtx,
 {
     int ok;
 
+    WOLFPROV_ENTER(WP_LOG_DH, "wp_dh_type_specific_does_selection");
+
     (void)provCtx;
 
     if (selection == 0) {
@@ -2750,7 +2832,7 @@ static int wp_dh_type_specific_does_selection(WOLFPROV_CTX* provCtx,
         ok = (selection & OSSL_KEYMGMT_SELECT_ALL_PARAMETERS) != 0;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_DH, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -2855,6 +2937,8 @@ static int wp_dh_spki_does_selection(WOLFPROV_CTX* provCtx, int selection)
 {
     int ok;
 
+    WOLFPROV_ENTER(WP_LOG_DH, "wp_dh_spki_does_selection");
+
     (void)provCtx;
 
     if (selection == 0) {
@@ -2864,7 +2948,7 @@ static int wp_dh_spki_does_selection(WOLFPROV_CTX* provCtx, int selection)
         ok = (selection & OSSL_KEYMGMT_SELECT_PUBLIC_KEY) != 0;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_DH, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -2964,6 +3048,8 @@ static int wp_dh_pki_does_selection(WOLFPROV_CTX* provCtx, int selection)
 {
     int ok;
 
+    WOLFPROV_ENTER(WP_LOG_DH, "wp_dh_pki_does_selection");
+
     (void)provCtx;
 
     if (selection == 0) {
@@ -2973,7 +3059,7 @@ static int wp_dh_pki_does_selection(WOLFPROV_CTX* provCtx, int selection)
         ok = (selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY) != 0;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_DH, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 

--- a/src/wp_digests.c
+++ b/src/wp_digests.c
@@ -123,6 +123,7 @@ static int name##_init(CTX* ctx, const OSSL_PARAM params[])                    \
 {                                                                              \
     int ok = 1;                                                                \
     (void)params;                                                              \
+    WOLFPROV_ENTER(WP_LOG_DIGEST, #name "_init");                             \
     if (!wolfssl_prov_is_running()) {                                          \
         ok = 0;                                                                \
     }                                                                          \
@@ -150,6 +151,7 @@ static int name##_init(CTX* ctx, const OSSL_PARAM params[])                    \
 static int name##_update(void* ctx, const unsigned char* in, size_t inLen)     \
 {                                                                              \
     int ok = 1;                                                                \
+    WOLFPROV_ENTER(WP_LOG_DIGEST, #name "_update");                           \
     int rc = upd(ctx, in, (word32)inLen);                                      \
     if (rc != 0) {                                                             \
         ok = 0;                                                                \
@@ -174,6 +176,7 @@ static int name##_final(void* ctx, unsigned char* out, size_t* outLen,         \
     size_t outSize)                                                            \
 {                                                                              \
     int ok = 1;                                                                \
+    WOLFPROV_ENTER(WP_LOG_DIGEST, #name "_final");                            \
     if (!wolfssl_prov_is_running()) {                                          \
         ok = 0;                                                                \
     }                                                                          \
@@ -251,6 +254,8 @@ static int wp_digest_get_params(OSSL_PARAM params[], size_t blkSize,
 {
     OSSL_PARAM* p = NULL;
     int ok = 1;
+
+    WOLFPROV_ENTER(WP_LOG_DIGEST, "wp_digest_get_params");
 
     p = OSSL_PARAM_locate(params, OSSL_DIGEST_PARAM_BLOCK_SIZE);
     if ((p != NULL) && (!OSSL_PARAM_set_size_t(p, blkSize))) {
@@ -565,6 +570,7 @@ static int name##_init(CTX* ctx, const OSSL_PARAM params[])                    \
 {                                                                              \
     int ok = 1;                                                                \
     (void)params;                                                              \
+    WOLFPROV_ENTER(WP_LOG_DIGEST, #name "_init");                             \
     if (!wolfssl_prov_is_running()) {                                          \
         ok = 0;                                                                \
     }                                                                          \
@@ -597,6 +603,7 @@ static int name##_final(CTX* ctx, unsigned char* out, size_t* outLen,          \
     size_t outSize)                                                            \
 {                                                                              \
     int ok = 1;                                                                \
+    WOLFPROV_ENTER(WP_LOG_DIGEST, #name "_final");                            \
     if (!wolfssl_prov_is_running()) {                                          \
         ok = 0;                                                                \
     }                                                                          \
@@ -674,6 +681,7 @@ static CTX* name##_dupctx(CTX* src)                                            \
 static int name##_set_ctx_params(CTX* ctx, const OSSL_PARAM params[])          \
 {                                                                              \
     int ok = 1;                                                                \
+    WOLFPROV_ENTER(WP_LOG_DIGEST, #name "_set_ctx_params");                   \
     if (!wolfssl_prov_is_running()) {                                          \
         ok = 0;                                                                \
     }                                                                          \

--- a/src/wp_drbg.c
+++ b/src/wp_drbg.c
@@ -118,6 +118,8 @@ static int wp_drbg_instantiate(wp_DrbgCtx* ctx, unsigned int strength,
 {
     int ok = 1;
 
+    WOLFPROV_ENTER(WP_LOG_RNG, "wp_drbg_instantiate");
+
     (void)predResist;
     (void)params;
 
@@ -159,6 +161,8 @@ static int wp_drbg_instantiate(wp_DrbgCtx* ctx, unsigned int strength,
  */
 static int wp_drbg_uninstantiate(wp_DrbgCtx* ctx)
 {
+    WOLFPROV_ENTER(WP_LOG_RNG, "wp_drbg_uninstantiate");
+
 #if LIBWOLFSSL_VERSION_HEX >= 0x05000000
     (void)wc_rng_free(ctx->rng);
 #else
@@ -188,6 +192,8 @@ static int wp_drbg_generate(wp_DrbgCtx* ctx, unsigned char* out,
 {
     int ok = 1;
     int rc;
+
+    WOLFPROV_ENTER(WP_LOG_RNG, "wp_drbg_generate");
 
     (void)predResist;
 
@@ -236,6 +242,8 @@ static int wp_drbg_reseed(wp_DrbgCtx* ctx, int predResist,
 {
     int ok = 1;
 
+    WOLFPROV_ENTER(WP_LOG_RNG, "wp_drbg_reseed");
+
 #if 0
     /* Calling Hash_DRBG_Instantiate would be better. */
     int rc;
@@ -274,6 +282,8 @@ static int wp_drbg_enable_locking(wp_DrbgCtx* ctx)
 {
     int ok = 1;
 
+    WOLFPROV_ENTER(WP_LOG_RNG, "wp_drbg_enable_locking");
+
 #ifndef WP_SINGLE_THREADED
     if (ctx->mutex == NULL) {
         ctx->mutex = OPENSSL_malloc(sizeof(*ctx->mutex));
@@ -304,6 +314,9 @@ static int wp_drbg_enable_locking(wp_DrbgCtx* ctx)
 static int wp_drbg_lock(wp_DrbgCtx* ctx)
 {
     int ok = 1;
+
+    WOLFPROV_ENTER(WP_LOG_RNG, "wp_drbg_lock");
+
 #ifndef WP_SINGLE_THREADED
     int rc;
 
@@ -327,6 +340,8 @@ static int wp_drbg_lock(wp_DrbgCtx* ctx)
  */
 static int wp_drbg_unlock(wp_DrbgCtx* ctx)
 {
+    WOLFPROV_ENTER(WP_LOG_RNG, "wp_drbg_unlock");
+
 #ifndef WP_SINGLE_THREADED
     if (ctx->mutex != NULL) {
        wc_UnLockMutex(ctx->mutex);
@@ -371,6 +386,8 @@ static int wp_drbg_get_ctx_params(wp_DrbgCtx* ctx, OSSL_PARAM params[])
 {
     int ok = 1;
     OSSL_PARAM* p;
+
+    WOLFPROV_ENTER(WP_LOG_RNG, "wp_drbg_get_ctx_params");
 
     (void)ctx;
 
@@ -419,6 +436,8 @@ static const OSSL_PARAM* wp_drbg_settable_ctx_params(wp_DrbgCtx* ctx,
  */
 static int wp_drbg_set_ctx_params(wp_DrbgCtx* ctx, const OSSL_PARAM params[])
 {
+    WOLFPROV_ENTER(WP_LOG_RNG, "wp_drbg_set_ctx_params");
+
     (void)ctx;
     (void)params;
     WOLFPROV_LEAVE(WP_LOG_RNG, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), 1);
@@ -433,6 +452,8 @@ static int wp_drbg_set_ctx_params(wp_DrbgCtx* ctx, const OSSL_PARAM params[])
  */
 static int wp_drbg_verify_zeroization(wp_DrbgCtx* ctx)
 {
+    WOLFPROV_ENTER(WP_LOG_RNG, "wp_drbg_verify_zeroization");
+
     (void)ctx;
     WOLFPROV_LEAVE(WP_LOG_RNG, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), 1);
     return 1;
@@ -457,6 +478,8 @@ static size_t wp_drbg_get_seed(wp_DrbgCtx* ctx, unsigned char** pSeed,
     int ok = 1;
     int rc;
     unsigned char* buffer;
+
+    WOLFPROV_ENTER(WP_LOG_RNG, "wp_drbg_get_seed");
 
     (void)entropy;
     (void)maxLen;

--- a/src/wp_ecc_kmgmt.c
+++ b/src/wp_ecc_kmgmt.c
@@ -144,6 +144,8 @@ static int wp_ecc_map_group_name(wp_Ecc* ecc, const char* name)
     int ok = 1;
     size_t i;
 
+    WOLFPROV_ENTER(WP_LOG_ECC, "wp_ecc_map_group_name");
+
     for (i = 0; i < WP_ECC_GROUP_MAP_SZ; i++) {
         if (strcasecmp(wp_ecc_group_map[i].name, name) == 0) {
             ecc->curveId = wp_ecc_group_map[i].curveId;
@@ -156,7 +158,7 @@ static int wp_ecc_map_group_name(wp_Ecc* ecc, const char* name)
         ok = 0;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_ECC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -196,6 +198,8 @@ static int wp_ecc_set_bits(wp_Ecc* ecc)
     int ok = 0;
     size_t i;
 
+    WOLFPROV_ENTER(WP_LOG_ECC, "wp_ecc_set_bits");
+
     for (i = 0; i < WP_ECC_GROUP_MAP_SZ; i++) {
         if (ecc->curveId == wp_ecc_group_map[i].curveId) {
             ecc->bits = wp_ecc_group_map[i].bits;
@@ -204,7 +208,7 @@ static int wp_ecc_set_bits(wp_Ecc* ecc)
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_ECC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -248,6 +252,8 @@ int wp_ecc_up_ref(wp_Ecc* ecc)
     int ok = 1;
     int rc;
 
+    WOLFPROV_ENTER(WP_LOG_ECC, "wp_ecc_up_ref");
+
     rc = wc_LockMutex(&ecc->mutex);
     if (rc < 0) {
         ok = 0;
@@ -257,11 +263,11 @@ int wp_ecc_up_ref(wp_Ecc* ecc)
         wc_UnLockMutex(&ecc->mutex);
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_ECC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 #else
     ecc->refCnt++;
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), 1);
+    WOLFPROV_LEAVE(WP_LOG_ECC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), 1);
     return 1;
 #endif
 }
@@ -535,6 +541,8 @@ static int wp_ecc_set_params_enc_pub_key(wp_Ecc *ecc, const OSSL_PARAM params[],
     unsigned char* data = NULL;
     size_t len;
 
+    WOLFPROV_ENTER(WP_LOG_ECC, "wp_ecc_set_params_enc_pub_key");
+
     if (!wp_params_get_octet_string_ptr(params, key, &data, &len)) {
         ok = 0;
     }
@@ -549,7 +557,7 @@ static int wp_ecc_set_params_enc_pub_key(wp_Ecc *ecc, const OSSL_PARAM params[],
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_ECC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -565,6 +573,8 @@ static int wp_ecc_set_params_pub(wp_Ecc *ecc, const OSSL_PARAM params[])
 {
     int ok = 1;
     int set = 0;
+
+    WOLFPROV_ENTER(WP_LOG_ECC, "wp_ecc_set_params_pub");
 
     if (!wp_params_get_mp(params, OSSL_PKEY_PARAM_EC_PUB_X,
             ecc->key.pubkey.x, &set)) {
@@ -592,7 +602,7 @@ static int wp_ecc_set_params_pub(wp_Ecc *ecc, const OSSL_PARAM params[])
         ok = 0;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_ECC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -608,6 +618,8 @@ static int wp_ecc_set_params(wp_Ecc *ecc, const OSSL_PARAM params[])
 {
     int ok = 1;
     const OSSL_PARAM *p;
+
+    WOLFPROV_ENTER(WP_LOG_ECC, "wp_ecc_set_params");
 
     if (params != NULL) {
         if (!wp_ecc_set_params_pub(ecc, params)) {
@@ -629,7 +641,7 @@ static int wp_ecc_set_params(wp_Ecc *ecc, const OSSL_PARAM params[])
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_ECC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -706,6 +718,8 @@ static int wp_ecc_get_params_enc_pub_key(wp_Ecc* ecc, OSSL_PARAM params[],
     int ok = 1;
     OSSL_PARAM* p;
 
+    WOLFPROV_ENTER(WP_LOG_ECC, "wp_ecc_get_params_enc_pub_key");
+
     p = OSSL_PARAM_locate(params, key);
     if (p != NULL) {
         int rc;
@@ -728,7 +742,7 @@ static int wp_ecc_get_params_enc_pub_key(wp_Ecc* ecc, OSSL_PARAM params[],
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_ECC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -778,6 +792,8 @@ static int wp_ecc_get_params(wp_Ecc* ecc, OSSL_PARAM params[])
 {
     int ok = 1;
     OSSL_PARAM* p;
+
+    WOLFPROV_ENTER(WP_LOG_ECC, "wp_ecc_get_params");
 
     /* Maximum secret size. */
     p = OSSL_PARAM_locate(params, OSSL_PKEY_PARAM_MAX_SIZE);
@@ -853,7 +869,7 @@ static int wp_ecc_get_params(wp_Ecc* ecc, OSSL_PARAM params[])
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_ECC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -868,6 +884,8 @@ static int wp_ecc_get_params(wp_Ecc* ecc, OSSL_PARAM params[])
 static int wp_ecc_has(const wp_Ecc* ecc, int selection)
 {
     int ok = 1;
+
+    WOLFPROV_ENTER(WP_LOG_ECC, "wp_ecc_has");
 
     if (!wolfssl_prov_is_running()) {
        ok = 0;
@@ -884,7 +902,7 @@ static int wp_ecc_has(const wp_Ecc* ecc, int selection)
             ok &= ecc->curveId != 0;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_ECC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -901,6 +919,8 @@ static int wp_ecc_match(wp_Ecc* ecc1, wp_Ecc* ecc2, int selection)
 {
     int ok = 1;
     int checked = 0;
+
+    WOLFPROV_ENTER(WP_LOG_ECC, "wp_ecc_match");
 
     if (!wolfssl_prov_is_running()) {
         ok = 0;
@@ -936,7 +956,7 @@ static int wp_ecc_match(wp_Ecc* ecc1, wp_Ecc* ecc2, int selection)
         ok = ok && checked;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_ECC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -954,6 +974,8 @@ static int wp_ecc_validate_public_key_quick(const wp_Ecc* ecc)
 {
     int ok = 1;
 
+    WOLFPROV_ENTER(WP_LOG_ECC, "wp_ecc_validate_public_key_quick");
+
     if (wc_ecc_point_is_at_infinity((ecc_point*)&ecc->key.pubkey)) {
         ok = 0;
     }
@@ -964,7 +986,7 @@ static int wp_ecc_validate_public_key_quick(const wp_Ecc* ecc)
     }
 #endif
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_ECC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 #endif
@@ -985,6 +1007,8 @@ static int wp_ecc_validate(const wp_Ecc* ecc, int selection, int checkType)
     int ok = 1;
     int origType;
     int rc;
+
+    WOLFPROV_ENTER(WP_LOG_ECC, "wp_ecc_validate");
 
     /* Only named curves supported. */
     if (((selection & OSSL_KEYMGMT_SELECT_DOMAIN_PARAMETERS) != 0) &&
@@ -1030,7 +1054,7 @@ static int wp_ecc_validate(const wp_Ecc* ecc, int selection, int checkType)
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_ECC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1046,6 +1070,8 @@ static int wp_ecc_import_group(wp_Ecc* ecc, const OSSL_PARAM params[])
 {
     int ok = 1;
     const OSSL_PARAM* p;
+
+    WOLFPROV_ENTER(WP_LOG_ECC, "wp_ecc_import_group");
 
     p = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_GROUP_NAME);
     if (p != NULL) {
@@ -1067,7 +1093,7 @@ static int wp_ecc_import_group(wp_Ecc* ecc, const OSSL_PARAM params[])
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_ECC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1084,6 +1110,8 @@ static int wp_ecc_import_keypair(wp_Ecc* ecc, const OSSL_PARAM params[],
     int priv)
 {
     int ok = 1;
+
+    WOLFPROV_ENTER(WP_LOG_ECC, "wp_ecc_import_keypair");
 
     if (wp_ecc_set_params_pub(ecc, params) != 1) {
         ok = 0;
@@ -1108,7 +1136,7 @@ static int wp_ecc_import_keypair(wp_Ecc* ecc, const OSSL_PARAM params[],
         ecc->hasPriv = 1;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_ECC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1125,6 +1153,8 @@ static int wp_ecc_import_other(wp_Ecc* ecc, const OSSL_PARAM params[])
     int ok = 1;
     const OSSL_PARAM* p;
 
+    WOLFPROV_ENTER(WP_LOG_ECC, "wp_ecc_import_other");
+
     /* Use cofactor when performing ECDH. */
     p = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_USE_COFACTOR_ECDH);
     if ((p != NULL) && !OSSL_PARAM_get_int(p, &ecc->cofactor)) {
@@ -1139,7 +1169,7 @@ static int wp_ecc_import_other(wp_Ecc* ecc, const OSSL_PARAM params[])
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_ECC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1155,6 +1185,8 @@ static int wp_ecc_import_other(wp_Ecc* ecc, const OSSL_PARAM params[])
 static int wp_ecc_import(wp_Ecc* ecc, int selection, const OSSL_PARAM params[])
 {
     int ok = 1;
+
+    WOLFPROV_ENTER(WP_LOG_ECC, "wp_ecc_import");
 
     if (!wolfssl_prov_is_running()) {
         ok = 0;
@@ -1181,7 +1213,7 @@ static int wp_ecc_import(wp_Ecc* ecc, int selection, const OSSL_PARAM params[])
         ok = 0;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_ECC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1341,11 +1373,13 @@ static int wp_ecc_export_params(wp_Ecc* ecc, OSSL_PARAM* params, int* pIdx)
     int ok = 1;
     int i = *pIdx;
 
+    WOLFPROV_ENTER(WP_LOG_ECC, "wp_ecc_export_params");
+
     wp_param_set_utf8_string_ptr(&params[i++], OSSL_PKEY_PARAM_GROUP_NAME,
         wp_ecc_get_group_name(ecc));
 
     *pIdx = i;
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_ECC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1396,6 +1430,8 @@ static int wp_ecc_export_keypair(wp_Ecc* ecc, OSSL_PARAM* params, int* pIdx,
     int i = *pIdx;
     word32 outLen;
 
+    WOLFPROV_ENTER(WP_LOG_ECC, "wp_ecc_export_keypair");
+
     outLen = WP_ECC_PUBLIC_KEY_SIZE(ecc);
     rc = wc_ecc_export_x963_ex(&ecc->key, data + *idx, &outLen, 0);
     if (rc != 0) {
@@ -1417,7 +1453,7 @@ static int wp_ecc_export_keypair(wp_Ecc* ecc, OSSL_PARAM* params, int* pIdx,
     }
 
     *pIdx = i;
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_ECC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1435,13 +1471,15 @@ static int wp_ecc_export_other(wp_Ecc* ecc, OSSL_PARAM* params, int* pIdx)
     int ok = 1;
     int i = *pIdx;
 
+    WOLFPROV_ENTER(WP_LOG_ECC, "wp_ecc_export_other");
+
     wp_param_set_int(&params[i++], OSSL_PKEY_PARAM_USE_COFACTOR_ECDH,
         &ecc->cofactor);
     wp_param_set_int(&params[i++], OSSL_PKEY_PARAM_EC_INCLUDE_PUBLIC,
         &ecc->includePublic);
 
     *pIdx = i;
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_ECC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1470,6 +1508,8 @@ static int wp_ecc_export(wp_Ecc *ecc, int selection, OSSL_CALLBACK *paramCb,
     int expPub = (selection & OSSL_KEYMGMT_SELECT_PUBLIC_KEY) != 0;
     int expPriv = (selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY) != 0;
     int expOther = (selection & OSSL_KEYMGMT_SELECT_OTHER_PARAMETERS) != 0;
+
+    WOLFPROV_ENTER(WP_LOG_ECC, "wp_ecc_export");
 
     if (!expParams) {
         ok = 0;
@@ -1505,7 +1545,7 @@ static int wp_ecc_export(wp_Ecc *ecc, int selection, OSSL_CALLBACK *paramCb,
     }
     OPENSSL_clear_free(data, len);
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_ECC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1597,6 +1637,8 @@ static int wp_ecc_gen_set_template(wp_EccGenCtx* ctx, wp_Ecc* ecc)
     int ok = 1;
     const char* name = NULL;
 
+    WOLFPROV_ENTER(WP_LOG_ECC, "wp_ecc_gen_set_template");
+
     if (!wolfssl_prov_is_running()) {
         ok = 0;
     }
@@ -1612,7 +1654,7 @@ static int wp_ecc_gen_set_template(wp_EccGenCtx* ctx, wp_Ecc* ecc)
         ctx->curveName[sizeof(ctx->curveName)-1] = '\0';
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_ECC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1631,6 +1673,8 @@ static int wp_ecc_gen_set_params(wp_EccGenCtx* ctx, const OSSL_PARAM params[])
 {
     int ok = 1;
     const OSSL_PARAM* p;
+
+    WOLFPROV_ENTER(WP_LOG_ECC, "wp_ecc_gen_set_params");
 
     p = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_USE_COFACTOR_ECDH);
     if ((p != NULL) && (!OSSL_PARAM_get_int(p, &ctx->cofactor))) {
@@ -1654,13 +1698,13 @@ static int wp_ecc_gen_set_params(wp_EccGenCtx* ctx, const OSSL_PARAM params[])
                 ok = 0;
             }
             if (!ok) {
-                WOLFPROV_ERROR_MSG(WP_LOG_PK,
+                WOLFPROV_ERROR_MSG(WP_LOG_ECC,
                     "only named curve encoding supported");
             }
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_ECC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1885,11 +1929,13 @@ static int wp_ecc_enc_dec_set_ctx_params(wp_EccEncDecCtx* ctx,
 {
     int ok = 1;
 
+    WOLFPROV_ENTER(WP_LOG_ECC, "wp_ecc_enc_dec_set_ctx_params");
+
     if (!wp_cipher_from_params(params, &ctx->cipher, &ctx->cipherName)) {
         ok = 0;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_ECC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1960,18 +2006,20 @@ static int wp_ecc_decode_params(wp_Ecc* ecc, unsigned char* data, word32 len)
     int rc;
     word32 oidLen;
 
+    WOLFPROV_ENTER(WP_LOG_ECC, "wp_ecc_decode_params");
+
     /* TODO: manually decoding as wolfSSL doesn't offer API to do this. */
     if (len < 3) {
         ok = 0;
     }
     if (ok && (data[0] != 0x06)) {
-        WOLFPROV_MSG(WP_LOG_PK, "Invalid data");
+        WOLFPROV_MSG(WP_LOG_ECC, "Invalid data");
         ok = 0;
     }
     if (ok) {
         oidLen = data[1];
         if ((oidLen >= 0x80) || (oidLen + 2 > len)) {
-            WOLFPROV_MSG(WP_LOG_PK, "OID out of bounds");
+            WOLFPROV_MSG(WP_LOG_ECC, "OID out of bounds");
             ok = 0;
         }
     }
@@ -1982,7 +2030,7 @@ static int wp_ecc_decode_params(wp_Ecc* ecc, unsigned char* data, word32 len)
         ecc->curveId = wp_ecc_get_curve_id_from_oid(data + 2, oidLen);
     #endif
         if (ecc->curveId == ECC_CURVE_INVALID) {
-            WOLFPROV_MSG(WP_LOG_PK, "Invalid curve");
+            WOLFPROV_MSG(WP_LOG_ECC, "Invalid curve");
             ok = 0;
         }
     }
@@ -1990,16 +2038,16 @@ static int wp_ecc_decode_params(wp_Ecc* ecc, unsigned char* data, word32 len)
     if (ok) {
         rc = wc_ecc_set_curve(&ecc->key, 0, ecc->curveId);
         if (rc != 0) {
-            WOLFPROV_MSG(WP_LOG_PK, "Can't set curve: %d",rc);
+            WOLFPROV_MSG(WP_LOG_ECC, "Can't set curve: %d",rc);
             ok = 0;
         }
     }
     if (ok && (!wp_ecc_set_bits(ecc))) {
-        WOLFPROV_MSG(WP_LOG_PK, "Can't set bits");
+        WOLFPROV_MSG(WP_LOG_ECC, "Can't set bits");
         ok = 0;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_ECC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -2007,6 +2055,8 @@ static int wp_ecc_decode_x963_pub(wp_Ecc* ecc, unsigned char* data, word32 len)
 {
     int ok = 1;
     int rc;
+
+    WOLFPROV_ENTER(WP_LOG_ECC, "wp_ecc_decode_x963_pub");
 
     rc = wc_ecc_import_x963((const byte *)data, len, &ecc->key);
     if (rc != 0) {
@@ -2021,7 +2071,7 @@ static int wp_ecc_decode_x963_pub(wp_Ecc* ecc, unsigned char* data, word32 len)
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_ECC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -2039,6 +2089,8 @@ static int wp_ecc_decode_spki(wp_Ecc* ecc, unsigned char* data, word32 len)
     int ok = 1;
     int rc;
     word32 idx = 0;
+
+    WOLFPROV_ENTER(WP_LOG_ECC, "wp_ecc_decode_spki");
 
     if (!wolfssl_prov_is_running()) {
         ok = 0;
@@ -2058,7 +2110,7 @@ static int wp_ecc_decode_spki(wp_Ecc* ecc, unsigned char* data, word32 len)
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_ECC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -2076,6 +2128,8 @@ static int wp_ecc_decode_pki(wp_Ecc* ecc, unsigned char* data, word32 len)
     int ok = 1;
     int rc;
     word32 idx = 0;
+
+    WOLFPROV_ENTER(WP_LOG_ECC, "wp_ecc_decode_pki");
 
     if (!wolfssl_prov_is_running()) {
         ok = 0;
@@ -2117,7 +2171,7 @@ static int wp_ecc_decode_pki(wp_Ecc* ecc, unsigned char* data, word32 len)
         ecc->hasPub = 1;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_ECC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -2138,6 +2192,8 @@ static int wp_ecc_dec_send_params(wp_Ecc* ecc, OSSL_CALLBACK *dataCb,
     OSSL_PARAM params[4];
     int object_type = OSSL_OBJECT_PKEY;
 
+    WOLFPROV_ENTER(WP_LOG_ECC, "wp_ecc_dec_send_params");
+
     params[0] = OSSL_PARAM_construct_int(OSSL_OBJECT_PARAM_TYPE, &object_type);
     params[1] = OSSL_PARAM_construct_utf8_string(OSSL_OBJECT_PARAM_DATA_TYPE,
         (char*)"EC", 0);
@@ -2151,7 +2207,7 @@ static int wp_ecc_dec_send_params(wp_Ecc* ecc, OSSL_CALLBACK *dataCb,
         ok = 0;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_ECC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -2179,6 +2235,8 @@ static int wp_ecc_decode(wp_EccEncDecCtx* ctx, OSSL_CORE_BIO *cBio,
     wp_Ecc* ecc = NULL;
     unsigned char* data = NULL;
     word32 len = 0;
+
+    WOLFPROV_ENTER(WP_LOG_ECC, "wp_ecc_decode");
 
     (void)pwCb;
     (void)pwCbArg;
@@ -2239,7 +2297,7 @@ static int wp_ecc_decode(wp_EccEncDecCtx* ctx, OSSL_CORE_BIO *cBio,
             ok = 1;
         }
     }
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_ECC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -2256,6 +2314,8 @@ static int wp_ecc_encode_params_size(const wp_Ecc *ecc, size_t* keyLen)
     int ok = 1;
     word32 len = 0;
 
+    WOLFPROV_ENTER(WP_LOG_ECC, "wp_ecc_encode_params_size");
+
     if (wc_ecc_get_oid(ecc->key.dp->oidSum, NULL, &len) <= 0) {
         ok = 0;
     }
@@ -2264,7 +2324,7 @@ static int wp_ecc_encode_params_size(const wp_Ecc *ecc, size_t* keyLen)
         *keyLen = len + 2;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_ECC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -2285,6 +2345,8 @@ static int wp_ecc_encode_params(const wp_Ecc *ecc, unsigned char* keyData,
     word32 len;
     const byte *oid;
 
+    WOLFPROV_ENTER(WP_LOG_ECC, "wp_ecc_encode_params");
+
     if (wc_ecc_get_oid(ecc->key.dp->oidSum, &oid, &len) <= 0) {
         ok = 0;
     }
@@ -2295,7 +2357,7 @@ static int wp_ecc_encode_params(const wp_Ecc *ecc, unsigned char* keyData,
         *keyLen = len + 2;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_ECC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -2313,6 +2375,8 @@ static int wp_ecc_encode_pub_size(const wp_Ecc *ecc, size_t* keyLen)
     int rc;
     word32 len;
 
+    WOLFPROV_ENTER(WP_LOG_ECC, "wp_ecc_encode_pub_size");
+
     rc = wc_ecc_export_x963_ex((ecc_key*)&ecc->key, NULL, &len, 0);
     if (rc != LENGTH_ONLY_E) {
         ok = 0;
@@ -2321,7 +2385,7 @@ static int wp_ecc_encode_pub_size(const wp_Ecc *ecc, size_t* keyLen)
         *keyLen = len;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_ECC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -2342,6 +2406,8 @@ static int wp_ecc_encode_pub(const wp_Ecc *ecc, unsigned char* keyData,
     int rc;
     word32 len = (word32)*keyLen;
 
+    WOLFPROV_ENTER(WP_LOG_ECC, "wp_ecc_encode_pub");
+
     rc = wc_ecc_export_x963_ex((ecc_key*)&ecc->key, keyData, &len, 0);
     if (rc != 0) {
         ok = 0;
@@ -2350,7 +2416,7 @@ static int wp_ecc_encode_pub(const wp_Ecc *ecc, unsigned char* keyData,
         *keyLen = len;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_ECC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -2367,6 +2433,8 @@ static int wp_ecc_encode_priv_size(const wp_Ecc *ecc, size_t* keyLen)
     int ok = 1;
 #if LIBWOLFSSL_VERSION_HEX >= 0x05000000
     int rc;
+
+    WOLFPROV_ENTER(WP_LOG_ECC, "wp_ecc_encode_priv_size");
 
     rc = wc_EccKeyDerSize((ecc_key*)&ecc->key, 1);
     if (rc <= 0) {
@@ -2388,7 +2456,7 @@ static int wp_ecc_encode_priv_size(const wp_Ecc *ecc, size_t* keyLen)
     }
 #endif
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_ECC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -2409,6 +2477,8 @@ static int wp_ecc_encode_priv(const wp_Ecc *ecc, unsigned char* keyData,
     int rc;
     word32 len = (word32)*keyLen;
 
+    WOLFPROV_ENTER(WP_LOG_ECC, "wp_ecc_encode_priv");
+
     rc = wc_EccKeyToDer((ecc_key*)&ecc->key, keyData, len);
     if (rc <= 0) {
         ok = 0;
@@ -2417,7 +2487,7 @@ static int wp_ecc_encode_priv(const wp_Ecc *ecc, unsigned char* keyData,
         *keyLen = rc;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_ECC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -2434,6 +2504,8 @@ static int wp_ecc_encode_spki_size(const wp_Ecc *ecc, size_t* keyLen)
     int ok = 1;
     int rc;
 
+    WOLFPROV_ENTER(WP_LOG_ECC, "wp_ecc_encode_spki_size");
+
     rc = wc_EccPublicKeyDerSize((ecc_key*)&ecc->key, 1);
     if (rc < 0) {
         ok = 0;
@@ -2442,7 +2514,7 @@ static int wp_ecc_encode_spki_size(const wp_Ecc *ecc, size_t* keyLen)
         *keyLen = rc;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_ECC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -2463,6 +2535,8 @@ static int wp_ecc_encode_spki(const wp_Ecc *ecc, unsigned char* keyData,
     int rc;
     word32 len = (word32)*keyLen;
 
+    WOLFPROV_ENTER(WP_LOG_ECC, "wp_ecc_encode_spki");
+
     rc = wc_EccPublicKeyToDer((ecc_key*)&ecc->key, keyData, len, 1);
     if (rc <= 0) {
         ok = 0;
@@ -2471,7 +2545,7 @@ static int wp_ecc_encode_spki(const wp_Ecc *ecc, unsigned char* keyData,
         *keyLen = rc;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_ECC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -2489,6 +2563,8 @@ static int wp_ecc_encode_pki_size(const wp_Ecc *ecc, size_t* keyLen)
     int rc;
     word32 len;
 
+    WOLFPROV_ENTER(WP_LOG_ECC, "wp_ecc_encode_pki_size");
+
     PRIVATE_KEY_UNLOCK();
     rc = wc_EccKeyToPKCS8((ecc_key*)&ecc->key, NULL, &len);
     PRIVATE_KEY_LOCK();
@@ -2499,7 +2575,7 @@ static int wp_ecc_encode_pki_size(const wp_Ecc *ecc, size_t* keyLen)
         *keyLen = len;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_ECC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -2520,6 +2596,8 @@ static int wp_ecc_encode_pki(const wp_Ecc *ecc, unsigned char* keyData,
     int rc;
     word32 len = (word32)*keyLen;
 
+    WOLFPROV_ENTER(WP_LOG_ECC, "wp_ecc_encode_pki");
+
     /* TODO: for older versions, curve is always included! */
     PRIVATE_KEY_UNLOCK();
     rc = wc_EccKeyToPKCS8((ecc_key*)&ecc->key, keyData, &len);
@@ -2531,7 +2609,7 @@ static int wp_ecc_encode_pki(const wp_Ecc *ecc, unsigned char* keyData,
         *keyLen = len;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_ECC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -2550,6 +2628,8 @@ static int wp_ecc_encode_epki_size(const wp_Ecc *ecc, size_t* keyLen)
     int rc;
     word32 len;
 
+    WOLFPROV_ENTER(WP_LOG_ECC, "wp_ecc_encode_epki_size");
+
     PRIVATE_KEY_UNLOCK();
     rc = wc_EccKeyToPKCS8((ecc_key*)&ecc->key, NULL, &len);
     PRIVATE_KEY_LOCK();
@@ -2560,7 +2640,7 @@ static int wp_ecc_encode_epki_size(const wp_Ecc *ecc, size_t* keyLen)
         *keyLen = ((len + 15) / 16) * 16;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_ECC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -2586,6 +2666,8 @@ static int wp_ecc_encode_epki(const wp_EccEncDecCtx* ctx, const wp_Ecc *ecc,
     int rc;
     word32 len = (word32)*keyLen;
 
+    WOLFPROV_ENTER(WP_LOG_ECC, "wp_ecc_encode_epki");
+
     /* Encode key. */
     PRIVATE_KEY_UNLOCK();
     rc = wc_EccKeyToPKCS8((ecc_key*)&ecc->key, keyData, &len);
@@ -2598,7 +2680,7 @@ static int wp_ecc_encode_epki(const wp_EccEncDecCtx* ctx, const wp_Ecc *ecc,
         ok = 0;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_ECC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 #endif
@@ -2632,6 +2714,8 @@ static int wp_ecc_encode(wp_EccEncDecCtx* ctx, OSSL_CORE_BIO *cBio,
     int pemType = PKCS8_PRIVATEKEY_TYPE;
     int private = 0;
     byte* cipherInfo = NULL;
+
+    WOLFPROV_ENTER(WP_LOG_ECC, "wp_ecc_encode");
 
     (void)params;
     (void)pwCb;
@@ -2785,7 +2869,7 @@ static int wp_ecc_encode(wp_EccEncDecCtx* ctx, OSSL_CORE_BIO *cBio,
         OPENSSL_free(pemData);
     }
     OPENSSL_free(cipherInfo);
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_ECC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -2837,6 +2921,8 @@ static int wp_ecc_type_specific_does_selection(WOLFPROV_CTX* provCtx,
 {
     int ok;
 
+    WOLFPROV_ENTER(WP_LOG_ECC, "wp_ecc_type_specific_does_selection");
+
     (void)provCtx;
 
     if (selection == 0) {
@@ -2846,7 +2932,7 @@ static int wp_ecc_type_specific_does_selection(WOLFPROV_CTX* provCtx,
         ok = (selection & OSSL_KEYMGMT_SELECT_ALL_PARAMETERS) != 0;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_ECC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -2952,6 +3038,8 @@ static int wp_ecc_spki_does_selection(WOLFPROV_CTX* provCtx, int selection)
 {
     int ok;
 
+    WOLFPROV_ENTER(WP_LOG_ECC, "wp_ecc_spki_does_selection");
+
     (void)provCtx;
 
     if (selection == 0) {
@@ -2961,7 +3049,7 @@ static int wp_ecc_spki_does_selection(WOLFPROV_CTX* provCtx, int selection)
         ok = (selection & OSSL_KEYMGMT_SELECT_PUBLIC_KEY) != 0;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_ECC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -3061,6 +3149,8 @@ static int wp_ecc_pki_does_selection(WOLFPROV_CTX* provCtx, int selection)
 {
     int ok;
 
+    WOLFPROV_ENTER(WP_LOG_ECC, "wp_ecc_pki_does_selection");
+
     (void)provCtx;
 
     if (selection == 0) {
@@ -3070,7 +3160,7 @@ static int wp_ecc_pki_does_selection(WOLFPROV_CTX* provCtx, int selection)
         ok = (selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY) != 0;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_ECC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -3231,6 +3321,8 @@ static int wp_ecc_x9_62_does_selection(WOLFPROV_CTX* provCtx,
 {
     int ok;
 
+    WOLFPROV_ENTER(WP_LOG_ECC, "wp_ecc_x9_62_does_selection");
+
     (void)provCtx;
 
     if (selection == 0) {
@@ -3241,7 +3333,7 @@ static int wp_ecc_x9_62_does_selection(WOLFPROV_CTX* provCtx,
                            OSSL_KEYMGMT_SELECT_PRIVATE_KEY)) != 0;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_ECC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 

--- a/src/wp_ecdh_exch.c
+++ b/src/wp_ecdh_exch.c
@@ -178,6 +178,8 @@ static int wp_ecdh_init(wp_EcdhCtx* ctx, wp_Ecc* ecc, const OSSL_PARAM params[])
 {
     int ok = 1;
 
+    WOLFPROV_ENTER(WP_LOG_ECDH, "wp_ecdh_init");
+
     if (!wolfssl_prov_is_running()) {
         ok = 0;
     }
@@ -196,7 +198,7 @@ static int wp_ecdh_init(wp_EcdhCtx* ctx, wp_Ecc* ecc, const OSSL_PARAM params[])
         ok = wp_ecdh_set_ctx_params(ctx, params);
     }
 
-    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_ECDH, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -216,6 +218,8 @@ static int wp_ecdh_kdf_derive(wp_EcdhCtx* ctx, unsigned char* key,
     size_t* keyLen, size_t keySize, unsigned char* secret, size_t secLen)
 {
     int ok = 1;
+
+    WOLFPROV_ENTER(WP_LOG_ECDH, "wp_ecdh_kdf_derive");
 
     if (keySize < ctx->keyLen) {
         ok = 0;
@@ -240,7 +244,7 @@ static int wp_ecdh_kdf_derive(wp_EcdhCtx* ctx, unsigned char* key,
 #endif
     }
 
-    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_ECDH, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -261,6 +265,8 @@ static int wp_ecdh_derive_secret(wp_EcdhCtx* ctx, unsigned char* secret,
     int rc;
     word32 len = (word32)*secLen;
 
+    WOLFPROV_ENTER(WP_LOG_ECDH, "wp_ecdh_derive_secret");
+
 #ifdef HAVE_ECC_CDH
     if (ctx->cofactor) {
         wc_ecc_set_flags(wp_ecc_get_key(ctx->key), WC_ECC_FLAG_COFACTOR);
@@ -280,7 +286,7 @@ static int wp_ecdh_derive_secret(wp_EcdhCtx* ctx, unsigned char* secret,
         *secLen = len;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_ECDH, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -304,6 +310,8 @@ static int wp_ecdh_derive(wp_EcdhCtx* ctx, unsigned char* secret,
     unsigned char* out;
     size_t outLen;
     unsigned char tmp[72];
+
+    WOLFPROV_ENTER(WP_LOG_ECDH, "wp_ecdh_derive");
 
     if (!wolfssl_prov_is_running()) {
         ok = 0;
@@ -351,7 +359,7 @@ static int wp_ecdh_derive(wp_EcdhCtx* ctx, unsigned char* secret,
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_ECDH, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -366,6 +374,8 @@ static int wp_ecdh_derive(wp_EcdhCtx* ctx, unsigned char* secret,
 static int wp_ecdh_set_peer(wp_EcdhCtx* ctx, wp_Ecc* peer)
 {
     int ok = 1;
+
+    WOLFPROV_ENTER(WP_LOG_ECDH, "wp_ecdh_set_peer");
 
     if (!wolfssl_prov_is_running()) {
         ok = 0;
@@ -382,7 +392,7 @@ static int wp_ecdh_set_peer(wp_EcdhCtx* ctx, wp_Ecc* peer)
         ctx->peer = peer;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_ECDH, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -398,6 +408,8 @@ static int wp_ecdh_set_param_kdf(wp_EcdhCtx* ctx, const OSSL_PARAM params[])
 {
     int ok = 1;
     const char* kdf = NULL;
+
+    WOLFPROV_ENTER(WP_LOG_ECDH, "wp_ecdh_set_param_kdf");
 
     if (!wp_params_get_utf8_string_ptr(params, OSSL_EXCHANGE_PARAM_KDF_TYPE,
             &kdf)) {
@@ -416,7 +428,7 @@ static int wp_ecdh_set_param_kdf(wp_EcdhCtx* ctx, const OSSL_PARAM params[])
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_ECDH, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -433,6 +445,8 @@ static int wp_ecdh_set_param_kdf_digest(wp_EcdhCtx* ctx,
 {
     int ok = 1;
     const char* mdName = NULL;
+
+    WOLFPROV_ENTER(WP_LOG_ECDH, "wp_ecdh_set_param_kdf_digest");
 
     if (!wp_params_get_utf8_string_ptr(params, OSSL_EXCHANGE_PARAM_KDF_DIGEST,
             &mdName)) {
@@ -455,7 +469,7 @@ static int wp_ecdh_set_param_kdf_digest(wp_EcdhCtx* ctx,
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_ECDH, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -471,6 +485,8 @@ static int wp_ecdh_set_ctx_params(wp_EcdhCtx* ctx, const OSSL_PARAM params[])
 {
     int ok = 1;
     const OSSL_PARAM* p;
+
+    WOLFPROV_ENTER(WP_LOG_ECDH, "wp_ecdh_set_ctx_params");
 
     if (params != NULL) {
         if (!wp_params_get_int(params,
@@ -495,7 +511,7 @@ static int wp_ecdh_set_ctx_params(wp_EcdhCtx* ctx, const OSSL_PARAM params[])
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_ECDH, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -539,6 +555,8 @@ static int wp_ecdh_get_params_kdf(wp_EcdhCtx* ctx, OSSL_PARAM params[])
      int ok = 1;
      OSSL_PARAM* p;
 
+     WOLFPROV_ENTER(WP_LOG_ECDH, "wp_ecdh_get_params_kdf");
+
      p = OSSL_PARAM_locate(params, OSSL_EXCHANGE_PARAM_KDF_TYPE);
      if (p != NULL) {
          const char* type = "";
@@ -550,7 +568,7 @@ static int wp_ecdh_get_params_kdf(wp_EcdhCtx* ctx, OSSL_PARAM params[])
          }
      }
 
-     WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+     WOLFPROV_LEAVE(WP_LOG_ECDH, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
      return ok;
 }
 
@@ -566,6 +584,8 @@ static int wp_ecdh_get_ctx_params(wp_EcdhCtx* ctx, OSSL_PARAM params[])
 {
      int ok = 1;
      OSSL_PARAM* p;
+
+     WOLFPROV_ENTER(WP_LOG_ECDH, "wp_ecdh_get_ctx_params");
 
      p = OSSL_PARAM_locate(params, OSSL_EXCHANGE_PARAM_EC_ECDH_COFACTOR_MODE);
      if ((p != NULL) && (!OSSL_PARAM_set_int(p, ctx->cofactor))) {
@@ -594,7 +614,7 @@ static int wp_ecdh_get_ctx_params(wp_EcdhCtx* ctx, OSSL_PARAM params[])
          }
      }
 
-     WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+     WOLFPROV_LEAVE(WP_LOG_ECDH, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
      return ok;
 }
 

--- a/src/wp_ecdsa_sig.c
+++ b/src/wp_ecdsa_sig.c
@@ -185,6 +185,8 @@ static int wp_ecdsa_signverify_init(wp_EcdsaSigCtx *ctx, wp_Ecc* ecc,
 {
     int ok = 1;
 
+    WOLFPROV_ENTER(WP_LOG_ECDSA, "wp_ecdsa_signverify_init");
+
     if (ctx == NULL || (ecc == NULL && ctx->ecc == NULL)) {
         ok = 0;
     }
@@ -206,7 +208,7 @@ static int wp_ecdsa_signverify_init(wp_EcdsaSigCtx *ctx, wp_Ecc* ecc,
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_ECDSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -224,6 +226,8 @@ static int wp_ecdsa_sign_init(wp_EcdsaSigCtx *ctx, wp_Ecc *ecc,
 {
     int ok;
 
+    WOLFPROV_ENTER(WP_LOG_ECDSA, "wp_ecdsa_sign_init");
+
     if (!wolfssl_prov_is_running()) {
         ok = 0;
     }
@@ -231,7 +235,7 @@ static int wp_ecdsa_sign_init(wp_EcdsaSigCtx *ctx, wp_Ecc *ecc,
         ok = wp_ecdsa_signverify_init(ctx, ecc, params, EVP_PKEY_OP_SIGN);
     }
 
-    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_ECDSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -254,6 +258,8 @@ static int wp_ecdsa_sign(wp_EcdsaSigCtx *ctx, unsigned char *sig,
     size_t *sigLen, size_t sigSize, const unsigned char *tbs, size_t tbsLen)
 {
     int ok = 1;
+
+    WOLFPROV_ENTER(WP_LOG_ECDSA, "wp_ecdsa_sign");
 
     if (!wolfssl_prov_is_running()) {
         ok = 0;
@@ -299,7 +305,7 @@ static int wp_ecdsa_sign(wp_EcdsaSigCtx *ctx, unsigned char *sig,
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_ECDSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -317,6 +323,8 @@ static int wp_ecdsa_verify_init(wp_EcdsaSigCtx *ctx, wp_Ecc *ecc,
 {
     int ok;
 
+    WOLFPROV_ENTER(WP_LOG_ECDSA, "wp_ecdsa_verify_init");
+
     if (!wolfssl_prov_is_running()) {
         ok = 0;
     }
@@ -324,7 +332,7 @@ static int wp_ecdsa_verify_init(wp_EcdsaSigCtx *ctx, wp_Ecc *ecc,
         ok = wp_ecdsa_signverify_init(ctx, ecc, params, EVP_PKEY_OP_VERIFY);
     }
 
-    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_ECDSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -344,6 +352,8 @@ static int wp_ecdsa_verify(wp_EcdsaSigCtx *ctx, const unsigned char *sig,
 {
     int ok = 1;
 
+    WOLFPROV_ENTER(WP_LOG_ECDSA, "wp_ecdsa_verify");
+
     if (!wolfssl_prov_is_running()) {
         ok = 0;
     }
@@ -359,7 +369,7 @@ static int wp_ecdsa_verify(wp_EcdsaSigCtx *ctx, const unsigned char *sig,
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_ECDSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -377,6 +387,8 @@ static int wp_ecdsa_verify_recover_init(wp_EcdsaSigCtx *ctx, wp_Ecc *ecc,
 {
     int ok = 1;
 
+    WOLFPROV_ENTER(WP_LOG_ECDSA, "wp_ecdsa_verify_recover_init");
+
     if (!wolfssl_prov_is_running()) {
         ok = 0;
     }
@@ -385,7 +397,7 @@ static int wp_ecdsa_verify_recover_init(wp_EcdsaSigCtx *ctx, wp_Ecc *ecc,
             EVP_PKEY_OP_VERIFYRECOVER);
     }
 
-    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_ECDSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -427,6 +439,8 @@ static int wp_ecdsa_setup_md(wp_EcdsaSigCtx *ctx, const char *mdName,
     const char *mdProps, int op)
 {
     int ok = 1;
+
+    WOLFPROV_ENTER(WP_LOG_ECDSA, "wp_ecdsa_setup_md");
 
     (void)op;
 
@@ -475,7 +489,7 @@ static int wp_ecdsa_setup_md(wp_EcdsaSigCtx *ctx, const char *mdName,
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_ECDSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -495,6 +509,8 @@ static int wp_ecdsa_digest_signverify_init(wp_EcdsaSigCtx *ctx,
 {
     int ok;
 
+    WOLFPROV_ENTER(WP_LOG_ECDSA, "wp_ecdsa_digest_signverify_init");
+
     ok = wp_ecdsa_signverify_init(ctx, ecc, params, op);
     if (ok) {
         if ((mdName != NULL) && ((mdName[0] == '\0') ||
@@ -503,7 +519,7 @@ static int wp_ecdsa_digest_signverify_init(wp_EcdsaSigCtx *ctx,
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_ECDSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -520,6 +536,9 @@ static int wp_ecdsa_digest_signverify_update(wp_EcdsaSigCtx *ctx,
     const unsigned char *data, size_t dataLen)
 {
     int ok = 1;
+
+    WOLFPROV_ENTER(WP_LOG_ECDSA, "wp_ecdsa_digest_signverify_update");
+
     int rc = wc_HashUpdate(&ctx->hash,
 #if LIBWOLFSSL_VERSION_HEX >= 0x05007004
             ctx->hash.type,
@@ -530,7 +549,7 @@ static int wp_ecdsa_digest_signverify_update(wp_EcdsaSigCtx *ctx,
     if (rc != 0) {
         ok = 0;
     }
-    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_ECDSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -549,6 +568,8 @@ static int wp_ecdsa_digest_sign_init(wp_EcdsaSigCtx *ctx, const char *mdName,
 {
     int ok;
 
+    WOLFPROV_ENTER(WP_LOG_ECDSA, "wp_ecdsa_digest_sign_init");
+
     if (!wolfssl_prov_is_running()) {
         ok = 0;
     }
@@ -557,7 +578,7 @@ static int wp_ecdsa_digest_sign_init(wp_EcdsaSigCtx *ctx, const char *mdName,
             EVP_PKEY_OP_SIGN);
     }
 
-    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_ECDSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -579,6 +600,8 @@ static int wp_ecdsa_digest_sign_final(wp_EcdsaSigCtx *ctx, unsigned char *sig,
 {
     int ok = 1;
     unsigned char digest[WC_MAX_DIGEST_SIZE];
+
+    WOLFPROV_ENTER(WP_LOG_ECDSA, "wp_ecdsa_digest_sign_final");
 
     if (!wolfssl_prov_is_running()) {
         ok = 0;
@@ -607,7 +630,7 @@ static int wp_ecdsa_digest_sign_final(wp_EcdsaSigCtx *ctx, unsigned char *sig,
             ));
     }
 
-    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_ECDSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -626,6 +649,8 @@ static int wp_ecdsa_digest_verify_init(wp_EcdsaSigCtx *ctx, const char *mdName,
 {
     int ok;
 
+    WOLFPROV_ENTER(WP_LOG_ECDSA, "wp_ecdsa_digest_verify_init");
+
     if (!wolfssl_prov_is_running()) {
         ok = 0;
     }
@@ -634,7 +659,7 @@ static int wp_ecdsa_digest_verify_init(wp_EcdsaSigCtx *ctx, const char *mdName,
             EVP_PKEY_OP_VERIFY);
     }
 
-    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_ECDSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -652,6 +677,8 @@ static int wp_ecdsa_digest_verify_final(wp_EcdsaSigCtx *ctx, unsigned char *sig,
 {
     int ok = 1;
     unsigned char digest[WC_MAX_DIGEST_SIZE];
+
+    WOLFPROV_ENTER(WP_LOG_ECDSA, "wp_ecdsa_digest_verify_final");
 
     if (!wolfssl_prov_is_running()) {
         ok = 0;
@@ -679,7 +706,7 @@ static int wp_ecdsa_digest_verify_final(wp_EcdsaSigCtx *ctx, unsigned char *sig,
             );
     }
 
-    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_ECDSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -731,6 +758,8 @@ static int wp_ecdsa_get_ctx_params(wp_EcdsaSigCtx *ctx, OSSL_PARAM *params)
     int ok = 1;
     OSSL_PARAM *p;
 
+    WOLFPROV_ENTER(WP_LOG_ECDSA, "wp_ecdsa_get_ctx_params");
+
     if (ctx == NULL) {
         ok = 0;
     }
@@ -749,7 +778,7 @@ static int wp_ecdsa_get_ctx_params(wp_EcdsaSigCtx *ctx, OSSL_PARAM *params)
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_ECDSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -792,6 +821,8 @@ static int wp_ecdsa_set_digest(wp_EcdsaSigCtx *ctx, const OSSL_PARAM *p,
     char mdProps[WP_MAX_MD_NAME_SIZE];
     char* pmdProps = NULL;
 
+    WOLFPROV_ENTER(WP_LOG_ECDSA, "wp_ecdsa_set_digest");
+
     if (!OSSL_PARAM_get_utf8_string(p, &pmdName, sizeof(mdName))) {
         ok = 0;
     }
@@ -806,7 +837,7 @@ static int wp_ecdsa_set_digest(wp_EcdsaSigCtx *ctx, const OSSL_PARAM *p,
         ok = wp_ecdsa_setup_md(ctx, mdName, pmdProps, ctx->op);
     }
 
-    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_ECDSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -824,6 +855,8 @@ static int wp_ecdsa_set_ctx_params(wp_EcdsaSigCtx *ctx, const OSSL_PARAM params[
     const OSSL_PARAM *p;
     const OSSL_PARAM *propsParam;
 
+    WOLFPROV_ENTER(WP_LOG_ECDSA, "wp_ecdsa_set_ctx_params");
+
     if (params != NULL) {
         p = OSSL_PARAM_locate_const(params, OSSL_SIGNATURE_PARAM_DIGEST);
         if (p != NULL) {
@@ -833,7 +866,7 @@ static int wp_ecdsa_set_ctx_params(wp_EcdsaSigCtx *ctx, const OSSL_PARAM params[
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_ECDSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 

--- a/src/wp_ecx_exch.c
+++ b/src/wp_ecx_exch.c
@@ -136,6 +136,8 @@ static int wp_ecx_init(wp_EcxCtx* ctx, wp_Ecx* ecx, const OSSL_PARAM params[])
 {
     int ok = 1;
 
+    WOLFPROV_ENTER(WP_LOG_X25519, "wp_ecx_init");
+
     /* No settable parameters. */
     (void)params;
 
@@ -153,7 +155,7 @@ static int wp_ecx_init(wp_EcxCtx* ctx, wp_Ecx* ecx, const OSSL_PARAM params[])
         ctx->key = ecx;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_X25519, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -170,6 +172,8 @@ static int wp_ecx_set_peer(wp_EcxCtx* ctx, wp_Ecx* peer)
 {
     int ok = 1;
 
+    WOLFPROV_ENTER(WP_LOG_X25519, "wp_ecx_set_peer");
+
     if (!wolfssl_prov_is_running()) {
         ok = 0;
     }
@@ -185,7 +189,7 @@ static int wp_ecx_set_peer(wp_EcxCtx* ctx, wp_Ecx* peer)
         ctx->peer = peer;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_X25519, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -219,6 +223,8 @@ static int wp_x25519_derive(wp_EcxCtx* ctx, unsigned char* secret,
     size_t* secLen, size_t secSize)
 {
     int ok = 1;
+
+    WOLFPROV_ENTER(WP_LOG_X25519, "wp_x25519_derive");
 
     if (!wolfssl_prov_is_running()) {
         ok = 0;
@@ -266,7 +272,7 @@ static int wp_x25519_derive(wp_EcxCtx* ctx, unsigned char* secret,
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_X25519, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -306,6 +312,8 @@ static int wp_x448_derive(wp_EcxCtx* ctx, unsigned char* secret,
 {
     int ok = 1;
 
+    WOLFPROV_ENTER(WP_LOG_X448, "wp_x448_derive");
+
     if (!wolfssl_prov_is_running()) {
         ok = 0;
     }
@@ -336,7 +344,7 @@ static int wp_x448_derive(wp_EcxCtx* ctx, unsigned char* secret,
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_X448, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 

--- a/src/wp_ecx_kmgmt.c
+++ b/src/wp_ecx_kmgmt.c
@@ -214,6 +214,8 @@ int wp_ecx_up_ref(wp_Ecx* ecx)
     int ok = 1;
     int rc;
 
+    WOLFPROV_ENTER(WP_LOG_KE, "wp_ecx_up_ref");
+
     rc = wc_LockMutex(&ecx->mutex);
     if (rc < 0) {
         ok = 0;
@@ -226,8 +228,9 @@ int wp_ecx_up_ref(wp_Ecx* ecx)
     WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 #else
+    WOLFPROV_ENTER(WP_LOG_KE, "wp_ecx_up_ref");
     ecx->refCnt++;
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), 1);
+    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), 1);
     return 1;
 #endif
 }
@@ -415,6 +418,8 @@ static int wp_ecx_set_params(wp_Ecx* ecx, const OSSL_PARAM params[])
     unsigned char* data = NULL;
     size_t len;
 
+    WOLFPROV_ENTER(WP_LOG_KE, "wp_ecx_set_params");
+
     if (!wp_params_get_octet_string_ptr(params,
             OSSL_PKEY_PARAM_ENCODED_PUBLIC_KEY, &data, &len)) {
         ok = 0;
@@ -493,6 +498,8 @@ static int wp_ecx_get_params_enc_pub_key(wp_Ecx* ecx, OSSL_PARAM params[],
     int ok = 1;
     OSSL_PARAM* p;
 
+    WOLFPROV_ENTER(WP_LOG_KE, "wp_ecx_get_params_enc_pub_key");
+
     p = OSSL_PARAM_locate(params, key);
     if (p != NULL) {
         word32 outLen = (word32)p->return_size;
@@ -527,6 +534,8 @@ static int wp_ecx_get_params_priv_key(wp_Ecx* ecx, OSSL_PARAM params[])
     int ok = 1;
     OSSL_PARAM* p;
 
+    WOLFPROV_ENTER(WP_LOG_KE, "wp_ecx_get_params_priv_key");
+
     p = OSSL_PARAM_locate(params, OSSL_PKEY_PARAM_PRIV_KEY);
     if (p != NULL) {
         word32 outLen = (word32)p->return_size;
@@ -560,6 +569,8 @@ static int wp_ecx_get_params(wp_Ecx* ecx, OSSL_PARAM params[])
 {
     int ok = 1;
     OSSL_PARAM* p;
+
+    WOLFPROV_ENTER(WP_LOG_KE, "wp_ecx_get_params");
 
     p = OSSL_PARAM_locate(params, OSSL_PKEY_PARAM_MAX_SIZE);
     if (p != NULL) {
@@ -608,6 +619,8 @@ static int wp_ecx_has(const wp_Ecx* ecx, int selection)
 {
     int ok = 1;
 
+    WOLFPROV_ENTER(WP_LOG_KE, "wp_ecx_has");
+
     if (!wolfssl_prov_is_running()) {
        ok = 0;
     }
@@ -641,6 +654,8 @@ static int wp_ecx_match_priv_key(const wp_Ecx* ecx1, const wp_Ecx* ecx2)
     word32 len1;
     unsigned char key2[WP_MAX_KEY_SIZE];
     word32 len2;
+
+    WOLFPROV_ENTER(WP_LOG_KE, "wp_ecx_match_priv_key");
 
     XMEMSET(key1, 0, sizeof(key1));
     XMEMSET(key2, 0, sizeof(key2));
@@ -687,6 +702,8 @@ static int wp_ecx_match_pub_key(const wp_Ecx* ecx1, const wp_Ecx* ecx2)
     unsigned char key2[WP_MAX_KEY_SIZE];
     word32 len2;
 
+    WOLFPROV_ENTER(WP_LOG_KE, "wp_ecx_match_pub_key");
+
     XMEMSET(key1, 0, sizeof(key1));
     XMEMSET(key2, 0, sizeof(key2));
     ok &= ecx1->hasPub && ecx2->hasPub;
@@ -730,6 +747,8 @@ static int wp_ecx_match(const wp_Ecx* ecx1, const wp_Ecx* ecx2, int selection)
 {
     int ok = 1;
 
+    WOLFPROV_ENTER(WP_LOG_KE, "wp_ecx_match");
+
     if (!wolfssl_prov_is_running()) {
         ok = 0;
     }
@@ -764,6 +783,8 @@ static int wp_ecx_validate_pub_key(const wp_Ecx* ecx)
     int rc;
     unsigned char key[WP_MAX_KEY_SIZE] = {0};
     word32 len = ecx->data->len;
+
+    WOLFPROV_ENTER(WP_LOG_KE, "wp_ecx_validate_pub_key");
 
     ok &= ecx->hasPub;
     if (ok) {
@@ -801,6 +822,8 @@ static int wp_ecx_x_validate(const wp_Ecx* ecx, int selection, int checkType)
 {
     int ok = 1;
 
+    WOLFPROV_ENTER(WP_LOG_KE, "wp_ecx_x_validate");
+
     (void)checkType;
 
     if (ok && ((selection & OSSL_KEYMGMT_SELECT_PUBLIC_KEY) != 0) &&
@@ -832,6 +855,8 @@ static int wp_ecx_x_validate(const wp_Ecx* ecx, int selection, int checkType)
 static int wp_ecx_ed_validate(const wp_Ecx* ecx, int selection, int checkType)
 {
     int ok = 1;
+
+    WOLFPROV_ENTER(WP_LOG_KE, "wp_ecx_ed_validate");
 
     (void)checkType;
 
@@ -872,6 +897,8 @@ static int wp_ecx_import(wp_Ecx* ecx, int selection, const OSSL_PARAM params[])
     unsigned char* privData = NULL;
     unsigned char* pubData = NULL;
     size_t len;
+
+    WOLFPROV_ENTER(WP_LOG_KE, "wp_ecx_import");
 
     if ((!wolfssl_prov_is_running()) || (ecx == NULL)) {
         ok = 0;
@@ -1024,6 +1051,8 @@ static int wp_ecx_export_keypair(wp_Ecx* ecx, OSSL_PARAM* params, int* pIdx,
     int i = *pIdx;
     word32 outLen;
 
+    WOLFPROV_ENTER(WP_LOG_KE, "wp_ecx_export_keypair");
+
     outLen = ecx->data->len;
     rc = (*ecx->data->exportPub)((void*)&ecx->key, data + *idx, &outLen,
         ECX_LITTLE_ENDIAN);
@@ -1074,6 +1103,8 @@ static int wp_ecx_export(wp_Ecx* ecx, int selection, OSSL_CALLBACK* paramCb,
     unsigned char* data = NULL;
     size_t len = 0;
     int expPriv = (selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY) != 0;
+
+    WOLFPROV_ENTER(WP_LOG_KE, "wp_ecx_export");
 
     if (!wolfssl_prov_is_running()) {
         ok = 0;
@@ -1200,6 +1231,8 @@ static int wp_ecx_gen_set_params(wp_EcxGenCtx* ctx, const OSSL_PARAM params[])
 {
     int ok = 1;
     const char* name = NULL;
+
+    WOLFPROV_ENTER(WP_LOG_KE, "wp_ecx_gen_set_params");
 
     (void)ctx;
 
@@ -1866,6 +1899,8 @@ static int wp_ecx_enc_dec_set_ctx_params(wp_EcxEncDecCtx* ctx,
 {
     int ok = 1;
 
+    WOLFPROV_ENTER(WP_LOG_KE, "wp_ecx_enc_dec_set_ctx_params");
+
     if (!wp_cipher_from_params(params, &ctx->cipher, &ctx->cipherName)) {
         ok = 0;
     }
@@ -1887,9 +1922,10 @@ static int wp_ecx_dec_send_params(wp_Ecx* ecx, const char* dataType,
     OSSL_CALLBACK* dataCb, void* dataCbArg)
 {
     int ok = 1;
-
     OSSL_PARAM params[4];
     int object_type = OSSL_OBJECT_PKEY;
+
+    WOLFPROV_ENTER(WP_LOG_KE, "wp_ecx_dec_send_params");
 
     params[0] = OSSL_PARAM_construct_int(OSSL_OBJECT_PARAM_TYPE, &object_type);
     params[1] = OSSL_PARAM_construct_utf8_string(OSSL_OBJECT_PARAM_DATA_TYPE,
@@ -1935,6 +1971,8 @@ static int wp_ecx_decode(wp_EcxEncDecCtx* ctx, OSSL_CORE_BIO* cBio,
     word32 idx = 0;
     wp_Ecx* ecx = NULL;
     const char* dataType = NULL;
+
+    WOLFPROV_ENTER(WP_LOG_KE, "wp_ecx_decode");
 
     if (!wolfssl_prov_is_running()) {
         ok = 0;
@@ -2035,6 +2073,8 @@ static int wp_ecx_encode(wp_EcxEncDecCtx* ctx, OSSL_CORE_BIO *cBio,
     int ok = 1;
     int rc;
     BIO* out = wp_corebio_get_bio(ctx->provCtx, cBio);
+
+    WOLFPROV_ENTER(WP_LOG_KE, "wp_ecx_encode");
 
     if (!wolfssl_prov_is_running()) {
         ok = 0;
@@ -2156,6 +2196,8 @@ static int wp_ecx_spki_does_selection(WOLFPROV_CTX* provCtx, int selection)
 {
     int ok = 0;
 
+    WOLFPROV_ENTER(WP_LOG_KE, "wp_ecx_spki_does_selection");
+
     (void)provCtx;
 
     if (selection == 0) {
@@ -2184,6 +2226,8 @@ static int wp_ecx_spki_does_selection(WOLFPROV_CTX* provCtx, int selection)
 static int wp_ecx_pki_does_selection(WOLFPROV_CTX* provCtx, int selection)
 {
     int ok;
+
+    WOLFPROV_ENTER(WP_LOG_KE, "wp_ecx_pki_does_selection");
 
     (void)provCtx;
 
@@ -2617,6 +2661,8 @@ static int wp_Ed25519PublicKeyToDer(ed25519_key* key, byte* output,
     word32 inLen)
 {
     int ok = 1;
+
+    WOLFPROV_ENTER(WP_LOG_KE, "wp_Ed25519PublicKeyToDer");
 
     /* Check if this is private key only. */
     if (!key->pubKeySet) {
@@ -3262,6 +3308,8 @@ const OSSL_DISPATCH wp_ed448_spki_decoder_functions[] = {
 static int wp_Ed448PublicKeyToDer(ed448_key* key, byte* output, word32 inLen)
 {
     int ok = 1;
+
+    WOLFPROV_ENTER(WP_LOG_KE, "wp_Ed448PublicKeyToDer");
 
     /* Check if this is private key only. */
     if (!key->pubKeySet) {

--- a/src/wp_ecx_sig.c
+++ b/src/wp_ecx_sig.c
@@ -182,6 +182,8 @@ static int wp_ecx_digest_signverify_init(wp_EcxSigCtx *ctx,
 {
     int ok = 1;
 
+    WOLFPROV_ENTER(WP_LOG_KE, "wp_ecx_digest_signverify_init");
+
     (void)params;
 
     if ((mdName != NULL) && (mdName[0] != '\0')) {
@@ -223,6 +225,8 @@ static int wp_ecx_digest_sign_init(wp_EcxSigCtx *ctx, const char *mdName,
 {
     int ok;
 
+    WOLFPROV_ENTER(WP_LOG_KE, "wp_ecx_digest_sign_init");
+
     if (!wolfssl_prov_is_running()) {
         ok = 0;
     }
@@ -249,6 +253,8 @@ static int wp_ecx_digest_verify_init(wp_EcxSigCtx *ctx, const char *mdName,
     wp_Ecx *ecx, const OSSL_PARAM params[])
 {
     int ok;
+
+    WOLFPROV_ENTER(WP_LOG_KE, "wp_ecx_digest_verify_init");
 
     if (!wolfssl_prov_is_running()) {
         ok = 0;
@@ -321,6 +327,8 @@ static int wp_ed25519_get_ctx_params(wp_EcxSigCtx *ctx, OSSL_PARAM *params)
     int ok = 1;
     OSSL_PARAM *p;
 
+    WOLFPROV_ENTER(WP_LOG_KE, "wp_ed25519_get_ctx_params");
+
     if (ctx == NULL) {
         ok = 0;
     }
@@ -353,6 +361,8 @@ static int wp_ed25519_digest_sign(wp_EcxSigCtx *ctx, unsigned char *sig,
     size_t *sigLen, size_t sigSize, const unsigned char *tbs, size_t tbsLen)
 {
     int ok = 1;
+
+    WOLFPROV_ENTER(WP_LOG_KE, "wp_ed25519_digest_sign");
 
     if (!wolfssl_prov_is_running()) {
         ok = 0;
@@ -429,6 +439,8 @@ static int wp_ed25519_digest_verify(wp_EcxSigCtx *ctx, unsigned char *sig,
     size_t sigLen, const unsigned char *tbs, size_t tbsLen)
 {
     int ok = 1;
+
+    WOLFPROV_ENTER(WP_LOG_KE, "wp_ed25519_digest_verify");
 
     if (!wolfssl_prov_is_running()) {
         ok = 0;
@@ -520,6 +532,8 @@ static int wp_ed448_get_ctx_params(wp_EcxSigCtx *ctx, OSSL_PARAM *params)
     int ok = 1;
     OSSL_PARAM *p;
 
+    WOLFPROV_ENTER(WP_LOG_KE, "wp_ed448_get_ctx_params");
+
     if (ctx == NULL) {
         ok = 0;
     }
@@ -552,6 +566,8 @@ static int wp_ed448_digest_sign(wp_EcxSigCtx *ctx, unsigned char *sig,
     size_t *sigLen, size_t sigSize, const unsigned char *tbs, size_t tbsLen)
 {
     int ok = 1;
+
+    WOLFPROV_ENTER(WP_LOG_KE, "wp_ed448_digest_sign");
 
     if (!wolfssl_prov_is_running()) {
         ok = 0;
@@ -631,6 +647,8 @@ static int wp_ed448_digest_verify(wp_EcxSigCtx *ctx, unsigned char *sig,
     size_t sigLen, const unsigned char *tbs, size_t tbsLen)
 {
     int ok = 1;
+
+    WOLFPROV_ENTER(WP_LOG_KE, "wp_ed448_digest_verify");
 
     if (!wolfssl_prov_is_running()) {
         ok = 0;

--- a/src/wp_file_store.c
+++ b/src/wp_file_store.c
@@ -199,6 +199,8 @@ static int wp_file_set_ctx_params(wp_FileCtx* ctx, const OSSL_PARAM params[])
     int ok = 1;
     const OSSL_PARAM *p;
 
+    WOLFPROV_ENTER(WP_LOG_PROVIDER, "wp_file_set_ctx_params");
+
     p = OSSL_PARAM_locate_const(params, OSSL_STORE_PARAM_PROPERTIES);
     if (p != NULL) {
         OPENSSL_free(ctx->propQuery);
@@ -279,6 +281,8 @@ static int wp_file_decoder_set_input_structure(OSSL_DECODER_CTX* decCtx,
     int type)
 {
     int ok = 1;
+
+    WOLFPROV_ENTER(WP_LOG_PROVIDER, "wp_file_decoder_set_input_structure");
 
     switch (type) {
         case OSSL_STORE_INFO_CERT:
@@ -363,6 +367,8 @@ static int wp_file_set_decoder(wp_FileCtx* ctx, OSSL_DECODER_CTX* decCtx)
     size_t i;
     OSSL_DECODER* decoder;
 
+    WOLFPROV_ENTER(WP_LOG_PROVIDER, "wp_file_set_decoder");
+
     for (i = 0; ok && (i < WP_DECODERS_SIZE); i++) {
         decoder = OSSL_DECODER_fetch(ctx->provCtx->libCtx, wp_decoders[i].name,
             wp_decoders[i].propQuery);
@@ -441,6 +447,8 @@ static int wp_file_load(wp_FileCtx* ctx, OSSL_CALLBACK* objCb, void* objCbArg,
 {
     int ok = 1;
 
+    WOLFPROV_ENTER(WP_LOG_PROVIDER, "wp_file_load");
+
     if (ctx->decCtx == NULL) {
         ctx->decCtx = wp_file_setup_decoders(ctx);
     }
@@ -485,6 +493,8 @@ static int wp_file_eof(wp_FileCtx* ctx)
  */
 static int wp_file_close(wp_FileCtx* ctx)
 {
+    WOLFPROV_ENTER(WP_LOG_PROVIDER, "wp_file_close");
+
     wp_filectx_free(ctx);
     WOLFPROV_LEAVE(WP_LOG_PROVIDER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), 1);
     return 1;

--- a/src/wp_gmac.c
+++ b/src/wp_gmac.c
@@ -116,6 +116,8 @@ static int wp_gmac_set_key(wp_GmacCtx* macCtx, const unsigned char *key,
 {
     int ok = 1;
 
+    WOLFPROV_ENTER(WP_LOG_MAC, "wp_gmac_set_key");
+
     if (keyLen > AES_256_KEY_SIZE) {
         ok = 0;
     }
@@ -190,6 +192,8 @@ static int wp_gmac_init(wp_GmacCtx* macCtx, const unsigned char* key,
 {
     int ok = 1;
 
+    WOLFPROV_ENTER(WP_LOG_MAC, "wp_gmac_init");
+
     if (!wolfssl_prov_is_running()) {
         ok = 0;
     }
@@ -218,6 +222,8 @@ static int wp_gmac_update(wp_GmacCtx* macCtx, const unsigned char* data,
 {
     int ok = 1;
     unsigned char* p;
+
+    WOLFPROV_ENTER(WP_LOG_MAC, "wp_gmac_update");
 
     /* Data cached as wolfSSL doesn't have a streaming API. */
     p = OPENSSL_realloc(macCtx->data, macCtx->dataLen + dataLen);
@@ -249,6 +255,8 @@ static int wp_gmac_final(wp_GmacCtx* macCtx, unsigned char* out, size_t* outl,
 {
     int ok = 1;
     int rc;
+
+    WOLFPROV_ENTER(WP_LOG_MAC, "wp_gmac_final");
 
     if (!wolfssl_prov_is_running()) {
         ok = 0;
@@ -303,6 +311,8 @@ static int wp_gmac_get_params(OSSL_PARAM params[])
 {
     int ok = 1;
     OSSL_PARAM *p;
+
+    WOLFPROV_ENTER(WP_LOG_MAC, "wp_gmac_get_params");
 
     p = OSSL_PARAM_locate(params, OSSL_MAC_PARAM_SIZE);
     if ((p != NULL) && (!OSSL_PARAM_set_size_t(p, AES_BLOCK_SIZE))) {
@@ -374,6 +384,8 @@ static int wp_gmac_setup_cipher(wp_GmacCtx* macCtx, const OSSL_PARAM params[])
     int ok = 1;
     const OSSL_PARAM *p;
 
+    WOLFPROV_ENTER(WP_LOG_MAC, "wp_gmac_setup_cipher");
+
     p = OSSL_PARAM_locate_const(params, OSSL_ALG_PARAM_CIPHER);
     if (p != NULL) {
         if (p->data_type != OSSL_PARAM_UTF8_STRING) {
@@ -413,6 +425,8 @@ static int wp_gmac_set_param_key(wp_GmacCtx* macCtx, const OSSL_PARAM params[])
     unsigned char* data = NULL;
     size_t len;
 
+    WOLFPROV_ENTER(WP_LOG_MAC, "wp_gmac_set_param_key");
+
     if (!wp_params_get_octet_string_ptr(params, OSSL_MAC_PARAM_KEY, &data,
             &len)) {
         ok = 0;
@@ -438,6 +452,8 @@ static int wp_gmac_set_param_iv(wp_GmacCtx* macCtx, const OSSL_PARAM params[])
     int ok = 1;
     unsigned char* data = NULL;
     size_t len;
+
+    WOLFPROV_ENTER(WP_LOG_MAC, "wp_gmac_set_param_iv");
 
     if (!wp_params_get_octet_string_ptr(params, OSSL_MAC_PARAM_IV, &data,
              &len)) {
@@ -468,6 +484,8 @@ static int wp_gmac_set_param_iv(wp_GmacCtx* macCtx, const OSSL_PARAM params[])
 static int wp_gmac_set_ctx_params(wp_GmacCtx* macCtx, const OSSL_PARAM params[])
 {
     int ok = 1;
+
+    WOLFPROV_ENTER(WP_LOG_MAC, "wp_gmac_set_ctx_params");
 
     if (params != NULL) {
 

--- a/src/wp_hkdf.c
+++ b/src/wp_hkdf.c
@@ -175,6 +175,11 @@ static int wp_kdf_hkdf_derive(wp_HkdfCtx* ctx, unsigned char* key,
 {
     int ok = 1;
 
+    WOLFPROV_ENTER(WP_LOG_HKDF, "wp_kdf_hkdf_derive");
+    WOLFPROV_MSG_DEBUG(WP_LOG_HKDF, "HKDF derive: keyLen=%zu, mode=%d", keyLen, ctx->mode);
+    WOLFPROV_MSG_DEBUG(WP_LOG_HKDF, "HKDF derive: keySz=%zu, saltSz=%zu, infoSz=%zu", 
+                       ctx->keySz, ctx->saltSz, ctx->infoSz);
+
     if (!wolfssl_prov_is_running()) {
         ok = 0;
     }
@@ -231,7 +236,7 @@ static int wp_kdf_hkdf_derive(wp_HkdfCtx* ctx, unsigned char* key,
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_KDF, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_HKDF, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -247,6 +252,8 @@ static int wp_hkdf_base_get_mode(const OSSL_PARAM params[], int* mode)
 {
     int ok = 1;
     const OSSL_PARAM* p;
+
+    WOLFPROV_ENTER(WP_LOG_HKDF, "wp_hkdf_base_get_mode");
 
     p = OSSL_PARAM_locate_const(params, OSSL_KDF_PARAM_MODE);
     if (p != NULL) {
@@ -279,7 +286,7 @@ static int wp_hkdf_base_get_mode(const OSSL_PARAM params[], int* mode)
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_KDF, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_HKDF, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -296,6 +303,8 @@ static int wp_hkdf_base_set_ctx_params(wp_HkdfCtx* ctx,
 {
     int ok = 1;
     OSSL_PARAM *p;
+
+    WOLFPROV_ENTER(WP_LOG_HKDF, "wp_hkdf_base_set_ctx_params");
 
     if (params != NULL) {
         if (!wp_params_get_digest(params, NULL, ctx->provCtx->libCtx,
@@ -329,7 +338,7 @@ static int wp_hkdf_base_set_ctx_params(wp_HkdfCtx* ctx,
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_KDF, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_HKDF, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -346,6 +355,8 @@ static int wp_kdf_hkdf_get_ctx_params(wp_HkdfCtx* ctx, OSSL_PARAM params[])
     int ok = 1;
     OSSL_PARAM* p;
 
+    WOLFPROV_ENTER(WP_LOG_HKDF, "wp_kdf_hkdf_get_ctx_params");
+
     p = OSSL_PARAM_locate(params, OSSL_KDF_PARAM_SIZE);
     if (p != NULL) {
         size_t sz;
@@ -361,7 +372,7 @@ static int wp_kdf_hkdf_get_ctx_params(wp_HkdfCtx* ctx, OSSL_PARAM params[])
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_KDF, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_HKDF, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -378,6 +389,8 @@ static int wp_hkdf_base_set_info(wp_HkdfCtx* ctx, const OSSL_PARAM params[])
     int ok = 1;
     const OSSL_PARAM* p;
     unsigned char* q = ctx->info;
+
+    WOLFPROV_ENTER(WP_LOG_HKDF, "wp_hkdf_base_set_info");
 
     ctx->infoSz = 0;
     /* Combine all the data in the info parameters. */
@@ -397,7 +410,7 @@ static int wp_hkdf_base_set_info(wp_HkdfCtx* ctx, const OSSL_PARAM params[])
         params = p + 1;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_KDF, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_HKDF, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -414,6 +427,8 @@ static int wp_kdf_hkdf_set_ctx_params(wp_HkdfCtx* ctx,
 {
     int ok = 1;
 
+    WOLFPROV_ENTER(WP_LOG_HKDF, "wp_kdf_hkdf_set_ctx_params");
+
     if (params != NULL) {
         if (!wp_hkdf_base_set_ctx_params(ctx, params)) {
             ok = 0;
@@ -422,7 +437,7 @@ static int wp_kdf_hkdf_set_ctx_params(wp_HkdfCtx* ctx,
             ok = 0;
         }
     }
-    WOLFPROV_LEAVE(WP_LOG_KDF, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_HKDF, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -520,6 +535,14 @@ static int wp_tls13_hkdf_expand(wp_HkdfCtx* ctx, unsigned char* inKey,
     size_t idx = 0;
     int rc;
 
+    WOLFPROV_ENTER(WP_LOG_HKDF, "wp_tls13_hkdf_expand");
+    WOLFPROV_MSG_DEBUG(WP_LOG_HKDF,
+        "TLS1.3 HKDF expand: inKeyLen=%zu, dataLen=%zu, keyLen=%zu",
+        inKeyLen, dataLen, keyLen);
+    WOLFPROV_MSG_DEBUG(WP_LOG_HKDF,
+        "TLS1.3 HKDF expand: prefixLen=%zu, labelLen=%zu",
+        ctx->prefixLen, ctx->labelLen);
+
     /* Construct info to expand from:
      *  - output key length
      *  - label
@@ -548,7 +571,7 @@ static int wp_tls13_hkdf_expand(wp_HkdfCtx* ctx, unsigned char* inKey,
         ok = 0;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_KDF, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_HKDF, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -566,12 +589,18 @@ static int wp_tls13_hkdf_extract(wp_HkdfCtx* ctx, unsigned char* key,
 {
     int ok = 1;
     int rc;
+
     unsigned char secret[WC_MAX_DIGEST_SIZE];
     unsigned char zeros[WC_MAX_DIGEST_SIZE];
     unsigned char* inKey;
     size_t inKeyLen;
     unsigned char* salt;
     size_t saltLen;
+
+    WOLFPROV_ENTER(WP_LOG_HKDF, "wp_tls13_hkdf_extract");
+    WOLFPROV_MSG_DEBUG(WP_LOG_HKDF, "TLS1.3 HKDF extract: keyLen=%zu", keyLen);
+    WOLFPROV_MSG_DEBUG(WP_LOG_HKDF, "TLS1.3 HKDF extract: keySz=%zu, saltSz=%zu", 
+                       ctx->keySz, ctx->saltSz);
 
     if (ctx->key == NULL) {
         inKey = zeros;
@@ -617,7 +646,7 @@ static int wp_tls13_hkdf_extract(wp_HkdfCtx* ctx, unsigned char* key,
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_KDF, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_HKDF, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -635,6 +664,10 @@ static int wp_kdf_tls1_3_derive(wp_HkdfCtx* ctx, unsigned char* key,
     size_t keyLen, const OSSL_PARAM params[])
 {
     int ok = 1;
+
+    WOLFPROV_ENTER(WP_LOG_HKDF, "wp_kdf_tls1_3_derive");
+    WOLFPROV_MSG_DEBUG(WP_LOG_HKDF, "TLS1.3 KDF derive: keyLen=%zu, mode=%d",
+        keyLen, ctx->mode);
 
     if (!wolfssl_prov_is_running()) {
         ok = 0;
@@ -657,7 +690,7 @@ static int wp_kdf_tls1_3_derive(wp_HkdfCtx* ctx, unsigned char* key,
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_KDF, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_HKDF, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -673,6 +706,9 @@ static int wp_kdf_tls1_3_set_ctx_params(wp_HkdfCtx* ctx,
     const OSSL_PARAM params[])
 {
     int ok = 1;
+
+    WOLFPROV_ENTER(WP_LOG_HKDF, "wp_kdf_tls1_3_set_ctx_params");
+    WOLFPROV_MSG_DEBUG(WP_LOG_HKDF, "TLS1.3 KDF set params: mode=%d", ctx->mode);
 
     if (params != NULL) {
         if (!wp_hkdf_base_set_ctx_params(ctx, params)) {
@@ -695,7 +731,7 @@ static int wp_kdf_tls1_3_set_ctx_params(wp_HkdfCtx* ctx,
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_KDF, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_HKDF, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 

--- a/src/wp_hmac.c
+++ b/src/wp_hmac.c
@@ -123,6 +123,8 @@ static int wp_hmac_set_key(wp_HmacCtx* macCtx, const unsigned char* key,
     int ok = 1;
     word32 blockSize = wc_HashGetBlockSize(macCtx->type);
 
+    WOLFPROV_ENTER(WP_LOG_MAC, "wp_hmac_set_key");
+
     if (macCtx->keyLen > 0) {
         OPENSSL_secure_clear_free(macCtx->key, macCtx->keyLen);
     }
@@ -210,6 +212,8 @@ static int wp_hmac_init(wp_HmacCtx* macCtx, const unsigned char* key,
 {
     int ok = 1;
 
+    WOLFPROV_ENTER(WP_LOG_MAC, "wp_hmac_init");
+
     if (!wolfssl_prov_is_running()) {
         ok = 0;
     }
@@ -242,6 +246,8 @@ static int wp_hmac_update(wp_HmacCtx* macCtx, const unsigned char* data,
     int ok = 1;
     int rc;
 
+    WOLFPROV_ENTER(WP_LOG_MAC, "wp_hmac_update");
+
     rc = wc_HmacUpdate(&macCtx->hmac, data, (word32)dataLen);
     if (rc != 0) {
         ok = 0;
@@ -266,6 +272,8 @@ static int wp_hmac_final(wp_HmacCtx* macCtx, unsigned char* out, size_t* outl,
 {
     int ok = 1;
     int rc;
+
+    WOLFPROV_ENTER(WP_LOG_MAC, "wp_hmac_final");
 
     if (!wolfssl_prov_is_running()) {
         ok = 0;
@@ -324,6 +332,8 @@ static int wp_hmac_get_ctx_params(wp_HmacCtx* macCtx, OSSL_PARAM params[])
     int ok = 1;
     OSSL_PARAM* p;
 
+    WOLFPROV_ENTER(WP_LOG_MAC, "wp_hmac_get_ctx_params");
+
     p = OSSL_PARAM_locate(params, OSSL_MAC_PARAM_SIZE);
     if ((p != NULL) && (!OSSL_PARAM_set_size_t(p, macCtx->size))) {
         ok = 0;
@@ -375,6 +385,8 @@ static const OSSL_PARAM* wp_hmac_settable_ctx_params(wp_HmacCtx* macCtx,
 static int wp_hmac_set_ctx_params(wp_HmacCtx* macCtx, const OSSL_PARAM params[])
 {
     int ok = 1;
+
+    WOLFPROV_ENTER(WP_LOG_MAC, "wp_hmac_set_ctx_params");
 
     if (params != NULL) {
 

--- a/src/wp_internal.c
+++ b/src/wp_internal.c
@@ -54,6 +54,8 @@ int wp_provctx_lock_rng(WOLFPROV_CTX* provCtx)
     int ok = 1;
     int rc;
 
+    WOLFPROV_ENTER(WP_LOG_PROVIDER, "wp_provctx_lock_rng");
+
     rc = wc_LockMutex(&provCtx->rng_mutex);
     if (rc != 0) {
         ok = 0;
@@ -90,6 +92,8 @@ int wp_lock(wolfSSL_Mutex *mutex)
     int ok = 1;
     int rc;
 
+    WOLFPROV_ENTER(WP_LOG_KE, "wp_lock");
+
     if (mutex == NULL) {
         ok = 0;
     }
@@ -100,11 +104,11 @@ int wp_lock(wolfSSL_Mutex *mutex)
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_PROVIDER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 #else
     (void)mutex;
-    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), 1);
+    WOLFPROV_LEAVE(WP_LOG_PROVIDER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), 1);
     return 1;
 #endif
 }
@@ -125,6 +129,8 @@ int wp_unlock(wolfSSL_Mutex* mutex)
     int ok = 1;
     int rc;
 
+    WOLFPROV_ENTER(WP_LOG_KE, "wp_unlock");
+
     if (mutex == NULL) {
         ok = 0;
     }
@@ -135,11 +141,11 @@ int wp_unlock(wolfSSL_Mutex* mutex)
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_PROVIDER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 #else
     (void)mutex;
-    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), 1);
+    WOLFPROV_LEAVE(WP_LOG_PROVIDER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), 1);
     return 1;
 #endif
 }
@@ -327,6 +333,8 @@ int wp_hash_copy(wc_HashAlg* src, wc_HashAlg* dst, enum wc_HashType hashType)
 {
     int ok = 1;
     int rc = 0;
+
+    WOLFPROV_ENTER(WP_LOG_PROVIDER, "wp_hash_copy");
 
 #if LIBWOLFSSL_VERSION_HEX >= 0x05007004
     switch (src->type)
@@ -544,6 +552,8 @@ int wp_cipher_from_params(const OSSL_PARAM params[], int* cipher,
     int ok = 1;
     const OSSL_PARAM* p;
 
+    WOLFPROV_ENTER(WP_LOG_PROVIDER, "wp_cipher_from_params");
+
     p = OSSL_PARAM_locate_const(params, OSSL_ALG_PARAM_CIPHER);
     if (p != NULL) {
         if (p->data_type != OSSL_PARAM_UTF8_STRING) {
@@ -734,6 +744,8 @@ int wp_encrypt_key(WOLFPROV_CTX* provCtx, const char* cipherName,
     char password[1024];
     size_t passwordSz = sizeof(password);
 
+    WOLFPROV_ENTER(WP_LOG_PROVIDER, "wp_encrypt_key");
+
     /* Get password. */
     if (!pwCb(password, passwordSz, &passwordSz, NULL, pwCbArg)) {
         ok = 0;
@@ -838,6 +850,8 @@ int wp_read_der_bio(WOLFPROV_CTX *provctx, OSSL_CORE_BIO *coreBio, unsigned char
     unsigned char buf[128]; /* Read 128 bytes at a time. */
     unsigned char* p;
 
+    WOLFPROV_ENTER(WP_LOG_PROVIDER, "wp_read_der_bio");
+
     BIO *bio = wp_corebio_get_bio(provctx, coreBio);
     if (bio == NULL) {
         ok = 0;
@@ -886,6 +900,8 @@ int wp_read_pem_bio(WOLFPROV_CTX *provctx, OSSL_CORE_BIO *coreBio,
     long readLen = 1;
     char buf[128];
     unsigned char* p;
+
+    WOLFPROV_ENTER(WP_LOG_PROVIDER, "wp_read_pem_bio");
 
     BIO *bio = wp_corebio_get_bio(provctx, coreBio);
     if (bio == NULL) {

--- a/src/wp_kbkdf.c
+++ b/src/wp_kbkdf.c
@@ -167,6 +167,8 @@ static int wp_kdf_kbkdf_set_ctx_params(wp_KbkdfCtx* ctx,
     int ok = 1;
     OSSL_PARAM* p;
 
+    WOLFPROV_ENTER(WP_LOG_KDF, "wp_kdf_kbkdf_set_ctx_params");
+
     if (params != NULL) {
         if (ok) {
             p = OSSL_PARAM_locate((OSSL_PARAM*)params, OSSL_KDF_PARAM_MODE);
@@ -282,6 +284,7 @@ static int wp_kdf_kbkdf_set_ctx_params(wp_KbkdfCtx* ctx,
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KDF, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -298,6 +301,8 @@ static int wp_kdf_kbkdf_get_ctx_params(wp_KbkdfCtx* ctx, OSSL_PARAM params[])
     int ok = 1;
     OSSL_PARAM* p;
 
+    WOLFPROV_ENTER(WP_LOG_KDF, "wp_kdf_kbkdf_get_ctx_params");
+
     (void)ctx;
 
     p = OSSL_PARAM_locate(params, OSSL_KDF_PARAM_SIZE);
@@ -307,6 +312,7 @@ static int wp_kdf_kbkdf_get_ctx_params(wp_KbkdfCtx* ctx, OSSL_PARAM params[])
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KDF, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -375,6 +381,8 @@ static int wp_kbkdf_init_hmac(wp_KbkdfCtx* ctx, unsigned char* key,
     word32 localKeyLen = 0;
     word32 blockSize = wc_HashGetBlockSize(ctx->hashType);
 
+    WOLFPROV_ENTER(WP_LOG_KDF, "wp_kbkdf_init_hmac");
+
     if (keyLen < blockSize) {
         /* wolfSSL FIPS needs a key that is at least block size in length with
          * the unused parts zeroed out.
@@ -395,6 +403,7 @@ static int wp_kbkdf_init_hmac(wp_KbkdfCtx* ctx, unsigned char* key,
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KDF, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     /* Use rc style return */
     return (ok == 1) ? 0 : -1;
 }
@@ -405,6 +414,8 @@ static int wp_kbkdf_init_mac(wp_KbkdfCtx* ctx, unsigned char* key,
 {
     int ok = 1;
     int rc = 0;
+
+    WOLFPROV_ENTER(WP_LOG_KDF, "wp_kbkdf_init_mac");
 
     switch(ctx->mac) {
 #ifdef WP_HAVE_HMAC
@@ -432,6 +443,7 @@ static int wp_kbkdf_init_mac(wp_KbkdfCtx* ctx, unsigned char* key,
         ok = 0;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KDF, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -460,6 +472,8 @@ static int wp_kbkdf_mac_update(wp_KbkdfCtx* ctx, const unsigned char *data,
     int ok = 1;
     int rc = 0;
 
+    WOLFPROV_ENTER(WP_LOG_KDF, "wp_kbkdf_mac_update");
+
     switch(ctx->mac) {
 #ifdef WP_HAVE_HMAC
         case WP_MAC_TYPE_HMAC:
@@ -479,6 +493,7 @@ static int wp_kbkdf_mac_update(wp_KbkdfCtx* ctx, const unsigned char *data,
         ok = 0;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KDF, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -510,6 +525,8 @@ static int wp_kbkdf_mac_final(wp_KbkdfCtx* ctx, unsigned char *out,
     int rc = 0;
     word32 outSz;
 
+    WOLFPROV_ENTER(WP_LOG_KDF, "wp_kbkdf_mac_final");
+
     (void)outSz;
 
     switch(ctx->mac) {
@@ -540,6 +557,7 @@ static int wp_kbkdf_mac_final(wp_KbkdfCtx* ctx, unsigned char *out,
             ok = 0;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KDF, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -566,6 +584,8 @@ static int wp_kdf_kbkdf_derive(wp_KbkdfCtx* ctx, unsigned char* key,
     size_t written = 0;
     unsigned char k_i[WP_MAX_MAC_SIZE];
     unsigned char zero = 0;
+
+    WOLFPROV_ENTER(WP_LOG_KDF, "wp_kdf_kbkdf_derive");
 
     if (!wolfssl_prov_is_running()) {
         ok = 0;
@@ -656,6 +676,7 @@ static int wp_kdf_kbkdf_derive(wp_KbkdfCtx* ctx, unsigned char* key,
         wp_kbkdf_mac_free(ctx);
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KDF, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 

--- a/src/wp_kdf_exch.c
+++ b/src/wp_kdf_exch.c
@@ -153,6 +153,8 @@ static int wp_kdf_init(wp_KdfCtx* ctx, wp_Kdf* kdf, const OSSL_PARAM params[])
 {
     int ok = 1;
 
+    WOLFPROV_ENTER(WP_LOG_KDF, "wp_kdf_init");
+
     if (!wolfssl_prov_is_running()) {
         ok = 0;
     }
@@ -188,6 +190,8 @@ static int wp_kdf_derive(wp_KdfCtx* ctx, unsigned char* secret, size_t* secLen,
     size_t secSize)
 {
     int ok = 1;
+
+    WOLFPROV_ENTER(WP_LOG_KDF, "wp_kdf_derive");
 
     if (!wolfssl_prov_is_running()) {
         ok = 0;

--- a/src/wp_kdf_kmgmt.c
+++ b/src/wp_kdf_kmgmt.c
@@ -58,6 +58,8 @@ int wp_kdf_up_ref(wp_Kdf* kdf)
     int ok = 1;
     int rc;
 
+    WOLFPROV_ENTER(WP_LOG_KDF, "wp_kdf_up_ref");
+
     rc = wc_LockMutex(&kdf->mutex);
     if (rc < 0) {
         ok = 0;
@@ -150,6 +152,8 @@ void wp_kdf_free(wp_Kdf* kdf)
  */
 static int wp_kdf_has(const wp_Kdf* kdf, int selection)
 {
+    WOLFPROV_ENTER(WP_LOG_KDF, "wp_kdf_has");
+    
     (void)kdf;
     (void)selection;
     WOLFPROV_LEAVE(WP_LOG_KDF, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), 1);

--- a/src/wp_krb5kdf.c
+++ b/src/wp_krb5kdf.c
@@ -143,6 +143,8 @@ static int wp_kdf_krb5kdf_set_ctx_params(wp_Krb5kdfCtx* ctx,
     int ok = 1;
     OSSL_PARAM* p;
 
+    WOLFPROV_ENTER(WP_LOG_KRB5KDF, "wp_kdf_krb5kdf_set_ctx_params");
+
     if (params != NULL) {
         if (ok) {
             p = OSSL_PARAM_locate((OSSL_PARAM*)params, OSSL_KDF_PARAM_CIPHER);
@@ -194,6 +196,7 @@ static int wp_kdf_krb5kdf_set_ctx_params(wp_Krb5kdfCtx* ctx,
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KRB5KDF, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -211,6 +214,8 @@ static int wp_kdf_krb5kdf_get_ctx_params(wp_Krb5kdfCtx* ctx,
     int ok = 1;
     OSSL_PARAM* p;
 
+    WOLFPROV_ENTER(WP_LOG_KRB5KDF, "wp_kdf_krb5kdf_get_ctx_params");
+
     (void)ctx;
 
     p = OSSL_PARAM_locate(params, OSSL_KDF_PARAM_SIZE);
@@ -220,6 +225,7 @@ static int wp_kdf_krb5kdf_get_ctx_params(wp_Krb5kdfCtx* ctx,
         }
     }
 
+    WOLFPROV_LEAVE(WP_LOG_KRB5KDF, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -446,6 +452,8 @@ static int wp_kdf_krb5kdf_derive(wp_Krb5kdfCtx* ctx, unsigned char* key,
     byte *plain = NULL;
     byte *cipher = NULL;
 
+    WOLFPROV_ENTER(WP_LOG_KRB5KDF, "wp_kdf_krb5kdf_derive");
+
     if (!wolfssl_prov_is_running()) {
         ok = 0;
     }
@@ -507,6 +515,7 @@ static int wp_kdf_krb5kdf_derive(wp_Krb5kdfCtx* ctx, unsigned char* key,
 
     wc_AesFree(&aes);
 
+    WOLFPROV_LEAVE(WP_LOG_KRB5KDF, "wp_kdf_krb5kdf_derive", ok);
     return ok;
 }
 

--- a/src/wp_logging.c
+++ b/src/wp_logging.c
@@ -150,6 +150,10 @@ int wolfProv_SetLogComponents(int componentMask)
 static void wolfprovider_log(const int logLevel, const int component,
                            const char *const logMessage)
 {
+    /* Check compile-time configuration first */
+    if (!WOLFPROV_COMPILE_TIME_CHECK(component, logLevel))
+        return;
+
     /* Don't log messages that do not match our current logging level */
     if ((providerLogLevel & logLevel) != logLevel)
         return;
@@ -222,6 +226,38 @@ void WOLFPROV_MSG_VERBOSE(int component, const char* fmt, ...)
     va_list vlist;
     va_start(vlist, fmt);
     wolfprovider_msg_internal(component, WP_LOG_VERBOSE, fmt, vlist);
+    va_end(vlist);
+}
+
+/**
+ * Log function for debug messages, prints to WP_LOG_DEBUG level.
+ *
+ * @param component [IN] Component type, from wolfProv_LogComponents enum.
+ * @param fmt   [IN] Log message format string.
+ * @param vargs [IN] Variable arguments, used with format string, fmt.
+ */
+WP_PRINTF_FUNC(2, 3)
+void WOLFPROV_MSG_DEBUG(int component, const char* fmt, ...)
+{
+    va_list vlist;
+    va_start(vlist, fmt);
+    wolfprovider_msg_internal(component, WP_LOG_DEBUG, fmt, vlist);
+    va_end(vlist);
+}
+
+/**
+ * Log function for trace messages, prints to WP_LOG_TRACE level.
+ *
+ * @param component [IN] Component type, from wolfProv_LogComponents enum.
+ * @param fmt   [IN] Log message format string.
+ * @param vargs [IN] Variable arguments, used with format string, fmt.
+ */
+WP_PRINTF_FUNC(2, 3)
+void WOLFPROV_MSG_TRACE(int component, const char* fmt, ...)
+{
+    va_list vlist;
+    va_start(vlist, fmt);
+    wolfprovider_msg_internal(component, WP_LOG_TRACE, fmt, vlist);
     va_end(vlist);
 }
 

--- a/src/wp_logging.c
+++ b/src/wp_logging.c
@@ -151,16 +151,19 @@ static void wolfprovider_log(const int logLevel, const int component,
                            const char *const logMessage)
 {
     /* Check compile-time configuration first */
-    if (!WOLFPROV_COMPILE_TIME_CHECK(component, logLevel))
+    if (!WOLFPROV_COMPILE_TIME_CHECK(component, logLevel)) {
         return;
+    }
 
     /* Don't log messages that do not match our current logging level */
-    if ((providerLogLevel & logLevel) != logLevel)
+    if ((providerLogLevel & logLevel) != logLevel) {
         return;
+    }
 
     /* Don't log messages from components that do not match enabled list */
-    if ((providerLogComponents & component) != component)
+    if ((providerLogComponents & component) != component) {
         return;
+    }
 
     if (log_function) {
         log_function(logLevel, component, logMessage);

--- a/src/wp_mac_kmgmt.c
+++ b/src/wp_mac_kmgmt.c
@@ -95,6 +95,8 @@ int wp_mac_up_ref(wp_Mac* mac)
     int ok = 1;
     int rc;
 
+    WOLFPROV_ENTER(WP_LOG_MAC, "wp_mac_up_ref");
+
     rc = wc_LockMutex(&mac->mutex);
     if (rc < 0) {
         ok = 0;
@@ -136,6 +138,8 @@ int wp_mac_get_type(wp_Mac* mac)
 int wp_mac_get_private_key(wp_Mac* mac, unsigned char** priv, size_t* privLen)
 {
     int ok = 0;
+
+    WOLFPROV_ENTER(WP_LOG_MAC, "wp_mac_get_private_key");
 
     if (mac != NULL) {
         *priv = mac->key;
@@ -304,6 +308,8 @@ static int wp_mac_has(const wp_Mac* mac, int selection)
 {
     int ok = 1;
 
+    WOLFPROV_ENTER(WP_LOG_MAC, "wp_mac_has");
+
     if (!wolfssl_prov_is_running()) {
        ok = 0;
     }
@@ -330,6 +336,8 @@ static int wp_mac_has(const wp_Mac* mac, int selection)
 static int wp_mac_match(const wp_Mac* mac1, const wp_Mac* mac2, int selection)
 {
    int ok = 1;
+
+    WOLFPROV_ENTER(WP_LOG_MAC, "wp_mac_match");
 
     if (!wolfssl_prov_is_running()) {
         ok = 0;
@@ -358,6 +366,8 @@ static int wp_mac_import(wp_Mac *mac, int selection, const OSSL_PARAM params[])
 {
     int ok = 1;
     const OSSL_PARAM* p;
+
+    WOLFPROV_ENTER(WP_LOG_MAC, "wp_mac_import");
 
     if ((!wolfssl_prov_is_running()) || (mac == NULL)) {
         ok = 0;
@@ -423,6 +433,8 @@ static int wp_mac_export_priv_key(wp_Mac* mac, OSSL_PARAM* params, int* pIdx,
 {
     int i = *pIdx;
 
+    WOLFPROV_ENTER(WP_LOG_MAC, "wp_mac_export_priv_key");
+
     if (mac->keyLen != MAX_SIZE_T) {
         XMEMCPY(data + *idx, mac->key, mac->keyLen);
         wp_param_set_octet_string_ptr(&params[i++], OSSL_PKEY_PARAM_PRIV_KEY,
@@ -462,6 +474,8 @@ static int wp_mac_export(wp_Mac *mac, int selection, OSSL_CALLBACK *paramCb,
     int paramsSz = 0;
     unsigned char* data = NULL;
     size_t len = 0;
+
+    WOLFPROV_ENTER(WP_LOG_MAC, "wp_mac_export");
 
     if (!wolfssl_prov_is_running()) {
         ok = 0;
@@ -539,6 +553,8 @@ static wp_MacGenCtx* wp_mac_gen_init(WOLFPROV_CTX* provCtx,
 static int wp_mac_gen_set_params(wp_MacGenCtx* ctx, const OSSL_PARAM params[])
 {
     int ok = 1;
+
+    WOLFPROV_ENTER(WP_LOG_MAC, "wp_mac_gen_set_params");
 
     if (!wp_params_get_octet_string(params, OSSL_PKEY_PARAM_PRIV_KEY,
             &ctx->key, &ctx->keyLen, 1)) {
@@ -628,6 +644,8 @@ static int wp_mac_get_params(wp_Mac* mac, OSSL_PARAM params[])
 {
     int ok = 1;
     OSSL_PARAM* p;
+
+    WOLFPROV_ENTER(WP_LOG_MAC, "wp_mac_get_params");
 
     if (mac->keyLen != MAX_SIZE_T) {
         p = OSSL_PARAM_locate(params, OSSL_PKEY_PARAM_PRIV_KEY);

--- a/src/wp_mac_sig.c
+++ b/src/wp_mac_sig.c
@@ -193,6 +193,8 @@ static int wp_mac_digest_sign_init(wp_MacSigCtx *ctx, const char *mdName,
     OSSL_PARAM lParams[4];
     int lParamSz = 0;
 
+    WOLFPROV_ENTER(WP_LOG_MAC, "wp_mac_digest_sign_init");
+
     if (!wolfssl_prov_is_running()) {
         ok = 0;
     }
@@ -263,6 +265,8 @@ static int wp_mac_digest_sign_update(wp_MacSigCtx *ctx,
 {
     int ok = 1;
 
+    WOLFPROV_ENTER(WP_LOG_MAC, "wp_mac_digest_sign_update");
+
     if (!EVP_MAC_update(ctx->macCtx, data, dataLen)) {
         ok = 0;
     }
@@ -288,6 +292,8 @@ static int wp_mac_digest_sign_final(wp_MacSigCtx *ctx, unsigned char *sig,
     size_t *sigLen, size_t sigSize)
 {
     int ok = 1;
+
+    WOLFPROV_ENTER(WP_LOG_MAC, "wp_mac_digest_sign_final");
 
     if (!wolfssl_prov_is_running()) {
         ok = 0;

--- a/src/wp_params.c
+++ b/src/wp_params.c
@@ -43,6 +43,8 @@ int wp_mp_read_unsigned_bin_le(mp_int* mp, const unsigned char* data,
     size_t i;
     int rc;
 
+    WOLFPROV_ENTER(WP_LOG_PROVIDER, "wp_mp_read_unsigned_bin_le");
+
     /* Make big-endian. */
     for (i = 0; i < len; i++) {
         rdata[i] = data[len - 1 - i];
@@ -72,6 +74,8 @@ int wp_mp_to_unsigned_bin_le(mp_int* mp, unsigned char* data, size_t len)
     int ok = 1;
     int rc;
     size_t i;
+
+    WOLFPROV_ENTER(WP_LOG_PROVIDER, "wp_mp_to_unsigned_bin_le");
 
     rc = mp_to_unsigned_bin(mp, data);
     if (rc != 0) {
@@ -156,6 +160,8 @@ int wp_param_set_mp(OSSL_PARAM* p, const char* key, mp_int* mp,
 {
     int ok = 1;
 
+    WOLFPROV_ENTER(WP_LOG_PROVIDER, "wp_param_set_mp");
+
     p->key = key;
     p->data_type = OSSL_PARAM_UNSIGNED_INTEGER;
     p->return_size = p->data_size = mp_unsigned_bin_size(mp);
@@ -217,6 +223,8 @@ int wp_params_get_digest(const OSSL_PARAM* params, char* name,
     int ok = 1;
     const char* mdName = NULL;
 
+    WOLFPROV_ENTER(WP_LOG_PROVIDER, "wp_params_get_digest");
+
     if (!wp_params_get_utf8_string_ptr(params, OSSL_ALG_PARAM_DIGEST,
             &mdName)) {
         ok = 0;
@@ -264,6 +272,8 @@ int wp_params_get_mp(const OSSL_PARAM* params, const char* key, mp_int* mp,
     int ok = 1;
     const OSSL_PARAM* p;
 
+    WOLFPROV_ENTER(WP_LOG_PROVIDER, "wp_params_get_mp");
+
     if (set != NULL) {
         *set = 0;
     }
@@ -306,6 +316,8 @@ int wp_params_get_octet_string(const OSSL_PARAM* params, const char* key,
     int ok = 1;
     const OSSL_PARAM* p;
 
+    WOLFPROV_ENTER(WP_LOG_PROVIDER, "wp_params_get_octet_string");
+
     p = OSSL_PARAM_locate_const(params, key);
     if (p != NULL) {
         if (secure) {
@@ -342,6 +354,8 @@ int wp_params_get_bn_be(const OSSL_PARAM* params, const char* key,
 {
     int ok = 1;
     const OSSL_PARAM* p;
+
+    WOLFPROV_ENTER(WP_LOG_PROVIDER, "wp_params_get_bn_be");
 
     p = OSSL_PARAM_locate_const(params, key);
     if ((p != NULL) && (p->data_type != OSSL_PARAM_UNSIGNED_INTEGER)) {
@@ -396,6 +410,8 @@ int wp_params_get_octet_string_ptr(const OSSL_PARAM* params, const char* key,
     int ok = 1;
     const OSSL_PARAM* p;
 
+    WOLFPROV_ENTER(WP_LOG_PROVIDER, "wp_params_get_octet_string_ptr");
+
     p = OSSL_PARAM_locate_const(params, key);
     if ((p != NULL) && (p->data_type != OSSL_PARAM_OCTET_STRING)) {
         ok = 0;
@@ -426,6 +442,8 @@ int wp_params_get_utf8_string(const OSSL_PARAM* params, const char* key,
 {
     int ok = 1;
     const OSSL_PARAM* p;
+
+    WOLFPROV_ENTER(WP_LOG_PROVIDER, "wp_params_get_utf8_string");
 
     p = OSSL_PARAM_locate_const(params, key);
     if ((p != NULL) && (p->data_type != OSSL_PARAM_UTF8_STRING)) {
@@ -459,6 +477,8 @@ int wp_params_get_utf8_string_ptr(const OSSL_PARAM* params, const char* key,
     int ok = 1;
     const OSSL_PARAM* p;
 
+    WOLFPROV_ENTER(WP_LOG_PROVIDER, "wp_params_get_utf8_string_ptr");
+
     p = OSSL_PARAM_locate_const(params, key);
     if ((p != NULL) && (p->data_type != OSSL_PARAM_UTF8_STRING)) {
         ok = 0;
@@ -487,6 +507,8 @@ int wp_params_get_size_t(const OSSL_PARAM* params, const char* key, size_t* val)
     int ok = 1;
     const OSSL_PARAM* p;
 
+    WOLFPROV_ENTER(WP_LOG_PROVIDER, "wp_params_get_size_t");
+
     p = OSSL_PARAM_locate_const(params, key);
     if ((p != NULL) && (!OSSL_PARAM_get_size_t(p, val))) {
         ok = 0;
@@ -513,6 +535,8 @@ int wp_params_get_uint64(const OSSL_PARAM* params, const char* key,
     int ok = 1;
     const OSSL_PARAM* p;
 
+    WOLFPROV_ENTER(WP_LOG_PROVIDER, "wp_params_get_uint64");
+
     p = OSSL_PARAM_locate_const(params, key);
     if ((p != NULL) && (!OSSL_PARAM_get_uint64(p, val))) {
         ok = 0;
@@ -537,6 +561,8 @@ int wp_params_get_int(const OSSL_PARAM* params, const char* key, int* val)
 {
     int ok = 1;
     const OSSL_PARAM* p;
+
+    WOLFPROV_ENTER(WP_LOG_PROVIDER, "wp_params_get_int");
 
     p = OSSL_PARAM_locate_const(params, key);
     if ((p != NULL) && (!OSSL_PARAM_get_int(p, val))) {
@@ -564,6 +590,8 @@ int wp_params_get_uint(const OSSL_PARAM* params, const char* key,
 {
     int ok = 1;
     const OSSL_PARAM* p;
+
+    WOLFPROV_ENTER(WP_LOG_PROVIDER, "wp_params_get_uint");
 
     if (set != NULL) {
         *set = 0;
@@ -598,6 +626,8 @@ int wp_params_set_mp(OSSL_PARAM params[], const char* key, mp_int* mp,
 {
     int ok = 1;
     OSSL_PARAM* p;
+
+    WOLFPROV_ENTER(WP_LOG_PROVIDER, "wp_params_set_mp");
 
     p = OSSL_PARAM_locate(params, key);
     if ((p != NULL) && (allow != 1)) {
@@ -637,6 +667,8 @@ int wp_params_set_octet_string_be(OSSL_PARAM params[], const char* key,
 {
     int ok = 1;
     OSSL_PARAM* p;
+
+    WOLFPROV_ENTER(WP_LOG_PROVIDER, "wp_params_set_octet_string_be");
 
     p = OSSL_PARAM_locate(params, key);
     if (p != NULL) {

--- a/src/wp_pbkdf2.c
+++ b/src/wp_pbkdf2.c
@@ -147,6 +147,8 @@ static int wp_pbkdf2_base_set_ctx_params(wp_Pbkdf2Ctx* ctx,
 {
     int ok = 1;
 
+    WOLFPROV_ENTER(WP_LOG_PBKDF2, "wp_pbkdf2_base_set_ctx_params");
+
     if (params != NULL) {
         if (!wp_params_get_digest(params, NULL, ctx->provCtx->libCtx,
                 &ctx->mdType, &ctx->mdLen)) {
@@ -168,7 +170,7 @@ static int wp_pbkdf2_base_set_ctx_params(wp_Pbkdf2Ctx* ctx,
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_KDF, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_PBKDF2, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -185,6 +187,8 @@ static int wp_kdf_pbkdf2_get_ctx_params(wp_Pbkdf2Ctx* ctx, OSSL_PARAM params[])
     int ok = 1;
     OSSL_PARAM* p;
 
+    WOLFPROV_ENTER(WP_LOG_PBKDF2, "wp_kdf_pbkdf2_get_ctx_params");
+
     (void)ctx;
 
     p = OSSL_PARAM_locate(params, OSSL_KDF_PARAM_SIZE);
@@ -194,7 +198,7 @@ static int wp_kdf_pbkdf2_get_ctx_params(wp_Pbkdf2Ctx* ctx, OSSL_PARAM params[])
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_KDF, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_PBKDF2, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -244,6 +248,8 @@ static int wp_kdf_pbkdf2_derive(wp_Pbkdf2Ctx* ctx, unsigned char* key,
 {
     int ok = 1;
 
+    WOLFPROV_ENTER(WP_LOG_PBKDF2, "wp_kdf_pbkdf2_derive");
+
     if (!wolfssl_prov_is_running()) {
         ok = 0;
     }
@@ -270,7 +276,7 @@ static int wp_kdf_pbkdf2_derive(wp_Pbkdf2Ctx* ctx, unsigned char* key,
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_KDF, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_PBKDF2, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -287,12 +293,14 @@ static int wp_kdf_pbkdf2_set_ctx_params(wp_Pbkdf2Ctx* ctx,
 {
     int ok;
 
+    WOLFPROV_ENTER(WP_LOG_PBKDF2, "wp_kdf_pbkdf2_set_ctx_params");
+
     ok = wp_pbkdf2_base_set_ctx_params(ctx, params);
     if (ok && !wp_params_get_int(params, OSSL_KDF_PARAM_PKCS5, &ctx->pkcs5)) {
         ok = 0;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_KDF, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_PBKDF2, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -356,6 +364,8 @@ static int wp_kdf_pkcs12_derive(wp_Pbkdf2Ctx* ctx, unsigned char* key,
 {
     int ok = 1;
 
+    WOLFPROV_ENTER(WP_LOG_PBKDF2, "wp_kdf_pkcs12_derive");
+
     if (!wolfssl_prov_is_running()) {
         ok = 0;
     }
@@ -382,7 +392,7 @@ static int wp_kdf_pkcs12_derive(wp_Pbkdf2Ctx* ctx, unsigned char* key,
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_KDF, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_PBKDF2, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -399,13 +409,15 @@ static int wp_kdf_pkcs12_set_ctx_params(wp_Pbkdf2Ctx* ctx,
 {
     int ok;
 
+    WOLFPROV_ENTER(WP_LOG_PBKDF2, "wp_kdf_pkcs12_set_ctx_params");
+
     ok = wp_pbkdf2_base_set_ctx_params(ctx, params);
     if (ok && !wp_params_get_int(params, OSSL_KDF_PARAM_PKCS12_ID,
             &ctx->keyUse)) {
         ok = 0;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_KDF, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_PBKDF2, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 

--- a/src/wp_rsa_asym.c
+++ b/src/wp_rsa_asym.c
@@ -209,6 +209,8 @@ static int wp_rsaa_init(wp_RsaAsymCtx* ctx, wp_Rsa* rsa,
 {
     int ok = 1;
 
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsaa_init");
+
     if (ctx->rsa != rsa) {
         if (wp_rsa_get_type(rsa) != RSA_FLAG_TYPE_RSA) {
             ERR_raise_data(ERR_LIB_PROV,
@@ -234,7 +236,7 @@ static int wp_rsaa_init(wp_RsaAsymCtx* ctx, wp_Rsa* rsa,
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -252,6 +254,8 @@ static int wp_rsaa_encrypt_init(wp_RsaAsymCtx* ctx, wp_Rsa* rsa,
 {
     int ok;
 
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsaa_encrypt_init");
+
     if (!wolfssl_prov_is_running()) {
         ok = 0;
     }
@@ -259,7 +263,7 @@ static int wp_rsaa_encrypt_init(wp_RsaAsymCtx* ctx, wp_Rsa* rsa,
         ok = wp_rsaa_init(ctx, rsa, params, EVP_PKEY_OP_SIGN);
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -283,6 +287,8 @@ static int wp_rsaa_encrypt(wp_RsaAsymCtx* ctx, unsigned char* out,
 {
     int ok = 1;
     word32 sz;
+
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsaa_encrypt");
 
     if (!wolfssl_prov_is_running()) {
         ok = 0;
@@ -340,7 +346,7 @@ static int wp_rsaa_encrypt(wp_RsaAsymCtx* ctx, unsigned char* out,
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -358,6 +364,8 @@ static int wp_rsaa_decrypt_init(wp_RsaAsymCtx* ctx, wp_Rsa* rsa,
 {
     int ok;
 
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsaa_decrypt_init");
+
     if (!wolfssl_prov_is_running()) {
         ok = 0;
     }
@@ -365,7 +373,7 @@ static int wp_rsaa_decrypt_init(wp_RsaAsymCtx* ctx, wp_Rsa* rsa,
         ok = wp_rsaa_init(ctx, rsa, params, EVP_PKEY_OP_DECRYPT);
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -386,6 +394,8 @@ static int wp_rsaa_decrypt(wp_RsaAsymCtx* ctx, unsigned char* out,
 {
     int ok = 1;
     word32 sz;
+
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsaa_decrypt");
 
     if (!wolfssl_prov_is_running()) {
         ok = 0;
@@ -491,7 +501,7 @@ static int wp_rsaa_decrypt(wp_RsaAsymCtx* ctx, unsigned char* out,
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -508,6 +518,8 @@ static int wp_rsaa_setup_md(wp_RsaAsymCtx* ctx, const char* mdName,
     const char* mdProps)
 {
     int ok = 1;
+
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsaa_setup_md");
 
     if (mdName != NULL) {
         ctx->oaepHashType = wp_name_to_wc_hash_type(ctx->libCtx, mdName,
@@ -533,7 +545,7 @@ static int wp_rsaa_setup_md(wp_RsaAsymCtx* ctx, const char* mdName,
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -551,6 +563,8 @@ static int wp_rsaa_setup_mgf1_md(wp_RsaAsymCtx* ctx, const char* mdName,
 {
     int ok = 1;
 
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsaa_setup_mgf1_md");
+
     OPENSSL_strlcpy(ctx->mgf1MdName, mdName, sizeof(ctx->mgf1MdName));
     ctx->mgf = wp_name_to_wc_mgf(ctx->libCtx, mdName, mdProps);
     if (ctx->mgf == WC_MGF1NONE) {
@@ -560,7 +574,7 @@ static int wp_rsaa_setup_mgf1_md(wp_RsaAsymCtx* ctx, const char* mdName,
         ctx->mgfSet = 1;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -575,6 +589,8 @@ static int wp_rsaa_setup_mgf1_md(wp_RsaAsymCtx* ctx, const char* mdName,
 static int wp_rsaa_get_pad_mode(int padMode, OSSL_PARAM* p)
 {
     int ok = 1;
+
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsaa_get_pad_mode");
 
     if (p->data_type == OSSL_PARAM_INTEGER) {
         if (!OSSL_PARAM_set_int(p, padMode)) {
@@ -597,7 +613,7 @@ static int wp_rsaa_get_pad_mode(int padMode, OSSL_PARAM* p)
         ok = 0;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -613,6 +629,8 @@ static int wp_rsaa_get_ctx_params(wp_RsaAsymCtx* ctx, OSSL_PARAM* params)
 {
     int ok = 1;
     OSSL_PARAM* p;
+
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsaa_get_ctx_params");
 
     if (ctx == NULL) {
         ok = 0;
@@ -663,7 +681,7 @@ static int wp_rsaa_get_ctx_params(wp_RsaAsymCtx* ctx, OSSL_PARAM* params)
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -714,6 +732,8 @@ static int wp_rsaa_set_digest(wp_RsaAsymCtx* ctx, const OSSL_PARAM* p,
     char mdProps[WP_MAX_PROPS_SIZE];
     char* pmdProps = NULL;
 
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsaa_set_digest");
+
     if (!OSSL_PARAM_get_utf8_string(p, &pmdName, sizeof(mdName))) {
         ok = 0;
     }
@@ -728,7 +748,7 @@ static int wp_rsaa_set_digest(wp_RsaAsymCtx* ctx, const OSSL_PARAM* p,
         ok = wp_rsaa_setup_md(ctx, mdName, pmdProps);
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -744,6 +764,8 @@ static int wp_rsaa_set_pad_mode(wp_RsaAsymCtx* ctx, const OSSL_PARAM* p)
 {
     int ok = 1;
     int padMode = 0;
+
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsaa_set_pad_mode");
 
     if (p->data_type == OSSL_PARAM_INTEGER) {
         if (!OSSL_PARAM_get_int(p, &padMode)) {
@@ -771,7 +793,7 @@ static int wp_rsaa_set_pad_mode(wp_RsaAsymCtx* ctx, const OSSL_PARAM* p)
         ctx->padMode = padMode;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -793,6 +815,8 @@ static int wp_rsaa_set_mgf1_digest(wp_RsaAsymCtx* ctx, const OSSL_PARAM* p,
     char mgfMdProps[WP_MAX_PROPS_SIZE] = "";
     char* pmgfMdProps = NULL;
 
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsaa_set_mgf1_digest");
+
     if (!OSSL_PARAM_get_utf8_string(p, &pmgfMdName, sizeof(mgfMdName))) {
         ok = 0;
     }
@@ -807,7 +831,7 @@ static int wp_rsaa_set_mgf1_digest(wp_RsaAsymCtx* ctx, const OSSL_PARAM* p,
         ok = wp_rsaa_setup_mgf1_md(ctx, mgfMdName, pmgfMdProps);
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -824,6 +848,8 @@ static int wp_rsaa_set_ctx_params(wp_RsaAsymCtx* ctx, const OSSL_PARAM params[])
     int ok = 1;
     const OSSL_PARAM* p;
     const OSSL_PARAM* propsParam;
+
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsaa_set_ctx_params");
 
     if (params != NULL) {
         p = OSSL_PARAM_locate_const(params, OSSL_ASYM_CIPHER_PARAM_OAEP_DIGEST);
@@ -880,7 +906,7 @@ static int wp_rsaa_set_ctx_params(wp_RsaAsymCtx* ctx, const OSSL_PARAM params[])
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 

--- a/src/wp_rsa_kem.c
+++ b/src/wp_rsa_kem.c
@@ -227,6 +227,8 @@ static int wp_rsasve_gen_rand_bytes(wp_RsaKemCtx* ctx, unsigned char* out)
     mp_int mod;
     RsaKey* key = wp_rsa_get_key(ctx->rsa);
 
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsasve_gen_rand_bytes");
+
     rc = mp_init_multi(&r, &mod, NULL, NULL, NULL, NULL);
     if (rc != 0) {
         ok = 0;
@@ -264,7 +266,7 @@ static int wp_rsasve_gen_rand_bytes(wp_RsaKemCtx* ctx, unsigned char* out)
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -289,6 +291,8 @@ static int wp_rsasve_generate(wp_RsaKemCtx* ctx, unsigned char* out,
     word32 nLen;
     word32 oLen;
     RsaKey* rsa = NULL;
+
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsasve_generate");
 
     if ((out == NULL) && (outLen == NULL) && (secretLen == NULL)) {
         ok = 0;
@@ -337,7 +341,7 @@ static int wp_rsasve_generate(wp_RsaKemCtx* ctx, unsigned char* out,
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -357,6 +361,8 @@ static int wp_rsakem_encapsulate(wp_RsaKemCtx* ctx, unsigned char* out,
 {
     int ok;
 
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsakem_encapsulate");
+
     switch (ctx->op) {
         case WP_RSA_KEM_OP_RSASVE:
             ok = wp_rsasve_generate(ctx, out, outlen, secret, secretlen);
@@ -367,7 +373,7 @@ static int wp_rsakem_encapsulate(wp_RsaKemCtx* ctx, unsigned char* out,
             break;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -391,6 +397,8 @@ static int wp_rsasve_recover(wp_RsaKemCtx* ctx, unsigned char* out,
     int ok = 1;
     word32 nLen;
     RsaKey* rsa = wp_rsa_get_key(ctx->rsa);
+
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsasve_recover");
 
     /* Step 1: get the byte length of n */
     nLen = wc_RsaEncryptSize(rsa);
@@ -427,7 +435,7 @@ static int wp_rsasve_recover(wp_RsaKemCtx* ctx, unsigned char* out,
         *outLen = nLen;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -447,6 +455,8 @@ static int wp_rsakem_decapsulate(wp_RsaKemCtx* ctx, unsigned char* out,
 {
     int ok;
 
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsakem_decapsulate");
+
     switch (ctx->op) {
         case WP_RSA_KEM_OP_RSASVE:
             ok = wp_rsasve_recover(ctx, out, outlen, in, inlen);
@@ -457,7 +467,7 @@ static int wp_rsakem_decapsulate(wp_RsaKemCtx* ctx, unsigned char* out,
             break;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -511,6 +521,8 @@ static int wp_rsakem_set_ctx_params(wp_RsaKemCtx* ctx,
     int ok = 1;
     const char* op = NULL;
 
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsakem_set_ctx_params");
+
     /* Type of RSA KEM operation - only RSASVE supported. */
     if (!wp_params_get_utf8_string_ptr(params, OSSL_KEM_PARAM_OPERATION,
         &op)) {
@@ -526,7 +538,7 @@ static int wp_rsakem_set_ctx_params(wp_RsaKemCtx* ctx,
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 

--- a/src/wp_rsa_kmgmt.c
+++ b/src/wp_rsa_kmgmt.c
@@ -274,6 +274,8 @@ static int wp_rsa_gen_set_params(wp_RsaGenCtx* ctx, const OSSL_PARAM params[]);
  */
 int wp_rsa_up_ref(wp_Rsa* rsa)
 {
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsa_up_ref");
+
 #ifndef WP_SINGLE_THREADED
     int ok = 1;
     int rc;
@@ -287,11 +289,11 @@ int wp_rsa_up_ref(wp_Rsa* rsa)
         wc_UnLockMutex(&rsa->mutex);
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 #else
     rsa->refCnt++;
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), 1);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), 1);
     return 1;
 #endif
 }
@@ -353,8 +355,10 @@ static int wp_rsa_check_key_size_int(int keySize, int allow1024)
 {
     int ok = 1;
 
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsa_check_key_size_int");
+
     if ((keySize < RSA_MIN_SIZE) || (keySize > RSA_MAX_SIZE)) {
-        WOLFPROV_MSG(WP_LOG_PK, "RSA key size invalid: %d\n", keySize);
+        WOLFPROV_MSG(WP_LOG_RSA, "RSA key size invalid: %d\n", keySize);
         ok = 0;
     }
 #ifdef HAVE_FIPS
@@ -368,7 +372,7 @@ static int wp_rsa_check_key_size_int(int keySize, int allow1024)
     (void)allow1024;
 #endif
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -578,6 +582,8 @@ static wp_Rsa* wp_rsa_dup(const wp_Rsa* src, int selection)
  */
 static int wp_rsa_pss_params_set_pss_defaults(wp_RsaPssParams* pss)
 {
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsa_pss_params_set_pss_defaults");
+
     pss->hashType = WP_RSA_PSS_DIGEST_DEF;
     pss->mgf = WP_RSA_PSS_MGF_DEF;
     XSTRNCPY(pss->mdName, "SHA-1", sizeof(pss->mdName));
@@ -585,7 +591,7 @@ static int wp_rsa_pss_params_set_pss_defaults(wp_RsaPssParams* pss)
     pss->saltLen = WP_RSA_DEFAULT_SALT_LEN;
     pss->derTrailer = 1; /* Default: RFC8017 A.2.3 */
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), 1);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), 1);
     return 1;
 }
 
@@ -604,13 +610,15 @@ static int wp_rsa_pss_params_setup_mgf1_md(wp_RsaPssParams* pss,
 {
     int ok = 1;
 
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsa_pss_params_setup_mgf1_md");
+
     OPENSSL_strlcpy(pss->mgfMdName, mdName, sizeof(pss->mgfMdName));
     pss->mgf = wp_name_to_wc_mgf(libCtx, mdName, mdProps);
     if (pss->mgf == WC_MGF1NONE) {
         ok = 0;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -629,6 +637,8 @@ static int wp_rsa_pss_params_setup_md(wp_RsaPssParams* pss, const char* mdName,
 {
     int ok = 1;
 
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsa_pss_params_setup_md");
+
     pss->hashType = wp_name_to_wc_hash_type(libCtx, mdName, mdProps);
     if ((pss->hashType == WC_HASH_TYPE_NONE) ||
         (pss->hashType == WC_HASH_TYPE_MD5)) {
@@ -643,7 +653,7 @@ static int wp_rsa_pss_params_setup_md(wp_RsaPssParams* pss, const char* mdName,
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -666,6 +676,8 @@ static int wp_rsa_pss_params_set_digest(wp_RsaPssParams* pss,
     char mdProps[WP_MAX_MD_NAME_SIZE] = "";
     char* pMdProps = NULL;
 
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsa_pss_params_set_digest");
+
     if (!OSSL_PARAM_get_utf8_string(p, &pMdName, sizeof(mdName))) {
         ok = 0;
     }
@@ -680,7 +692,7 @@ static int wp_rsa_pss_params_set_digest(wp_RsaPssParams* pss,
         ok = wp_rsa_pss_params_setup_md(pss, mdName, mdProps, libCtx);
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -703,6 +715,8 @@ static int wp_rsa_pss_params_set_mgf1_digest(wp_RsaPssParams* pss,
     char mdProps[WP_MAX_MD_NAME_SIZE] = "";
     char* pMdProps = NULL;
 
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsa_pss_params_set_mgf1_digest");
+
     if (!OSSL_PARAM_get_utf8_string(p, &pMdName, sizeof(mdName))) {
         ok = 0;
     }
@@ -717,7 +731,7 @@ static int wp_rsa_pss_params_set_mgf1_digest(wp_RsaPssParams* pss,
         ok = wp_rsa_pss_params_setup_mgf1_md(pss, mdName, mdProps, libCtx);
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -737,6 +751,8 @@ static int wp_rsa_pss_params_set_params(wp_RsaPssParams* pss,
     int ok = 1;
     const OSSL_PARAM* p;
     const OSSL_PARAM* propsParam = NULL;
+
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsa_pss_params_set_params");
 
     if (!defaultsSet) {
         if (!wp_rsa_pss_params_set_pss_defaults(pss)) {
@@ -783,7 +799,7 @@ static int wp_rsa_pss_params_set_params(wp_RsaPssParams* pss,
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -857,6 +873,8 @@ static int wp_rsa_get_params_key_data(wp_Rsa* rsa,  OSSL_PARAM params[])
     int ok = 1;
     int i;
 
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsa_get_params_key_data");
+
     for (i = 0; ok && (i < WP_RSA_PARAM_NUMS_CNT); i++) {
         OSSL_PARAM* p = OSSL_PARAM_locate(params, wp_rsa_param_key[i]);
         if (p != NULL) {
@@ -874,7 +892,7 @@ static int wp_rsa_get_params_key_data(wp_Rsa* rsa,  OSSL_PARAM params[])
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -890,6 +908,8 @@ static int wp_rsa_get_params_pss(wp_RsaPssParams* pss,  OSSL_PARAM params[])
 {
     int ok = 1;
     OSSL_PARAM* p;
+
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsa_get_params_pss");
 
     if (pss->hashType != WP_RSA_PSS_DIGEST_DEF) {
         p = OSSL_PARAM_locate(params, OSSL_PKEY_PARAM_RSA_DIGEST);
@@ -911,7 +931,7 @@ static int wp_rsa_get_params_pss(wp_RsaPssParams* pss,  OSSL_PARAM params[])
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -927,6 +947,8 @@ static int wp_rsa_get_params(wp_Rsa* rsa, OSSL_PARAM params[])
 {
     int ok = 1;
     OSSL_PARAM* p;
+
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsa_get_params");
 
     p = OSSL_PARAM_locate(params, OSSL_PKEY_PARAM_MAX_SIZE);
     if ((p != NULL) && !OSSL_PARAM_set_int(p, (rsa->bits + 7) / 8)) {
@@ -961,7 +983,7 @@ static int wp_rsa_get_params(wp_Rsa* rsa, OSSL_PARAM params[])
         ok = 0;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -977,6 +999,8 @@ static int wp_rsa_has(const wp_Rsa* rsa, int selection)
 {
     int ok = 1;
 
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsa_has");
+
     if (!wolfssl_prov_is_running()) {
        ok = 0;
     }
@@ -990,7 +1014,7 @@ static int wp_rsa_has(const wp_Rsa* rsa, int selection)
             ok &= rsa->hasPriv;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1007,6 +1031,8 @@ static int wp_rsa_match(const wp_Rsa* rsa1, const wp_Rsa* rsa2, int selection)
 {
     int ok = 1;
     int checked = 0;
+
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsa_match");
 
     if (ok && mp_cmp((mp_int*)&rsa1->key.e, (mp_int*)&rsa2->key.e) != MP_EQ) {
         ok = 0;
@@ -1031,7 +1057,7 @@ static int wp_rsa_match(const wp_Rsa* rsa1, const wp_Rsa* rsa2, int selection)
         ok = ok && checked;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1051,6 +1077,8 @@ static int wp_rsa_validate(const wp_Rsa* rsa, int selection, int checkType)
     int ok = 1;
     int checkPub = (selection & OSSL_KEYMGMT_SELECT_PUBLIC_KEY) != 0;
     int checkPriv = (selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY) != 0;
+
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsa_validate");
 
     (void)checkType;
 
@@ -1076,7 +1104,7 @@ static int wp_rsa_validate(const wp_Rsa* rsa, int selection, int checkType)
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1098,11 +1126,13 @@ static int wp_rsa_import_key_data(wp_Rsa* rsa, const OSSL_PARAM params[],
     mp_int* mp = NULL;
     const OSSL_PARAM* p = NULL;
 
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsa_import_key_data");
+
     /* N and E params are the only ones required by OSSL, so match that.
      * See ossl_rsa_fromdata() and RSA_set0_key() in OpenSSL. */
     if (OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_RSA_N) == NULL || 
         OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_RSA_E) == NULL) {
-        WOLFPROV_MSG(WP_LOG_PK, "Param N or E is missing");
+        WOLFPROV_MSG(WP_LOG_RSA, "Param N or E is missing");
         ok = 0;
     }
 
@@ -1122,7 +1152,7 @@ static int wp_rsa_import_key_data(wp_Rsa* rsa, const OSSL_PARAM params[],
             }
             if (index < 0) {
                 /* Follow OSSL implementation and ignore irrelevant fields. */
-                WOLFPROV_MSG(WP_LOG_PK, "Unexpected param %s, skipping.", 
+                WOLFPROV_MSG(WP_LOG_RSA, "Unexpected param %s, skipping.", 
                     p->key);
                 continue;
             }
@@ -1131,7 +1161,7 @@ static int wp_rsa_import_key_data(wp_Rsa* rsa, const OSSL_PARAM params[],
             if (ok) {
                 mp = (mp_int*)(((byte*)&rsa->key) + wp_rsa_offset[index]);
                 if (!wp_mp_read_unsigned_bin_le(mp, p->data, p->data_size)) {
-                    WOLFPROV_MSG(WP_LOG_PK,
+                    WOLFPROV_MSG(WP_LOG_RSA,
                         "Failed to read %s from parameters", p->key);
                     ok = 0;
                 }
@@ -1139,7 +1169,7 @@ static int wp_rsa_import_key_data(wp_Rsa* rsa, const OSSL_PARAM params[],
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1157,6 +1187,8 @@ static int wp_rsa_import(wp_Rsa* rsa, int selection, const OSSL_PARAM params[])
     int ok = 1;
     int importPriv =  (selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY) != 0;
     int importPub =  (selection & OSSL_KEYMGMT_SELECT_PUBLIC_KEY) != 0;
+
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsa_import");
 
     if ((!wolfssl_prov_is_running()) || (rsa == NULL)) {
         ok = 0;
@@ -1180,7 +1212,7 @@ static int wp_rsa_import(wp_Rsa* rsa, int selection, const OSSL_PARAM params[])
         rsa->hasPriv = importPriv;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1231,6 +1263,8 @@ static int wp_rsa_pss_params_export(wp_RsaPssParams* pss, OSSL_PARAM* params,
 {
     int i = *idx;
 
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsa_pss_params_export");
+
     wp_param_set_utf8_string_ptr(&params[i++], OSSL_PKEY_PARAM_RSA_DIGEST,
         pss->mdName);
     wp_param_set_utf8_string_ptr(&params[i++], OSSL_PKEY_PARAM_MGF1_DIGEST,
@@ -1241,7 +1275,7 @@ static int wp_rsa_pss_params_export(wp_RsaPssParams* pss, OSSL_PARAM* params,
         &pss->saltLen);
 
     *idx = i;
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), 1);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), 1);
     return 1;
 }
 
@@ -1298,6 +1332,8 @@ static int wp_rsa_export_keypair(wp_Rsa* rsa, OSSL_PARAM* params, int* pIdx,
     int j;
     int cnt;
 
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsa_export_keypair");
+
     if (priv) {
         cnt = WP_RSA_PARAM_NUMS_CNT;
     }
@@ -1314,7 +1350,7 @@ static int wp_rsa_export_keypair(wp_Rsa* rsa, OSSL_PARAM* params, int* pIdx,
     }
 
     *pIdx = i;
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1339,6 +1375,8 @@ static int wp_rsa_export(wp_Rsa* rsa, int selection, OSSL_CALLBACK* paramCb,
     unsigned char* data = NULL;
     size_t len = 0;
     int expPriv = (selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY) != 0;
+
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsa_export");
 
     if (!wolfssl_prov_is_running()) {
         ok = 0;
@@ -1370,7 +1408,7 @@ static int wp_rsa_export(wp_Rsa* rsa, int selection, OSSL_CALLBACK* paramCb,
     (void)paramSz;
     OPENSSL_clear_free(data, len);
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1523,6 +1561,8 @@ static int wp_rsa_gen_set_params(wp_RsaGenCtx* ctx, const OSSL_PARAM params[])
     int ok = 1;
     const OSSL_PARAM* p;
 
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsa_gen_set_params");
+
     if (params) {
         p = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_RSA_BITS);
         if (p != NULL) {
@@ -1564,7 +1604,7 @@ static int wp_rsa_gen_set_params(wp_RsaGenCtx* ctx, const OSSL_PARAM params[])
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1914,11 +1954,13 @@ static int wp_rsa_enc_dec_set_ctx_params(wp_RsaEncDecCtx* ctx,
 {
     int ok = 1;
 
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsa_enc_dec_set_ctx_params");
+
     if (!wp_cipher_from_params(params, &ctx->cipher, &ctx->cipherName)) {
         ok = 0;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1950,6 +1992,8 @@ static int wp_rsa_find_oid(unsigned char* data, word32 len, unsigned char* oid,
     int ok = 0;
     word32 i;
 
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsa_find_oid");
+
     for (i = 0; i < len - RSA_PKCS1_OID_SZ - 1; i++) {
         /* Find the base OID. */
         if (XMEMCMP(data + i, oid, oidLen) == 0) {
@@ -1959,7 +2003,7 @@ static int wp_rsa_find_oid(unsigned char* data, word32 len, unsigned char* oid,
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1979,6 +2023,8 @@ static int wp_rsa_determine_type(wp_Rsa* rsa, unsigned char* data, word32 len)
     int ok = 1;
     word32 idx = 0;
 
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsa_determine_type");
+
     if (wp_rsa_find_oid(data, len, rsa_pkcs1_oid, RSA_PKCS1_OID_SZ, &idx)) {
         /* Check OID is for PKCS #1.5. */
         if (data[idx + RSA_PKCS1_OID_SZ] == RSA_PKCS1_5_BYTE) {
@@ -1993,7 +2039,7 @@ static int wp_rsa_determine_type(wp_Rsa* rsa, unsigned char* data, word32 len)
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -2149,6 +2195,8 @@ static int wp_rsa_decode_spki(wp_Rsa* rsa, unsigned char* data, word32 len)
     int rc;
     word32 idx = 0;
 
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsa_decode_spki");
+
     if (!wolfssl_prov_is_running()) {
         ok = 0;
     }
@@ -2174,7 +2222,7 @@ static int wp_rsa_decode_spki(wp_Rsa* rsa, unsigned char* data, word32 len)
         rsa->hasPub = 1;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -2192,6 +2240,8 @@ static int wp_rsa_decode_pki(wp_Rsa* rsa, unsigned char* data, word32 len)
     int ok = 1;
     int rc;
     word32 idx = 0;
+
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsa_decode_pki");
 
     if (!wolfssl_prov_is_running()) {
         ok = 0;
@@ -2227,7 +2277,7 @@ static int wp_rsa_decode_pki(wp_Rsa* rsa, unsigned char* data, word32 len)
         rsa->hasPriv = 1;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -2253,6 +2303,8 @@ static int wp_rsa_find_pbkdf2_oid(unsigned char* data, word32 len)
     int ok = 0;
     word32 i;
 
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsa_find_pbkdf2_oid");
+
     for (i = 0; i < 40 && i + PBKDF2_OID_SZ < len; i++) {
         /* Find the base OID. */
         if (XMEMCMP(data + i, pbkdf2_oid, PBKDF2_OID_SZ) == 0) {
@@ -2261,7 +2313,7 @@ static int wp_rsa_find_pbkdf2_oid(unsigned char* data, word32 len)
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -2283,6 +2335,8 @@ static int wp_rsa_decode_enc_pki(wp_Rsa* rsa, unsigned char* data, word32 len,
     char password[1024];
     size_t passwordSz = sizeof(password);
 
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsa_decode_enc_pki");
+    
     if (!wolfssl_prov_is_running()) {
         ok = 0;
     }
@@ -2311,6 +2365,7 @@ static int wp_rsa_decode_enc_pki(wp_Rsa* rsa, unsigned char* data, word32 len,
         ok = wp_rsa_decode_pki(rsa, data, len);
     }
 
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -2330,6 +2385,8 @@ static int wp_rsa_dec_send_params(wp_Rsa* rsa, OSSL_CALLBACK* dataCb,
 {
     int ok = 1;
 
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsa_dec_send_params");
+
     OSSL_PARAM params[4];
     int object_type = OSSL_OBJECT_PKEY;
 
@@ -2346,7 +2403,7 @@ static int wp_rsa_dec_send_params(wp_Rsa* rsa, OSSL_CALLBACK* dataCb,
         ok = 0;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -2377,6 +2434,8 @@ static int wp_rsa_decode(wp_RsaEncDecCtx* ctx, OSSL_CORE_BIO* cBio,
 
     (void)pwCb;
     (void)pwCbArg;
+
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsa_decode");
 
     ctx->selection = selection;
 
@@ -2436,7 +2495,7 @@ static int wp_rsa_decode(wp_RsaEncDecCtx* ctx, OSSL_CORE_BIO* cBio,
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -2465,6 +2524,8 @@ int wp_rsa_pss_encode_alg_id(const wp_Rsa* rsa, const char* mdName,
     };
     int seq1LenIdx;
     int seq2LenIdx;
+
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsa_pss_encode_alg_id");
 
     if (pssAlgId == NULL) {
         /* Length opf header without optional parts. */
@@ -2606,7 +2667,7 @@ int wp_rsa_pss_encode_alg_id(const wp_Rsa* rsa, const char* mdName,
     /* Return length. */
     *len = i;
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -2621,6 +2682,8 @@ int wp_rsa_pss_encode_alg_id(const wp_Rsa* rsa, const char* mdName,
 static int wp_rsa_encode_spki_size(const wp_Rsa* rsa, size_t* keyLen)
 {
     int ok = 1;
+
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsa_encode_spki_size");
 
 #if LIBWOLFSSL_VERSION_HEX >= 0x05000000
     int ret;
@@ -2651,7 +2714,7 @@ static int wp_rsa_encode_spki_size(const wp_Rsa* rsa, size_t* keyLen)
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -2670,6 +2733,8 @@ static int wp_rsa_encode_spki(const wp_Rsa* rsa, unsigned char* keyData,
 {
     int ok = 1;
     int ret;
+
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsa_encode_spki");
 
     ret = wc_RsaKeyToPublicDer((RsaKey*)&rsa->key, keyData, (word32)*keyLen);
     if (ret <= 0) {
@@ -2710,7 +2775,7 @@ static int wp_rsa_encode_spki(const wp_Rsa* rsa, unsigned char* keyData,
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -2727,6 +2792,8 @@ static int wp_rsa_encode_pub_size(const wp_Rsa* rsa, size_t* keyLen)
     int ok = 1;
     int ret;
 
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsa_encode_pub_size");
+
 #if LIBWOLFSSL_VERSION_HEX >= 0x05000000
     ret = wc_RsaKeyToPublicDer_ex((RsaKey*)&rsa->key, NULL, 0, 0);
 #else
@@ -2739,7 +2806,7 @@ static int wp_rsa_encode_pub_size(const wp_Rsa* rsa, size_t* keyLen)
         *keyLen = ret;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -2759,6 +2826,8 @@ static int wp_rsa_encode_pub(const wp_Rsa* rsa, unsigned char* keyData,
     int ok = 1;
     int ret;
 
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsa_encode_pub");
+
 #if LIBWOLFSSL_VERSION_HEX >= 0x05000000
     ret = wc_RsaKeyToPublicDer_ex((RsaKey*)&rsa->key, keyData, (word32)*keyLen,
         0);
@@ -2776,7 +2845,7 @@ static int wp_rsa_encode_pub(const wp_Rsa* rsa, unsigned char* keyData,
         *keyLen = ret;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -2805,6 +2874,8 @@ static int wp_rsa_encode_pki_size(const wp_Rsa* rsa, size_t* keyLen, int algoId)
     int ret;
     word32 len;
 
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsa_encode_pki_size");
+
     ret = wc_RsaKeyToDer((RsaKey*)&rsa->key, NULL, 0);
     if (ret <= 0) {
         ok = 0;
@@ -2819,7 +2890,7 @@ static int wp_rsa_encode_pki_size(const wp_Rsa* rsa, size_t* keyLen, int algoId)
         *keyLen = len;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -2842,6 +2913,8 @@ static int wp_rsa_encode_pki(const wp_Rsa* rsa, unsigned char* keyData,
     unsigned char* pkcs1Data = NULL;
     size_t pkcs1Len = 0;
     word32 len;
+
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsa_encode_pki");
 
     ret = wc_RsaKeyToDer((RsaKey*)&rsa->key, NULL, 0);
     if (ret <= 0) {
@@ -2874,7 +2947,7 @@ static int wp_rsa_encode_pki(const wp_Rsa* rsa, unsigned char* keyData,
     }
 
     OPENSSL_clear_free(pkcs1Data, pkcs1Len);
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -2891,6 +2964,8 @@ static int wp_rsa_encode_priv_size(const wp_Rsa* rsa, size_t* keyLen)
     int ok = 1;
     int ret;
 
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsa_encode_priv_size");
+
     ret = wc_RsaKeyToDer((RsaKey*)&rsa->key, NULL, 0);
     if (ret <= 0) {
         ok = 0;
@@ -2899,7 +2974,7 @@ static int wp_rsa_encode_priv_size(const wp_Rsa* rsa, size_t* keyLen)
         *keyLen = ret;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -2919,6 +2994,8 @@ static int wp_rsa_encode_priv(const wp_Rsa* rsa, unsigned char* keyData,
     int ok = 1;
     int ret;
 
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsa_encode_priv");
+
     ret = wc_RsaKeyToDer((RsaKey*)&rsa->key, keyData, (word32)*keyLen);
     if (ret <= 0) {
         ok = 0;
@@ -2927,7 +3004,7 @@ static int wp_rsa_encode_priv(const wp_Rsa* rsa, unsigned char* keyData,
         *keyLen = ret;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -2950,6 +3027,8 @@ static int wp_rsa_encode_enc_pki_size(const wp_RsaEncDecCtx* ctx,
     byte fakeData[1];
     byte fakeSalt[16];
 
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsa_encode_enc_pki_size");
+
     /* Get encode private key length. */
     ok = wp_rsa_encode_pki_size(rsa, &len, RSA_ALGO_ID(ctx));
     if (ok) {
@@ -2966,7 +3045,7 @@ static int wp_rsa_encode_enc_pki_size(const wp_RsaEncDecCtx* ctx,
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -2995,6 +3074,8 @@ static int wp_rsa_encode_enc_pki(const wp_RsaEncDecCtx* ctx, const wp_Rsa* rsa,
     char password[1024];
     size_t passwordSz = sizeof(password);
     byte* encodedKey = NULL;
+
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsa_encode_enc_pki");
 
     /* TODO: support salt length of 8 for DES3. */
 
@@ -3036,7 +3117,7 @@ static int wp_rsa_encode_enc_pki(const wp_RsaEncDecCtx* ctx, const wp_Rsa* rsa,
 
     XFREE(encodedKey, NULL, DYNAMIC_TYPE_RSA_BUFFER);
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -3054,12 +3135,14 @@ static int wp_rsa_encode_epki_size(const wp_RsaEncDecCtx* ctx,
     int ok;
     size_t len;
 
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsa_encode_epki_size");
+
     ok = wp_rsa_encode_pki_size(rsa, &len, RSA_ALGO_ID(ctx));
     if (ok) {
         *keyLen = ((len + 15) / 16) * 16;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -3084,6 +3167,8 @@ static int wp_rsa_encode_epki(const wp_RsaEncDecCtx* ctx, const wp_Rsa* rsa,
     int ok = 1;
     size_t len = *keyLen;
 
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsa_encode_epki");
+
     /* Encode key. */
     ok = wp_rsa_encode_pki(rsa, keyData, &len, RSA_ALGO_ID(ctx));
     if (ok && (!wp_encrypt_key(ctx->provCtx, ctx->cipherName, keyData, keyLen,
@@ -3091,7 +3176,7 @@ static int wp_rsa_encode_epki(const wp_RsaEncDecCtx* ctx, const wp_Rsa* rsa,
         ok = 0;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 #endif
@@ -3116,6 +3201,8 @@ static int wp_rsa_encode(wp_RsaEncDecCtx* ctx, OSSL_CORE_BIO* cBio,
     int ok = 1;
     int rc;
     BIO *out = wp_corebio_get_bio(ctx->provCtx, cBio);
+
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsa_encode");
 
     if (!wolfssl_prov_is_running()) {
         ok = 0;
@@ -3271,7 +3358,7 @@ static int wp_rsa_encode(wp_RsaEncDecCtx* ctx, OSSL_CORE_BIO* cBio,
         OPENSSL_free(pemData);
     }
     BIO_free(out);
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -3323,6 +3410,8 @@ static int wp_rsa_spki_does_selection(WOLFPROV_CTX* provCtx, int selection)
 {
     int ok;
 
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsa_spki_does_selection");
+
     (void)provCtx;
 
     if (selection == 0) {
@@ -3332,7 +3421,7 @@ static int wp_rsa_spki_does_selection(WOLFPROV_CTX* provCtx, int selection)
         ok = (selection & OSSL_KEYMGMT_SELECT_PUBLIC_KEY) != 0;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -3435,6 +3524,8 @@ static int wp_rsa_pki_does_selection(WOLFPROV_CTX* provCtx, int selection)
 {
     int ok;
 
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsa_pki_does_selection");
+
     (void)provCtx;
 
     if (selection == 0) {
@@ -3444,7 +3535,7 @@ static int wp_rsa_pki_does_selection(WOLFPROV_CTX* provCtx, int selection)
         ok = (selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY) != 0;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -3609,6 +3700,8 @@ static int wp_rsa_legacy_does_selection(WOLFPROV_CTX* provCtx, int selection)
 {
     int ok;
 
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsa_legacy_does_selection");
+
     (void)provCtx;
 
     if (selection == 0) {
@@ -3618,7 +3711,7 @@ static int wp_rsa_legacy_does_selection(WOLFPROV_CTX* provCtx, int selection)
         ok = (selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY) != 0;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -3661,6 +3754,8 @@ static int wp_rsa_kp_does_selection(WOLFPROV_CTX* provCtx, int selection)
 {
     int ok;
 
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsa_kp_does_selection");
+
     (void)provCtx;
 
     if (selection == 0) {
@@ -3670,7 +3765,7 @@ static int wp_rsa_kp_does_selection(WOLFPROV_CTX* provCtx, int selection)
         ok = (selection & OSSL_KEYMGMT_SELECT_KEYPAIR) != 0;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -3931,6 +4026,8 @@ static int wp_rsa_text_enc_does_selection(WOLFPROV_CTX* provCtx, int selection)
 {
     int ok;
 
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsa_text_enc_does_selection");
+
     (void)provCtx;
 
     /* Text encoder supports both public and private key parts */
@@ -3942,7 +4039,7 @@ static int wp_rsa_text_enc_does_selection(WOLFPROV_CTX* provCtx, int selection)
              ((selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY) != 0);
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -4065,6 +4162,8 @@ static int wp_rsa_encode_text(wp_RsaEncDecCtx* ctx, OSSL_CORE_BIO* cBio,
     size_t printAmt = 0;
     char* expStr;
     int expLen;
+
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsa_encode_text");
 
     (void)params;
     (void)pwCb;
@@ -4215,7 +4314,7 @@ static int wp_rsa_encode_text(wp_RsaEncDecCtx* ctx, OSSL_CORE_BIO* cBio,
     OPENSSL_free(textData);
     BIO_free(out);
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 

--- a/src/wp_rsa_sig.c
+++ b/src/wp_rsa_sig.c
@@ -119,6 +119,8 @@ static int wp_rsa_setup_md(wp_RsaSigCtx* ctx, const char* mdName,
 {
     int ok = 1;
 
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsa_setup_md");
+
     if (mdProps == NULL) {
         mdProps = ctx->propQuery;
     }
@@ -189,7 +191,7 @@ static int wp_rsa_setup_md(wp_RsaSigCtx* ctx, const char* mdName,
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -208,6 +210,8 @@ static int wp_rsa_setup_mgf1_md(wp_RsaSigCtx* ctx, const char* mdName,
     int ok = 1;
     int mgf;
 
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsa_setup_mgf1_md");
+
     if (mdName != NULL) {
         OPENSSL_strlcpy(ctx->mgf1MdName, mdName, sizeof(ctx->mgf1MdName));
         mgf = wp_name_to_wc_mgf(ctx->libCtx, mdName, mdProps);
@@ -223,7 +227,7 @@ static int wp_rsa_setup_mgf1_md(wp_RsaSigCtx* ctx, const char* mdName,
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -406,6 +410,8 @@ static int wp_rsa_check_pss_salt_len(wp_RsaSigCtx* ctx)
     int maxSaltLen;
     int bits = wp_rsa_get_bits(ctx->rsa);
 
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsa_check_pss_salt_len");
+
 #if LIBWOLFSSL_VERSION_HEX >= 0x05007004
     maxSaltLen = ((bits + 7) / 8) - wc_HashGetDigestSize(ctx->hash.type) - 2;
 #else
@@ -436,7 +442,7 @@ static int wp_rsa_check_pss_salt_len(wp_RsaSigCtx* ctx)
         ok = 0;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -454,6 +460,8 @@ static int wp_rsa_signverify_init(wp_RsaSigCtx* ctx, wp_Rsa* rsa,
     const OSSL_PARAM params[], int op)
 {
     int ok = 1;
+
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsa_signverify_init");
 
     if ((ctx == NULL) || (ctx->rsa == NULL && rsa == NULL)) {
         ok = 0;
@@ -522,7 +530,7 @@ static int wp_rsa_signverify_init(wp_RsaSigCtx* ctx, wp_Rsa* rsa,
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -540,6 +548,8 @@ static int wp_rsa_sign_init(wp_RsaSigCtx* ctx, wp_Rsa* rsa,
 {
     int ok;
 
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsa_sign_init");
+
     if (!wolfssl_prov_is_running()) {
         ok = 0;
     }
@@ -547,7 +557,7 @@ static int wp_rsa_sign_init(wp_RsaSigCtx* ctx, wp_Rsa* rsa,
         ok = wp_rsa_signverify_init(ctx, rsa, params, EVP_PKEY_OP_SIGN);
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -570,6 +580,8 @@ static int wp_rsa_sign_pkcs1(wp_RsaSigCtx* ctx, unsigned char* sig,
     int rc;
     unsigned char* encodedDigest = NULL;
     int encodedDigestLen = 0;
+
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsa_sign_pkcs1");
 
 #if LIBWOLFSSL_VERSION_HEX >= 0x05007004
     if (ctx->hash.type != WC_HASH_TYPE_NONE)
@@ -632,7 +644,7 @@ static int wp_rsa_sign_pkcs1(wp_RsaSigCtx* ctx, unsigned char* sig,
 
     OPENSSL_free(encodedDigest);
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -661,6 +673,8 @@ static int wp_rsa_sign_pss(wp_RsaSigCtx* ctx, unsigned char* sig,
 #endif
         wp_rsa_get_key(ctx->rsa), EVP_PKEY_OP_SIGN);
 
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsa_sign_pss");
+
     if (ok) {
         if (wp_lock(wp_rsa_get_mutex(ctx->rsa)) != 1) {
             ok = 0;
@@ -686,7 +700,7 @@ static int wp_rsa_sign_pss(wp_RsaSigCtx* ctx, unsigned char* sig,
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -706,15 +720,17 @@ static int wp_add_x931_padding(unsigned char* to, size_t toLen,
     int ok = 1;
     int padBytes;
 
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_add_x931_padding");
+
     if (to == NULL || from == NULL) {
-        WOLFPROV_ERROR_MSG(WP_LOG_PK, "Bad argument.");
+        WOLFPROV_ERROR_MSG(WP_LOG_RSA, "Bad argument.");
         ok = 0;
     }
     else {
         /* Need at least two bytes for trailer and header. */
         padBytes = (int)(toLen - fromLen - 2);
         if (padBytes < 0) {
-            WOLFPROV_ERROR_MSG(WP_LOG_PK, "Output buffer too small.");
+            WOLFPROV_ERROR_MSG(WP_LOG_RSA, "Output buffer too small.");
             ok = 0;
         }
     }
@@ -735,7 +751,7 @@ static int wp_add_x931_padding(unsigned char* to, size_t toLen,
         to[toLen - 1] = 0xCC;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
 
     return ok;
 }
@@ -756,6 +772,8 @@ static int wp_rsa_sign_no_pad(wp_RsaSigCtx* ctx, unsigned char* sig,
     size_t* sigLen, size_t sigSize, const unsigned char* tbs, size_t tbsLen)
 {
     int ok = 1;
+
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsa_sign_no_pad");
 
     if (tbsLen != sigSize) {
         ok = 0;
@@ -781,7 +799,7 @@ static int wp_rsa_sign_no_pad(wp_RsaSigCtx* ctx, unsigned char* sig,
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -826,6 +844,8 @@ static int wp_rsa_sign_x931(wp_RsaSigCtx* ctx, unsigned char* sig,
     int rc = 0;
     mp_int toMp;
     mp_int nMinusTo;
+
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsa_sign_x931");
 
     paddedSz = wc_RsaEncryptSize(wp_rsa_get_key(ctx->rsa));
     if (paddedSz <= 0) {
@@ -914,7 +934,7 @@ static int wp_rsa_sign_x931(wp_RsaSigCtx* ctx, unsigned char* sig,
     mp_free(&toMp);
     mp_free(&nMinusTo);
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -938,7 +958,7 @@ static int wp_rsa_sign(wp_RsaSigCtx* ctx, unsigned char* sig, size_t* sigLen,
 {
     int ok = 1;
 
-    WOLFPROV_ENTER(WP_LOG_PK, __FUNCTION__);
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsa_sign");
 
     if (!wolfssl_prov_is_running()) {
         ok = 0;
@@ -970,7 +990,7 @@ static int wp_rsa_sign(wp_RsaSigCtx* ctx, unsigned char* sig, size_t* sigLen,
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -988,6 +1008,8 @@ static int wp_rsa_verify_init(wp_RsaSigCtx* ctx, wp_Rsa* rsa,
 {
     int ok;
 
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsa_verify_init");
+
     if (!wolfssl_prov_is_running()) {
         ok = 0;
     }
@@ -995,7 +1017,7 @@ static int wp_rsa_verify_init(wp_RsaSigCtx* ctx, wp_Rsa* rsa,
         ok = wp_rsa_signverify_init(ctx, rsa, params, EVP_PKEY_OP_VERIFY);
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1019,6 +1041,8 @@ static int wp_rsa_verify_pkcs1(wp_RsaSigCtx* ctx, const unsigned char* sig,
     int rc;
     unsigned char* encodedDigest = NULL;
     int encodedDigestLen = 0;
+
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsa_verify_pkcs1");
 
     rc = wc_RsaSSL_Verify(sig, (word32)sigLen, decryptedSig, (word32)sigLen,
         wp_rsa_get_key(ctx->rsa));
@@ -1056,7 +1080,7 @@ static int wp_rsa_verify_pkcs1(wp_RsaSigCtx* ctx, const unsigned char* sig,
         ok = 0;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1079,6 +1103,8 @@ static int wp_rsa_verify_pss(wp_RsaSigCtx* ctx, const unsigned char* sig,
     int ok = 1;
     int rc;
     int saltLen;
+
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsa_verify_pss");
 
 #if LIBWOLFSSL_VERSION_HEX >= 0x05007004
     if (ctx->hash.type == WC_HASH_TYPE_NONE)
@@ -1123,7 +1149,7 @@ static int wp_rsa_verify_pss(wp_RsaSigCtx* ctx, const unsigned char* sig,
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1147,6 +1173,8 @@ static int wp_rsa_verify_no_pad(wp_RsaSigCtx* ctx, const unsigned char* sig,
     int rc;
     word32 len = (word32)sigLen;
 
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsa_verify_no_pad");
+
     rc = wc_RsaDirect((byte*)sig, (word32)sigLen, decryptedSig, &len,
         wp_rsa_get_key(ctx->rsa), RSA_PUBLIC_DECRYPT, &ctx->rng);
     if (rc < 0) {
@@ -1157,7 +1185,7 @@ static int wp_rsa_verify_no_pad(wp_RsaSigCtx* ctx, const unsigned char* sig,
         ok = 0;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1179,6 +1207,8 @@ static int wp_remove_x931_padding(unsigned char** to, const unsigned char* from,
     int ok = 1;
     size_t idx = 0;
     size_t numCopy = 0;
+
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_remove_x931_padding");
 
     if (to == NULL || from == NULL || fromLen < 2) {
         ok = 0;
@@ -1220,7 +1250,7 @@ static int wp_remove_x931_padding(unsigned char** to, const unsigned char* from,
         ret = (int)numCopy;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ret);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ret);
     return ret;
 }
 
@@ -1246,6 +1276,8 @@ static int wp_rsa_verify_x931(wp_RsaSigCtx* ctx, const unsigned char* sig,
     unsigned char* unpadded = NULL;
     mp_int toMp;
     mp_int nMinusTo;
+
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsa_verify_x931");
 
     rc = wc_RsaDirect((byte*)sig, (word32)sigLen, decryptedSig, &len,
         wp_rsa_get_key(ctx->rsa), RSA_PUBLIC_DECRYPT, &ctx->rng);
@@ -1317,7 +1349,7 @@ static int wp_rsa_verify_x931(wp_RsaSigCtx* ctx, const unsigned char* sig,
         OPENSSL_free(unpadded);
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1337,7 +1369,7 @@ static int wp_rsa_verify(wp_RsaSigCtx* ctx, const unsigned char* sig,
 {
     int ok = 1;
 
-    WOLFPROV_ENTER(WP_LOG_PK, __FUNCTION__);
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsa_verify");
 
     if (!wolfssl_prov_is_running()) {
         ok = 0;
@@ -1375,7 +1407,7 @@ static int wp_rsa_verify(wp_RsaSigCtx* ctx, const unsigned char* sig,
         OPENSSL_free(decryptedSig);
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1393,6 +1425,8 @@ static int wp_rsa_verify_recover_init(wp_RsaSigCtx* ctx, wp_Rsa* rsa,
 {
     int ok = 1;
 
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsa_verify_recover_init");
+
     if (!wolfssl_prov_is_running()) {
         ok = 0;
     }
@@ -1401,7 +1435,7 @@ static int wp_rsa_verify_recover_init(wp_RsaSigCtx* ctx, wp_Rsa* rsa,
             EVP_PKEY_OP_VERIFYRECOVER);
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1422,13 +1456,15 @@ static int wp_rsa_verify_recover(wp_RsaSigCtx* ctx, unsigned char* rout,
     int rc;
     int ok = 1;
 
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsa_verify_recover");
+
     if ((ctx == NULL) || (rout == NULL) || (routlen == NULL) || (sig == NULL)) {
         ok = 0;
     }
 
     /* Only PKCS1 supported for now */
     if (ok && (ctx->padMode != RSA_PKCS1_PADDING)) {
-        WOLFPROV_ERROR_MSG(WP_LOG_PK, "Only PKCS1 padding supported"
+        WOLFPROV_ERROR_MSG(WP_LOG_RSA, "Only PKCS1 padding supported"
                                       " for verify recover");
         ok = 0;
     }
@@ -1463,13 +1499,15 @@ static int wp_rsa_digest_signverify_init(wp_RsaSigCtx* ctx, const char* mdName,
 {
     int ok;
 
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsa_digest_signverify_init");
+
     ok = wp_rsa_signverify_init(ctx, rsa, params, op);
     if (ok && ((mdName != NULL) && ((mdName[0] == '\0') ||
         (XSTRNCASECMP(ctx->mdName, mdName, XSTRLEN(ctx->mdName) + 1) != 0)))) {
         ok = wp_rsa_setup_md(ctx, mdName, ctx->propQuery, op);
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1486,6 +1524,9 @@ static int wp_rsa_digest_signverify_update(wp_RsaSigCtx* ctx,
     const unsigned char* data, size_t dataLen)
 {
     int ok = 1;
+
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsa_digest_signverify_update");
+
     int rc = wc_HashUpdate(&ctx->hash,
 #if LIBWOLFSSL_VERSION_HEX >= 0x05007004
             ctx->hash.type,
@@ -1496,7 +1537,7 @@ static int wp_rsa_digest_signverify_update(wp_RsaSigCtx* ctx,
     if (rc != 0) {
         ok = 0;
     }
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1515,6 +1556,8 @@ static int wp_rsa_digest_sign_init(wp_RsaSigCtx* ctx, const char* mdName,
 {
     int ok;
 
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsa_digest_sign_init");
+
     if (!wolfssl_prov_is_running()) {
         ok = 0;
     }
@@ -1523,7 +1566,7 @@ static int wp_rsa_digest_sign_init(wp_RsaSigCtx* ctx, const char* mdName,
             EVP_PKEY_OP_SIGN);
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1545,6 +1588,8 @@ static int wp_rsa_digest_sign_final(wp_RsaSigCtx* ctx, unsigned char* sig,
 {
     int ok = 1;
     unsigned char digest[WC_MAX_DIGEST_SIZE];
+
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsa_digest_sign_final");
 
     if (!wolfssl_prov_is_running()) {
         ok = 0;
@@ -1573,7 +1618,7 @@ static int wp_rsa_digest_sign_final(wp_RsaSigCtx* ctx, unsigned char* sig,
             ));
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1592,6 +1637,8 @@ static int wp_rsa_digest_verify_init(wp_RsaSigCtx* ctx, const char* mdName,
 {
     int ok;
 
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsa_digest_verify_init");
+
     if (!wolfssl_prov_is_running()) {
         ok = 0;
     }
@@ -1600,7 +1647,7 @@ static int wp_rsa_digest_verify_init(wp_RsaSigCtx* ctx, const char* mdName,
             EVP_PKEY_OP_VERIFY);
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1618,6 +1665,8 @@ static int wp_rsa_digest_verify_final(wp_RsaSigCtx* ctx, unsigned char* sig,
 {
     int ok = 1;
     unsigned char digest[WC_MAX_DIGEST_SIZE];
+
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsa_digest_verify_final");
 
     if (!wolfssl_prov_is_running()) {
         ok = 0;
@@ -1646,7 +1695,7 @@ static int wp_rsa_digest_verify_final(wp_RsaSigCtx* ctx, unsigned char* sig,
             ));
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1667,6 +1716,8 @@ static int wp_rsa_pss_get_alg_id(wp_RsaSigCtx* ctx, OSSL_PARAM* p)
     byte pssAlgId[MAX_RSA_PSS_PARAMS_DER_LEN];
     word32 len = MAX_RSA_PSS_PARAMS_DER_LEN;
 
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsa_pss_get_alg_id");
+
     /* Encode RSA-PSS parameters into buffer. */
     ok = wp_rsa_pss_encode_alg_id(ctx->rsa, ctx->mdName, ctx->mgf1MdName,
         ctx->saltLen, pssAlgId, &len);
@@ -1675,7 +1726,7 @@ static int wp_rsa_pss_get_alg_id(wp_RsaSigCtx* ctx, OSSL_PARAM* p)
         ok = OSSL_PARAM_set_octet_string(p, pssAlgId, len);
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1723,7 +1774,7 @@ static int wp_rsa_get_alg_id(wp_RsaSigCtx* ctx, OSSL_PARAM* p)
     }
     /* TODO: support more digests */
     else {
-        WOLFPROV_MSG(WP_LOG_PK, "Digest not supported: %s\n", ctx->mdName);
+        WOLFPROV_MSG(WP_LOG_RSA, "Digest not supported: %s\n", ctx->mdName);
     }
 
     return ok;
@@ -1740,6 +1791,8 @@ static int wp_rsa_get_alg_id(wp_RsaSigCtx* ctx, OSSL_PARAM* p)
 static int wp_rsa_get_pad_mode(int padMode, OSSL_PARAM* p)
 {
     int ok = 1;
+
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsa_get_pad_mode");
 
     if (p->data_type == OSSL_PARAM_INTEGER) {
         if (!OSSL_PARAM_set_int(p, padMode)) {
@@ -1762,7 +1815,7 @@ static int wp_rsa_get_pad_mode(int padMode, OSSL_PARAM* p)
         ok = 0;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1777,6 +1830,8 @@ static int wp_rsa_get_pad_mode(int padMode, OSSL_PARAM* p)
 static int wp_rsa_get_salt_len(int saltLen, OSSL_PARAM* p)
 {
     int ok = 1;
+
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsa_get_salt_len");
 
     if (p->data_type == OSSL_PARAM_INTEGER) {
         if (!OSSL_PARAM_set_int(p, saltLen)) {
@@ -1821,7 +1876,7 @@ static int wp_rsa_get_salt_len(int saltLen, OSSL_PARAM* p)
         ok = 0;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1837,6 +1892,8 @@ static int wp_rsa_get_ctx_params(wp_RsaSigCtx* ctx, OSSL_PARAM* params)
 {
     int ok = 1;
     OSSL_PARAM* p;
+
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsa_get_ctx_params");
 
     if (ctx == NULL) {
         ok = 0;
@@ -1877,7 +1934,7 @@ static int wp_rsa_get_ctx_params(wp_RsaSigCtx* ctx, OSSL_PARAM* params)
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1923,6 +1980,8 @@ static int wp_rsa_set_digest(wp_RsaSigCtx* ctx, const OSSL_PARAM* p,
     char mdProps[WP_MAX_MD_NAME_SIZE];
     char* pmdProps = NULL;
 
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsa_set_digest");
+
     if (!OSSL_PARAM_get_utf8_string(p, &pmdName, sizeof(mdName))) {
         ok = 0;
     }
@@ -1937,7 +1996,7 @@ static int wp_rsa_set_digest(wp_RsaSigCtx* ctx, const OSSL_PARAM* p,
         ok = wp_rsa_setup_md(ctx, mdName, pmdProps, ctx->op);
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -1953,6 +2012,8 @@ static int wp_rsa_set_pad_mode(wp_RsaSigCtx* ctx, const OSSL_PARAM* p)
 {
     int ok = 1;
     int padMode = 0;
+
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsa_set_pad_mode");
 
     if (p->data_type == OSSL_PARAM_INTEGER) {
         if (!OSSL_PARAM_get_int(p, &padMode)) {
@@ -2008,7 +2069,7 @@ static int wp_rsa_set_pad_mode(wp_RsaSigCtx* ctx, const OSSL_PARAM* p)
         ctx->padMode = padMode;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -2023,6 +2084,8 @@ static int wp_rsa_set_pad_mode(wp_RsaSigCtx* ctx, const OSSL_PARAM* p)
 static int wp_rsa_set_salt_len(wp_RsaSigCtx* ctx, const OSSL_PARAM* p)
 {
     int ok = 1;
+
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsa_set_salt_len");
 
     if (p->data_type == OSSL_PARAM_INTEGER) {
         if (!OSSL_PARAM_get_int(p, &ctx->saltLen)) {
@@ -2064,7 +2127,7 @@ static int wp_rsa_set_salt_len(wp_RsaSigCtx* ctx, const OSSL_PARAM* p)
         ok = 0;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -2086,6 +2149,8 @@ static int wp_rsa_set_mgf1_digest(wp_RsaSigCtx* ctx, const OSSL_PARAM* p,
     char mgfMdProps[WP_MAX_MD_NAME_SIZE] = "";
     char* pmgfMdProps = NULL;
 
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsa_set_mgf1_digest");
+
     if (!OSSL_PARAM_get_utf8_string(p, &pmgfMdName, sizeof(mgfMdName))) {
         ok = 0;
     }
@@ -2100,7 +2165,7 @@ static int wp_rsa_set_mgf1_digest(wp_RsaSigCtx* ctx, const OSSL_PARAM* p,
         ok = wp_rsa_setup_mgf1_md(ctx, mgfMdName, pmgfMdProps);
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 
@@ -2117,6 +2182,8 @@ static int wp_rsa_set_ctx_params(wp_RsaSigCtx* ctx, const OSSL_PARAM params[])
     int ok = 1;
     const OSSL_PARAM* p;
     const OSSL_PARAM* propsParam;
+
+    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsa_set_ctx_params");
 
     if (params != NULL) {
         p = OSSL_PARAM_locate_const(params, OSSL_SIGNATURE_PARAM_DIGEST);
@@ -2163,7 +2230,7 @@ static int wp_rsa_set_ctx_params(wp_RsaSigCtx* ctx, const OSSL_PARAM params[])
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_PK, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
 

--- a/src/wp_tls1_prf.c
+++ b/src/wp_tls1_prf.c
@@ -146,6 +146,8 @@ static int wp_kdf_tls1_prf_derive(wp_Tls1Prf_Ctx* ctx, unsigned char* key,
 {
     int ok = 1;
 
+    WOLFPROV_ENTER(WP_LOG_TLS1_PRF, "wp_kdf_tls1_prf_derive");
+
     if (!wolfssl_prov_is_running()) {
         ok = 0;
     }
@@ -213,6 +215,8 @@ static int wp_kdf_tls1_prf_get_seed(wp_Tls1Prf_Ctx* ctx,
     const OSSL_PARAM *p;
     unsigned char* q = ctx->seed + ctx->seedSz;
 
+    WOLFPROV_ENTER(WP_LOG_TLS1_PRF, "wp_kdf_tls1_prf_get_seed");
+
     /* Combine all the data in the seed parameters. */
     while (ok && ((p = OSSL_PARAM_locate_const(params,
             OSSL_KDF_PARAM_SEED)) != NULL)) {
@@ -245,6 +249,8 @@ static int wp_kdf_tls1_prf_set_ctx_params(wp_Tls1Prf_Ctx* ctx,
     const OSSL_PARAM params[])
 {
     int ok = 1;
+
+    WOLFPROV_ENTER(WP_LOG_TLS1_PRF, "wp_kdf_tls1_prf_set_ctx_params");
 
     if (params != NULL) {
         if (!wp_params_get_digest(params, NULL, ctx->provCtx->libCtx,
@@ -301,6 +307,8 @@ static int wp_kdf_tls1_prf_get_ctx_params(wp_Tls1Prf_Ctx* ctx,
 {
     int ok = 1;
     OSSL_PARAM *p;
+
+    WOLFPROV_ENTER(WP_LOG_TLS1_PRF, "wp_kdf_tls1_prf_get_ctx_params");
 
     (void)ctx;
 

--- a/src/wp_tls_capa.c
+++ b/src/wp_tls_capa.c
@@ -151,6 +151,8 @@ static int wp_tls_group_capability(OSSL_CALLBACK *cb, void *arg)
     int ok = 1;
     size_t i;
 
+    WOLFPROV_ENTER(WP_LOG_PROVIDER, "wp_tls_group_capability");
+
     for (i = 0; i < WP_PARAM_GROUP_CNT; i++) {
         if (!cb(wp_param_group_list[i], arg)) {
             ok = 0;
@@ -178,6 +180,8 @@ int wolfssl_prov_get_capabilities(void *provCtx, const char *capability,
     OSSL_CALLBACK *cb, void *arg)
 {
     int ok = 0;
+
+    WOLFPROV_ENTER(WP_LOG_PROVIDER, "wolfssl_prov_get_capabilities");
 
     (void)provCtx;
 

--- a/src/wp_wolfprov.c
+++ b/src/wp_wolfprov.c
@@ -78,6 +78,8 @@ static const OSSL_PARAM* wolfprov_gettable_params(void* provCtx)
  */
 int wolfssl_prov_is_running(void)
 {
+    WOLFPROV_ENTER(WP_LOG_PROVIDER, "wolfssl_prov_is_running");
+
 #ifdef WP_CHECK_FORCE_FAIL
     if (forceFail) {
       WOLFPROV_LEAVE(WP_LOG_PROVIDER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), 0);
@@ -183,6 +185,8 @@ static int bio_core_puts(BIO *bio, const char *str)
 
 static int bio_core_new(BIO *bio)
 {
+    WOLFPROV_ENTER(WP_LOG_PROVIDER, "bio_core_new");
+
     BIO_set_init(bio, 1);
 
     WOLFPROV_LEAVE(WP_LOG_PROVIDER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), 1);
@@ -191,6 +195,8 @@ static int bio_core_new(BIO *bio)
         
 static int bio_core_free(BIO *bio)
 {
+    WOLFPROV_ENTER(WP_LOG_PROVIDER, "bio_core_free");
+
     BIO_set_init(bio, 0);
     wolfssl_prov_bio_free(BIO_get_data(bio));
     
@@ -303,6 +309,8 @@ static int wolfprov_get_params(void* provCtx, OSSL_PARAM params[])
 {
     int ok = 1;
     OSSL_PARAM* p;
+
+    WOLFPROV_ENTER(WP_LOG_PROVIDER, "wolfprov_get_params");
 
     (void)provCtx;
 
@@ -948,6 +956,8 @@ static int wp_dummy_decode(WOLFPROV_CTX* ctx, OSSL_CORE_BIO* cBio,
     int selection, OSSL_CALLBACK* dataCb, void* dataCbArg,
     OSSL_PASSPHRASE_CALLBACK* pwCb, void* pwCbArg)
 {
+    WOLFPROV_ENTER(WP_LOG_PROVIDER, "wp_dummy_decode");
+
     (void)ctx;
     (void)cBio;
     (void)selection;
@@ -1105,6 +1115,9 @@ static const OSSL_ALGORITHM* wolfprov_query(void* provCtx, int id,
 {
     const OSSL_ALGORITHM* alg;
 
+    WOLFPROV_ENTER(WP_LOG_QUERY, "wolfprov_query");
+    WOLFPROV_MSG_DEBUG(WP_LOG_QUERY, "Query operation ID: %d", id);
+
     (void)provCtx;
 
     *no_cache = 0;
@@ -1154,6 +1167,7 @@ static const OSSL_ALGORITHM* wolfprov_query(void* provCtx, int id,
             break;
     }
 
+    WOLFPROV_LEAVE(WP_LOG_QUERY, "wolfprov_query", (alg != NULL) ? 1 : 0);
     return alg;
 }
 
@@ -1220,6 +1234,8 @@ int wolfssl_provider_init(const OSSL_CORE_HANDLE* handle,
     const OSSL_DISPATCH* in, const OSSL_DISPATCH** out, void** provCtx)
 {
     int ok = 1;
+
+    WOLFPROV_ENTER(WP_LOG_PROVIDER, "wolfssl_provider_init");
 
 #ifdef WOLFPROV_DEBUG
     ok = (wolfProv_Debugging_ON() == 0);


### PR DESCRIPTION
# Description

- Added a  `WOLFPROV_ENTER` for every `WOLFPROV_LEAVE` in src... 
- Added new `WOLFPROV_MSG_DEBUG` and `WOLFPROV_MSG_TRACE` for higher levels of debug output
- Created bitmaps for `wolfProv_LogType` and `wolfProv_LogComponents` that allows us to select any pair of debug level and any pair of components.
- Created a certain `WP_LOG_QUERY` category that allows us to see the operation ID when we do a query
- Added debug for hkdf, kdf, and krb5 and any missing enter / leave debugging we didnt have in place