### PR TITLE
Support for WOLFPROV_LEAVE_SILENT return 0 suppression

### DIFF
--- a/include/wolfprovider/wp_logging.h
+++ b/include/wolfprovider/wp_logging.h
@@ -42,6 +42,17 @@
 #define WOLFPROV_MAX_LOG_WIDTH 120
 #endif
 
+
+/* Helper macro to select function name for logging */
+#if defined(_WIN32)
+    #define WOLFPROV_FUNC_NAME __FUNCTION__
+#elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
+    #define WOLFPROV_FUNC_NAME __func__
+#else
+    #define WOLFPROV_FUNC_NAME ""
+#endif
+
+
 /* wolfProv debug logging support can be compiled in by defining
  * WOLFPROV_DEBUG or by using the --enable-debug configure option.
  *
@@ -236,18 +247,14 @@ int wolfProv_SetLogComponents(int componentMask);
     WOLFPROV_ERROR_FUNC_NULL_LINE(type, funcName, ret, __FILE__, __LINE__)
 
 void WOLFPROV_ENTER(int type, const char* msg);
-/* Call the extended version of the API with the function name of the caller. */
-#ifdef _WIN32
-    #define WOLFPROV_LEAVE(type, msg, ret) \
-        WOLFPROV_LEAVE_EX(type, __FUNCTION__, msg, ret)
-#elif __STDC__ && __STDC_VERSION__ >= 199901L
-    #define WOLFPROV_LEAVE(type, msg, ret) \
-        WOLFPROV_LEAVE_EX(type, __func__, msg, ret)
-#else
-    #define WOLFPROV_LEAVE(type, msg, ret) \
-        WOLFPROV_LEAVE_EX(type, "", msg, ret)
-#endif
+void WOLFPROV_ENTER_NOEXIT(int type, const char* msg);
+#define WOLFPROV_LEAVE(type, msg, ret) \
+    WOLFPROV_LEAVE_EX(type, WOLFPROV_FUNC_NAME, msg, ret)
 void WOLFPROV_LEAVE_EX(int type, const char* func, const char* msg, int ret);
+#define WOLFPROV_LEAVE_SILENT(type, msg, matched, ret) \
+    WOLFPROV_LEAVE_SILENT_EX(type, WOLFPROV_FUNC_NAME, msg, matched, ret)
+void WOLFPROV_LEAVE_SILENT_EX(int type, const char* func, const char* msg,
+    int matched, int ret);
 void WOLFPROV_MSG(int type, const char* fmt, ...);
 void WOLFPROV_MSG_VERBOSE(int type, const char* fmt, ...);
 void WOLFPROV_MSG_DEBUG(int type, const char* fmt, ...);
@@ -265,7 +272,9 @@ void WOLFPROV_BUFFER(int type, const unsigned char* buffer,
 #else /* WOLFPROV_DEBUG */
 
 #define WOLFPROV_ENTER(t, m)
+#define WOLFPROV_ENTER_NOEXIT(t, m)
 #define WOLFPROV_LEAVE(t, m, r)
+#define WOLFPROV_LEAVE_SILENT(t, f, m, r)
 #define WOLFPROV_MSG(t, m, ...)
 #define WOLFPROV_MSG_VERBOSE(t, m, ...)
 #define WOLFPROV_MSG_DEBUG(t, m, ...)

--- a/scripts/build-wolfprovider.sh
+++ b/scripts/build-wolfprovider.sh
@@ -20,6 +20,7 @@ show_help() {
   echo "  --fips-version=VER         Choose the wolfSSL FIPS version"
   echo "  --debian                   Build a Debian package"
   echo "  --quicktest                Disable some tests for a faster testing suite"
+  echo "  --leave-silent             Enable leave silent mode to suppress return 0 logging in probing functions"
   echo ""
   echo "Environment Variables:"
   echo "  OPENSSL_TAG                OpenSSL tag to use (e.g., openssl-3.5.0)"
@@ -112,6 +113,9 @@ for arg in "$@"; do
             ;;
         --quicktest)
             WOLFPROV_QUICKTEST=1
+            ;;
+        --leave-silent)
+            WOLFPROV_LEAVE_SILENT=1
             ;;
         *)
             args_wrong+="$arg, "

--- a/scripts/utils-wolfprovider.sh
+++ b/scripts/utils-wolfprovider.sh
@@ -78,6 +78,10 @@ install_wolfprov() {
         WOLFPROV_CONFIG_OPTS+=" --enable-debug"
     fi
 
+    if [ "${WOLFPROV_LEAVE_SILENT}" = "1" ]; then
+        WOLFPROV_CONFIG_CFLAGS="${WOLFPROV_CONFIG_CFLAGS} -DWOLFPROV_LEAVE_SILENT_MODE"
+    fi
+
     ./configure ${WOLFPROV_CONFIG_OPTS} CFLAGS="${WOLFPROV_CONFIG_CFLAGS}" >>$LOG_FILE 2>&1
     RET=$?
 

--- a/src/wp_dh_kmgmt.c
+++ b/src/wp_dh_kmgmt.c
@@ -2027,10 +2027,11 @@ extern int wc_DhPublicKeyDecode(const byte* input, word32* inOutIdx, DhKey* key,
 static int wp_dh_decode_spki(wp_Dh* dh, unsigned char* data, word32 len)
 {
     int ok = 1;
+    int matched = 0;
     int rc;
     word32 idx = 0;
 
-    WOLFPROV_ENTER(WP_LOG_DH, "wp_dh_decode_spki");
+    WOLFPROV_ENTER_NOEXIT(WP_LOG_DH, "wp_dh_decode_spki");
 
     rc = wc_DhPublicKeyDecode(data, &idx, &dh->key, len);
     if (rc != 0) {
@@ -2051,9 +2052,12 @@ static int wp_dh_decode_spki(wp_Dh* dh, unsigned char* data, word32 len)
     }
     if (ok) {
         dh->bits = mp_count_bits(&dh->key.p);
+        matched = 1;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_DH, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE_SILENT(WP_LOG_DH, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__),
+        matched, ok);
+    (void)matched;
     return ok;
 }
 #else
@@ -2088,11 +2092,12 @@ static int wp_dh_decode_spki(wp_Dh* dh, unsigned char* data, word32 len)
 static int wp_dh_decode_pki(wp_Dh* dh, unsigned char* data, word32 len)
 {
     int ok = 1;
+    int matched = 0;
     int rc;
     word32 idx = 0;
     unsigned char* base = NULL;
 
-    WOLFPROV_ENTER(WP_LOG_DH, "wp_dh_decode_pki");
+    WOLFPROV_ENTER_NOEXIT(WP_LOG_DH, "wp_dh_decode_pki");
 
     rc = wc_DhKeyDecode(data, &idx, &dh->key, len);
     if (rc != 0) {
@@ -2140,10 +2145,13 @@ static int wp_dh_decode_pki(wp_Dh* dh, unsigned char* data, word32 len)
     if (ok) {
         dh->pubSz = idx;
         dh->bits = mp_count_bits(&dh->key.p);
+        matched = 1;
     }
 
     OPENSSL_free(base);
-    WOLFPROV_LEAVE(WP_LOG_DH, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE_SILENT(WP_LOG_DH, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__),
+        matched, ok);
+    (void)matched;
     return ok;
 }
 #else
@@ -2177,10 +2185,11 @@ static int wp_dh_decode_pki(wp_Dh* dh, unsigned char* data, word32 len)
 static int wp_dh_decode_params(wp_Dh* dh, unsigned char* data, word32 len)
 {
     int ok = 1;
+    int matched = 0;
     int rc;
     word32 idx = 0;
 
-    WOLFPROV_ENTER(WP_LOG_DH, "wp_dh_decode_params");
+    WOLFPROV_ENTER_NOEXIT(WP_LOG_DH, "wp_dh_decode_params");
 
     rc = wc_DhKeyDecode(data, &idx, &dh->key, len);
     if (rc != 0) {
@@ -2188,9 +2197,12 @@ static int wp_dh_decode_params(wp_Dh* dh, unsigned char* data, word32 len)
     }
     if (ok) {
         dh->bits = mp_count_bits(&dh->key.p);
+        matched = 1;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_DH, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE_SILENT(WP_LOG_DH, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__),
+        matched, ok);
+    (void)matched;
     return ok;
 }
 
@@ -2820,19 +2832,26 @@ static int wp_dh_type_specific_does_selection(WOLFPROV_CTX* provCtx,
     int selection)
 {
     int ok;
+    int matched = 0;
 
-    WOLFPROV_ENTER(WP_LOG_DH, "wp_dh_type_specific_does_selection");
+    WOLFPROV_ENTER_NOEXIT(WP_LOG_DH, "wp_dh_type_specific_does_selection");
 
     (void)provCtx;
 
     if (selection == 0) {
         ok = 1;
+        matched = 1;
     }
     else {
         ok = (selection & OSSL_KEYMGMT_SELECT_ALL_PARAMETERS) != 0;
+        if (ok) {
+            matched = 1;
+        }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_DH, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE_SILENT(WP_LOG_DH, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__),
+        matched, ok);
+    (void)matched;
     return ok;
 }
 
@@ -2936,19 +2955,26 @@ static wp_DhEncDecCtx* wp_dh_spki_dec_new(WOLFPROV_CTX* provCtx)
 static int wp_dh_spki_does_selection(WOLFPROV_CTX* provCtx, int selection)
 {
     int ok;
+    int matched = 0;
 
-    WOLFPROV_ENTER(WP_LOG_DH, "wp_dh_spki_does_selection");
+    WOLFPROV_ENTER_NOEXIT(WP_LOG_DH, "wp_dh_spki_does_selection");
 
     (void)provCtx;
 
     if (selection == 0) {
         ok = 1;
+        matched = 1;
     }
     else {
         ok = (selection & OSSL_KEYMGMT_SELECT_PUBLIC_KEY) != 0;
+        if (ok) {
+            matched = 1;
+        }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_DH, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE_SILENT(WP_LOG_DH, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__),
+        matched, ok);
+    (void)matched;
     return ok;
 }
 
@@ -3047,19 +3073,26 @@ static wp_DhEncDecCtx* wp_dh_pki_dec_new(WOLFPROV_CTX* provCtx)
 static int wp_dh_pki_does_selection(WOLFPROV_CTX* provCtx, int selection)
 {
     int ok;
+    int matched = 0;
 
-    WOLFPROV_ENTER(WP_LOG_DH, "wp_dh_pki_does_selection");
+    WOLFPROV_ENTER_NOEXIT(WP_LOG_DH, "wp_dh_pki_does_selection");
 
     (void)provCtx;
 
     if (selection == 0) {
         ok = 1;
+        matched = 1;
     }
     else {
         ok = (selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY) != 0;
+        if (ok) {
+            matched = 1;
+        }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_DH, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE_SILENT(WP_LOG_DH, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__),
+        matched, ok);
+    (void)matched;
     return ok;
 }
 

--- a/src/wp_ecc_kmgmt.c
+++ b/src/wp_ecc_kmgmt.c
@@ -2003,10 +2003,11 @@ static int wp_ecc_get_curve_id_from_oid(unsigned char* oid, int len)
 static int wp_ecc_decode_params(wp_Ecc* ecc, unsigned char* data, word32 len)
 {
     int ok = 1;
+    int matched = 0;
     int rc;
     word32 oidLen;
 
-    WOLFPROV_ENTER(WP_LOG_ECC, "wp_ecc_decode_params");
+    WOLFPROV_ENTER_NOEXIT(WP_LOG_ECC, "wp_ecc_decode_params");
 
     /* TODO: manually decoding as wolfSSL doesn't offer API to do this. */
     if (len < 3) {
@@ -2047,22 +2048,40 @@ static int wp_ecc_decode_params(wp_Ecc* ecc, unsigned char* data, word32 len)
         ok = 0;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_ECC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    if (ok) {
+        matched = 1;
+    }
+    
+    WOLFPROV_LEAVE_SILENT(WP_LOG_ECC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__),
+        matched, ok);
+    (void)matched;
     return ok;
 }
 
+
+/**
+ * Decode the DER encoded ECC parameters (OID) into the ECC key object.
+ *
+ * @param [in, out] ecc   ECC key object.
+ * @param [in]      data  DER encoding of the parameters (OID).
+ * @param [in]      len   Length, in bytes, of DER encoding.
+ * @return  1 on success.
+ * @return  0 on failure.
+ */
 static int wp_ecc_decode_x963_pub(wp_Ecc* ecc, unsigned char* data, word32 len)
 {
     int ok = 1;
     int rc;
+    int matched = 0;
 
-    WOLFPROV_ENTER(WP_LOG_ECC, "wp_ecc_decode_x963_pub");
+    WOLFPROV_ENTER_NOEXIT(WP_LOG_ECC, "wp_ecc_decode_x963_pub");
 
     rc = wc_ecc_import_x963((const byte *)data, len, &ecc->key);
     if (rc != 0) {
         ok = 0;
     }
     if (ok) {
+        matched = 1;
         ecc->curveId = ecc->key.dp->id;
         ecc->hasPub = 1;
         /* Needs curveId set. */
@@ -2071,7 +2090,9 @@ static int wp_ecc_decode_x963_pub(wp_Ecc* ecc, unsigned char* data, word32 len)
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_ECC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE_SILENT(WP_LOG_ECC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__),
+        matched, ok);
+    (void)matched;
     return ok;
 }
 
@@ -2087,10 +2108,11 @@ static int wp_ecc_decode_x963_pub(wp_Ecc* ecc, unsigned char* data, word32 len)
 static int wp_ecc_decode_spki(wp_Ecc* ecc, unsigned char* data, word32 len)
 {
     int ok = 1;
+    int matched = 0;
     int rc;
     word32 idx = 0;
 
-    WOLFPROV_ENTER(WP_LOG_ECC, "wp_ecc_decode_spki");
+    WOLFPROV_ENTER_NOEXIT(WP_LOG_ECC, "wp_ecc_decode_spki");
 
     if (!wolfssl_prov_is_running()) {
         ok = 0;
@@ -2110,7 +2132,12 @@ static int wp_ecc_decode_spki(wp_Ecc* ecc, unsigned char* data, word32 len)
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_ECC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    if (ok) {
+        matched = 1;
+    }
+    WOLFPROV_LEAVE_SILENT(WP_LOG_ECC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__),
+        matched, ok);
+    (void)matched;
     return ok;
 }
 
@@ -2126,10 +2153,11 @@ static int wp_ecc_decode_spki(wp_Ecc* ecc, unsigned char* data, word32 len)
 static int wp_ecc_decode_pki(wp_Ecc* ecc, unsigned char* data, word32 len)
 {
     int ok = 1;
+    int matched = 0;
     int rc;
     word32 idx = 0;
 
-    WOLFPROV_ENTER(WP_LOG_ECC, "wp_ecc_decode_pki");
+    WOLFPROV_ENTER_NOEXIT(WP_LOG_ECC, "wp_ecc_decode_pki");
 
     if (!wolfssl_prov_is_running()) {
         ok = 0;
@@ -2171,7 +2199,12 @@ static int wp_ecc_decode_pki(wp_Ecc* ecc, unsigned char* data, word32 len)
         ecc->hasPub = 1;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_ECC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    if (ok) {
+        matched = 1;
+    }
+    WOLFPROV_LEAVE_SILENT(WP_LOG_ECC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__),
+        matched, ok);
+    (void)matched;
     return ok;
 }
 
@@ -2920,19 +2953,26 @@ static int wp_ecc_type_specific_does_selection(WOLFPROV_CTX* provCtx,
     int selection)
 {
     int ok;
+    int matched = 0;
 
-    WOLFPROV_ENTER(WP_LOG_ECC, "wp_ecc_type_specific_does_selection");
+    WOLFPROV_ENTER_NOEXIT(WP_LOG_ECC, "wp_ecc_type_specific_does_selection");
 
     (void)provCtx;
 
     if (selection == 0) {
         ok = 1;
+        matched = 1;
     }
     else {
         ok = (selection & OSSL_KEYMGMT_SELECT_ALL_PARAMETERS) != 0;
+        if (ok) {
+            matched = 1;
+        }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_ECC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE_SILENT(WP_LOG_ECC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__),
+        matched, ok);
+    (void)matched;
     return ok;
 }
 
@@ -3037,19 +3077,26 @@ static wp_EccEncDecCtx* wp_ecc_spki_dec_new(WOLFPROV_CTX* provCtx)
 static int wp_ecc_spki_does_selection(WOLFPROV_CTX* provCtx, int selection)
 {
     int ok;
+    int matched = 0;
 
-    WOLFPROV_ENTER(WP_LOG_ECC, "wp_ecc_spki_does_selection");
+    WOLFPROV_ENTER_NOEXIT(WP_LOG_ECC, "wp_ecc_spki_does_selection");
 
     (void)provCtx;
 
     if (selection == 0) {
         ok = 1;
+        matched = 1;
     }
     else {
         ok = (selection & OSSL_KEYMGMT_SELECT_PUBLIC_KEY) != 0;
+        if (ok) {
+            matched = 1;
+        }
     }
-
-    WOLFPROV_LEAVE(WP_LOG_ECC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    
+    WOLFPROV_LEAVE_SILENT(WP_LOG_ECC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__),
+        matched, ok);
+    (void)matched;
     return ok;
 }
 
@@ -3148,19 +3195,26 @@ static wp_EccEncDecCtx* wp_ecc_pki_dec_new(WOLFPROV_CTX* provCtx)
 static int wp_ecc_pki_does_selection(WOLFPROV_CTX* provCtx, int selection)
 {
     int ok;
+    int matched = 0;
 
-    WOLFPROV_ENTER(WP_LOG_ECC, "wp_ecc_pki_does_selection");
+    WOLFPROV_ENTER_NOEXIT(WP_LOG_ECC, "wp_ecc_pki_does_selection");
 
     (void)provCtx;
 
     if (selection == 0) {
         ok = 1;
+        matched = 1;
     }
     else {
         ok = (selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY) != 0;
+        if (ok) {
+            matched = 1;
+        }
     }
-
-    WOLFPROV_LEAVE(WP_LOG_ECC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    
+    WOLFPROV_LEAVE_SILENT(WP_LOG_ECC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__),
+        matched, ok);
+    (void)matched;
     return ok;
 }
 
@@ -3320,20 +3374,27 @@ static int wp_ecc_x9_62_does_selection(WOLFPROV_CTX* provCtx,
     int selection)
 {
     int ok;
+    int matched = 0;
 
-    WOLFPROV_ENTER(WP_LOG_ECC, "wp_ecc_x9_62_does_selection");
+    WOLFPROV_ENTER_NOEXIT(WP_LOG_ECC, "wp_ecc_x9_62_does_selection");
 
     (void)provCtx;
 
     if (selection == 0) {
         ok = 1;
+        matched = 1;
     }
     else {
         ok = (selection & (OSSL_KEYMGMT_SELECT_ALL_PARAMETERS |
                            OSSL_KEYMGMT_SELECT_PRIVATE_KEY)) != 0;
+        if (ok) {
+            matched = 1;
+        }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_ECC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE_SILENT(WP_LOG_ECC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__),
+        matched, ok);
+    (void)matched;
     return ok;
 }
 

--- a/src/wp_ecx_kmgmt.c
+++ b/src/wp_ecx_kmgmt.c
@@ -2195,19 +2195,26 @@ static int wp_ecx_export_object(wp_EcxEncDecCtx* ctx, wp_Ecx* ecx, size_t size,
 static int wp_ecx_spki_does_selection(WOLFPROV_CTX* provCtx, int selection)
 {
     int ok = 0;
+    int matched = 0;
 
-    WOLFPROV_ENTER(WP_LOG_KE, "wp_ecx_spki_does_selection");
+    WOLFPROV_ENTER_NOEXIT(WP_LOG_KE, "wp_ecx_spki_does_selection");
 
     (void)provCtx;
 
     if (selection == 0) {
         ok = 1;
+        matched = 1;
     }
     else {
         ok = (selection & OSSL_KEYMGMT_SELECT_PUBLIC_KEY) != 0;
+        if (ok) {
+            matched = 1;
+        }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE_SILENT(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__),
+        matched, ok);
+    (void)matched;
     return ok;
 }
 
@@ -2226,19 +2233,26 @@ static int wp_ecx_spki_does_selection(WOLFPROV_CTX* provCtx, int selection)
 static int wp_ecx_pki_does_selection(WOLFPROV_CTX* provCtx, int selection)
 {
     int ok;
+    int matched = 0;
 
-    WOLFPROV_ENTER(WP_LOG_KE, "wp_ecx_pki_does_selection");
+    WOLFPROV_ENTER_NOEXIT(WP_LOG_KE, "wp_ecx_pki_does_selection");
 
     (void)provCtx;
 
     if (selection == 0) {
         ok = 1;
+        matched = 1;
     }
     else {
         ok = (selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY) != 0;
+        if (ok) {
+            matched = 1;
+        }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE_SILENT(WP_LOG_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__),
+        matched, ok);
+    (void)matched;
     return ok;
 }
 

--- a/src/wp_logging.c
+++ b/src/wp_logging.c
@@ -280,6 +280,27 @@ void WOLFPROV_ENTER(int component, const char* msg)
 }
 
 /**
+ * Log function used to record function entry for check functions.
+ * These functions use WOLFPROV_LEAVE_SILENT and may not show up in logs.
+ * The "[NOEXIT]" prefix indicates that exit logging may be suppressed.
+ *
+ * @param component [IN] Component type, from wolfProv_LogComponents enum.
+ * @param msg  [IN] Log message.
+ */
+void WOLFPROV_ENTER_NOEXIT(int component, const char* msg)
+{
+    if (loggingEnabled) {
+#ifdef WOLFPROV_LEAVE_SILENT_MODE
+        char buffer[WOLFPROV_MAX_LOG_WIDTH];
+        XSNPRINTF(buffer, sizeof(buffer), "wolfProv Entering [NOEXIT] %s", msg);
+        wolfprovider_log(WP_LOG_ENTER, component, buffer);
+#else
+        WOLFPROV_ENTER(component, msg);
+#endif
+    }
+}
+
+/**
  * Log function used to record function exit. Extended for function name.
  *
  * @param component [IN] Component type, from wolfProv_LogComponents enum.
@@ -288,13 +309,45 @@ void WOLFPROV_ENTER(int component, const char* msg)
  * @param ret  [IN] Value that function will be returning.
  */
 void WOLFPROV_LEAVE_EX(int component, const char* func, const char* msg,
-    int ret)
+                         int ret)
 {
     if (loggingEnabled) {
         char buffer[WOLFPROV_MAX_LOG_WIDTH];
         XSNPRINTF(buffer, sizeof(buffer), "wolfProv Leaving %s, return %d (%s)",
                   msg, ret, func);
         wolfprovider_log(WP_LOG_LEAVE, component, buffer);
+    }
+}
+
+/**
+ * Log function to suppress LEAVE messages. This function only prints if
+ * ret == 1 AND matched is set. All other cases are suppressed by default
+ * to reduce noise from probe failures. Define WOLFPROV_LEAVE_SILENT to 
+ * enable this logic.
+ *
+ * @param component [IN] Component type, from wolfProv_LogComponents enum.
+ * @param func    [IN] Name of function that is exiting.
+ * @param msg     [IN] Log message (typically file:line).
+ * @param matched [IN] Nonzero if the probe envelope matched.
+ * @param ret     [IN] Value that function will be returning.
+ */
+void WOLFPROV_LEAVE_SILENT_EX(int component, const char* func, 
+                              const char* msg, int matched, int ret)
+{
+    if (loggingEnabled) {
+#ifdef WOLFPROV_LEAVE_SILENT_MODE
+        /* Success with match - always print */
+        if (ret == 1 && matched == 1) {
+            WOLFPROV_LEAVE_EX(component, func, msg, ret);
+        }
+        else {
+            /* Anything else is suppressed */
+        }
+#else
+        (void)matched;
+        /* Legacy behavior: log all returns including return 0 */
+        WOLFPROV_LEAVE_EX(component, func, msg, ret);
+#endif
     }
 }
 

--- a/src/wp_rsa_kmgmt.c
+++ b/src/wp_rsa_kmgmt.c
@@ -1990,20 +1990,24 @@ static int wp_rsa_find_oid(unsigned char* data, word32 len, unsigned char* oid,
     word32 oidLen, word32* offset)
 {
     int ok = 0;
+    int matched = 0;
     word32 i;
 
-    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsa_find_oid");
+    WOLFPROV_ENTER_NOEXIT(WP_LOG_RSA, "wp_rsa_find_oid");
 
     for (i = 0; i < len - RSA_PKCS1_OID_SZ - 1; i++) {
         /* Find the base OID. */
         if (XMEMCMP(data + i, oid, oidLen) == 0) {
             ok = 1;
+            matched = 1;  /* Found the OID */
             *offset = i;
             break;
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE_SILENT(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__),
+        matched, ok);
+    (void)matched;
     return ok;
 }
 
@@ -2192,10 +2196,11 @@ static int wp_rsa_pss_get_params(wp_Rsa* rsa, unsigned char* data, word32 len)
 static int wp_rsa_decode_spki(wp_Rsa* rsa, unsigned char* data, word32 len)
 {
     int ok = 1;
+    int matched = 0;
     int rc;
     word32 idx = 0;
 
-    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsa_decode_spki");
+    WOLFPROV_ENTER_NOEXIT(WP_LOG_RSA, "wp_rsa_decode_spki");
 
     if (!wolfssl_prov_is_running()) {
         ok = 0;
@@ -2215,14 +2220,19 @@ static int wp_rsa_decode_spki(wp_Rsa* rsa, unsigned char* data, word32 len)
          * keys. If we dont reject then the keytype gets set to RSA-PSS
          * which is wrong. For non-pkcs8 fail here for PSS decoder
          * and let the base RSA pick it up instead */
-        ok = wp_rsa_pss_get_params(rsa, data, len);
+        if (!wp_rsa_pss_get_params(rsa, data, len)) {
+            ok = 0;
+        }
     }
     if (ok) {
         rsa->bits = wc_RsaEncryptSize(&rsa->key) * 8;
         rsa->hasPub = 1;
+        matched = 1;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE_SILENT(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__),
+        matched, ok);
+    (void)matched;
     return ok;
 }
 
@@ -2238,10 +2248,11 @@ static int wp_rsa_decode_spki(wp_Rsa* rsa, unsigned char* data, word32 len)
 static int wp_rsa_decode_pki(wp_Rsa* rsa, unsigned char* data, word32 len)
 {
     int ok = 1;
+    int matched = 0;
     int rc;
     word32 idx = 0;
 
-    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsa_decode_pki");
+    WOLFPROV_ENTER_NOEXIT(WP_LOG_RSA, "wp_rsa_decode_pki");
 
     if (!wolfssl_prov_is_running()) {
         ok = 0;
@@ -2260,7 +2271,7 @@ static int wp_rsa_decode_pki(wp_Rsa* rsa, unsigned char* data, word32 len)
         if (rc >= 0) {
             rc = wc_RsaPrivateKeyDecode(data, &idx, &rsa->key, len);
             if (rc == 0) {
-                 ok = 1;
+                ok = 1;
             }
         }
     }
@@ -2269,15 +2280,20 @@ static int wp_rsa_decode_pki(wp_Rsa* rsa, unsigned char* data, word32 len)
         ok = 0;
     }
     if (ok && (rsa->type == RSA_FLAG_TYPE_RSASSAPSS)) {
-        ok = wp_rsa_pss_get_params(rsa, data, len);
+        if (!wp_rsa_pss_get_params(rsa, data, len)) {
+            ok = 0;
+        }
     }
     if (ok) {
         rsa->bits = wc_RsaEncryptSize(&rsa->key) * 8;
         rsa->hasPub = 1;
         rsa->hasPriv = 1;
+        matched = 1;
     }
 
-    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE_SILENT(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__),
+        matched, ok);
+    (void)matched;
     return ok;
 }
 
@@ -2301,19 +2317,23 @@ unsigned char pbkdf2_oid[] = {
 static int wp_rsa_find_pbkdf2_oid(unsigned char* data, word32 len)
 {
     int ok = 0;
+    int matched = 0;
     word32 i;
 
-    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsa_find_pbkdf2_oid");
+    WOLFPROV_ENTER_NOEXIT(WP_LOG_RSA, "wp_rsa_find_pbkdf2_oid");
 
     for (i = 0; i < 40 && i + PBKDF2_OID_SZ < len; i++) {
         /* Find the base OID. */
         if (XMEMCMP(data + i, pbkdf2_oid, PBKDF2_OID_SZ) == 0) {
             ok = 1;
+            matched = 1;  /* Found the PBKDF2 OID */
             break;
         }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE_SILENT(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__),
+        matched, ok);
+    (void)matched;
     return ok;
 }
 
@@ -2329,13 +2349,14 @@ static int wp_rsa_find_pbkdf2_oid(unsigned char* data, word32 len)
  * @return  0 on failure.
  */
 static int wp_rsa_decode_enc_pki(wp_Rsa* rsa, unsigned char* data, word32 len,
-     OSSL_PASSPHRASE_CALLBACK* pwCb, void* pwCbArg)
+    OSSL_PASSPHRASE_CALLBACK* pwCb, void* pwCbArg)
 {
     int ok = 1;
+    int matched = 0;
     char password[1024];
     size_t passwordSz = sizeof(password);
 
-    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsa_decode_enc_pki");
+    WOLFPROV_ENTER_NOEXIT(WP_LOG_RSA, "wp_rsa_decode_enc_pki");
     
     if (!wolfssl_prov_is_running()) {
         ok = 0;
@@ -2363,9 +2384,14 @@ static int wp_rsa_decode_enc_pki(wp_Rsa* rsa, unsigned char* data, word32 len,
     if (ok) {
         /* Decode private key. */
         ok = wp_rsa_decode_pki(rsa, data, len);
+        if (ok) {
+            matched = 1;
+        }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE_SILENT(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__),
+        matched, ok);
+    (void)matched;
     return ok;
 }
 
@@ -3409,19 +3435,26 @@ static wp_RsaEncDecCtx* wp_rsa_spki_dec_new(WOLFPROV_CTX* provCtx)
 static int wp_rsa_spki_does_selection(WOLFPROV_CTX* provCtx, int selection)
 {
     int ok;
+    int matched = 0;
 
-    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsa_spki_does_selection");
+    WOLFPROV_ENTER_NOEXIT(WP_LOG_RSA, "wp_rsa_spki_does_selection");
 
     (void)provCtx;
 
     if (selection == 0) {
         ok = 1;
+        matched = 1;
     }
     else {
         ok = (selection & OSSL_KEYMGMT_SELECT_PUBLIC_KEY) != 0;
+        if (ok) {
+            matched = 1;
+        }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE_SILENT(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__),
+        matched, ok);
+    (void)matched;
     return ok;
 }
 
@@ -3523,19 +3556,26 @@ static wp_RsaEncDecCtx* wp_rsa_pki_dec_new(WOLFPROV_CTX* provCtx)
 static int wp_rsa_pki_does_selection(WOLFPROV_CTX* provCtx, int selection)
 {
     int ok;
+    int matched = 0;
 
-    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsa_pki_does_selection");
+    WOLFPROV_ENTER_NOEXIT(WP_LOG_RSA, "wp_rsa_pki_does_selection");
 
     (void)provCtx;
 
     if (selection == 0) {
         ok = 1;
+        matched = 1;
     }
     else {
         ok = (selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY) != 0;
+        if (ok) {
+            matched = 1;
+        }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE_SILENT(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__),
+        matched, ok);
+    (void)matched;
     return ok;
 }
 
@@ -3699,19 +3739,26 @@ static wp_RsaEncDecCtx* wp_rsa_legacy_dec_new(WOLFPROV_CTX* provCtx)
 static int wp_rsa_legacy_does_selection(WOLFPROV_CTX* provCtx, int selection)
 {
     int ok;
+    int matched = 0;
 
-    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsa_legacy_does_selection");
+    WOLFPROV_ENTER_NOEXIT(WP_LOG_RSA, "wp_rsa_legacy_does_selection");
 
     (void)provCtx;
 
     if (selection == 0) {
         ok = 1;
+        matched = 1;
     }
     else {
         ok = (selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY) != 0;
+        if (ok) {
+            matched = 1;
+        }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE_SILENT(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__),
+        matched, ok);
+    (void)matched;
     return ok;
 }
 
@@ -3753,19 +3800,26 @@ static wp_RsaEncDecCtx* wp_rsa_kp_der_enc_new(WOLFPROV_CTX* provCtx)
 static int wp_rsa_kp_does_selection(WOLFPROV_CTX* provCtx, int selection)
 {
     int ok;
+    int matched = 0;
 
-    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsa_kp_does_selection");
+    WOLFPROV_ENTER_NOEXIT(WP_LOG_RSA, "wp_rsa_kp_does_selection");
 
     (void)provCtx;
 
     if (selection == 0) {
         ok = 1;
+        matched = 1;
     }
     else {
         ok = (selection & OSSL_KEYMGMT_SELECT_KEYPAIR) != 0;
+        if (ok) {
+            matched = 1;
+        }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE_SILENT(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__),
+        matched, ok);
+    (void)matched;
     return ok;
 }
 
@@ -4025,21 +4079,28 @@ static void wp_rsa_text_enc_free(wp_RsaEncDecCtx* ctx)
 static int wp_rsa_text_enc_does_selection(WOLFPROV_CTX* provCtx, int selection)
 {
     int ok;
+    int matched = 0;
 
-    WOLFPROV_ENTER(WP_LOG_RSA, "wp_rsa_text_enc_does_selection");
+    WOLFPROV_ENTER_NOEXIT(WP_LOG_RSA, "wp_rsa_text_enc_does_selection");
 
     (void)provCtx;
 
     /* Text encoder supports both public and private key parts */
     if (selection == 0) {
         ok = 1;
+        matched = 1;
     }
     else {
         ok = ((selection & OSSL_KEYMGMT_SELECT_PUBLIC_KEY) != 0) ||
              ((selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY) != 0);
+        if (ok) {
+            matched = 1;
+        }
     }
 
-    WOLFPROV_LEAVE(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE_SILENT(WP_LOG_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__),
+        matched, ok);
+    (void)matched;
     return ok;
 }
 


### PR DESCRIPTION
# Description 

- Adds a `WOLFPROV_LEAVE_SILENT` macro and `WOLFPROV_ENTER_NOEXIT` macro pair that can be used with `--debug` and `--leave-silent` to suppress decode functions called by `wp_*_decode()` and functions that return 0 but are not actually failures like `*_does_selection` functions. 
- This is not on by default because this could suppress real errors that return from decode functions. That said you can enable this but calling functions will need to be able to handle the failure case which in most cases would return correctly if called right. Either way in the output it will not show up.
- The `WOLFPROV_ENTER_NOEXIT` macro specifically adds a `[NOEXIT]` tag to the output of functions so users will know that there will be no leave function associated with the enter function. 
- The goal with this was to reduce the clutter of "false" return 0's we get in various tests. When testing the ./scripts/cmd_test/do-cmd-test.sh` we got 1092 return 0's with unit test we get 206. After our changes we get 30 and 127 respectively the failures in unit test are ofc neg testing failures and the 30 in cmd test are expected behavior but shouldn't be suppressed. 