### PR TITLE
Fix is_openssl_patched

### DIFF
--- a/.github/scripts/x11vnc/test_x11vnc.sh
+++ b/.github/scripts/x11vnc/test_x11vnc.sh
@@ -1,5 +1,19 @@
 #!/bin/bash
 
+# Usage: ./test_x11vnc.sh [log_file]
+# If no log file is provided, defaults to "x11vnc_test.log"
+
+# Set default log file
+LOG_FILE="${1:-x11vnc_test.log}"
+
+# Show usage if help is requested
+if [[ "$1" == "-h" || "$1" == "--help" ]]; then
+    echo "Usage: $0 [log_file]"
+    echo "  log_file: Path to the log file (default: x11vnc_test.log)"
+    echo "  -h, --help: Show this help message"
+    exit 0
+fi
+
 SCRIPTS_DIR="$GITHUB_WORKSPACE/.github/scripts/x11vnc"
 
 killall x11vnc > /dev/null 2> /dev/null
@@ -11,9 +25,9 @@ X11VNC_TEST_FAIL=0
 # CA / cert generation
 
 
-echo -e "\n\nTesting -sslGenCA\n" > x11vnc_test.log
+echo -e "\n\nTesting -sslGenCA\n" > "$LOG_FILE"
 
-$SCRIPTS_DIR/x11vnc_sslgenca.exp >> x11vnc_test.log 2>> x11vnc_test.log
+$SCRIPTS_DIR/x11vnc_sslgenca.exp >> "$LOG_FILE" 2>> "$LOG_FILE"
 
 if [ $? -eq 0 ] && [ -f "ca-dir/CA/cacert.pem" ] && [ -f "ca-dir/CA/private/cakey.pem" ]
 then
@@ -24,9 +38,9 @@ else
 fi
 
 
-echo -e "\n\nTesting -sslGenCert client\n" >> x11vnc_test.log
+echo -e "\n\nTesting -sslGenCert client\n" >> "$LOG_FILE"
 
-$SCRIPTS_DIR/x11vnc_sslgencert_client.exp >> x11vnc_test.log 2>> x11vnc_test.log
+$SCRIPTS_DIR/x11vnc_sslgencert_client.exp >> "$LOG_FILE" 2>> "$LOG_FILE"
 
 if [ $? -eq 0 ] && [ -f "ca-dir/clients/wolf.pem" ] && [ -f "ca-dir/clients/wolf.crt" ]
 then
@@ -37,9 +51,9 @@ else
 fi
 
 
-echo -e "\n\nTesting -sslGenCert server\n" >> x11vnc_test.log
+echo -e "\n\nTesting -sslGenCert server\n" >> "$LOG_FILE"
 
-$SCRIPTS_DIR/x11vnc_sslgencert_server.exp >> x11vnc_test.log 2>> x11vnc_test.log
+$SCRIPTS_DIR/x11vnc_sslgencert_server.exp >> "$LOG_FILE" 2>> "$LOG_FILE"
 
 if [ $? -eq 0 ] && [ -f "ca-dir/server-wolf.pem" ] && [ -f "ca-dir/server-wolf.crt" ]
 then
@@ -50,13 +64,13 @@ else
 fi
 
 
-echo -e "\n\nTesting -sslCertInfo\n" >> x11vnc_test.log
+echo -e "\n\nTesting -sslCertInfo\n" >> "$LOG_FILE"
 
 OPENSSL_CONF='' OPENSSL_MODULES='' timeout 5 x11vnc -sslCertInfo ca-dir/server-wolf.pem > cert_info_ossl.txt
 timeout 5 x11vnc -sslCertInfo ca-dir/server-wolf.pem > cert_info.txt
 
-if [ $? -eq 0 ] && diff -y cert_info.txt cert_info_ossl.txt >> x11vnc_test.log 2>> x11vnc_test.log \
-    && cat cert_info.txt >> x11vnc_test.log
+if [ $? -eq 0 ] && diff -y cert_info.txt cert_info_ossl.txt >> "$LOG_FILE" 2>> "$LOG_FILE" \
+    && cat cert_info.txt >> "$LOG_FILE"
 then
     echo "[ PASSED ] -sslCertInfo"
 else
@@ -65,9 +79,9 @@ else
 fi
 
 
-echo -e "\n\nTesting -sslEncKey\n" >> x11vnc_test.log
+echo -e "\n\nTesting -sslEncKey\n" >> "$LOG_FILE"
 
-$SCRIPTS_DIR/x11vnc_sslenckey.exp >> x11vnc_test.log 2>> x11vnc_test.log
+$SCRIPTS_DIR/x11vnc_sslenckey.exp >> "$LOG_FILE" 2>> "$LOG_FILE"
 
 if [ $? -eq 0 ] && grep -q "BEGIN ENCRYPTED PRIVATE KEY" ca-dir/server-wolf.pem
 then
@@ -83,12 +97,12 @@ fi
 
 # Setup Xvfb, which is a purely virtual display, i.e., humans cannot see it
 # but it works the same as any other X server
-Xvfb :0 -screen 0 100x100x8 2>> x11vnc_test.log &
+Xvfb :0 -screen 0 100x100x8 2>> "$LOG_FILE" &
 sleep 2
 
 
 # Testing with SSL will use the TLSNone security type
-echo -e "\n\nTesting -ssl handshake, authentication, initialization...\n" >> x11vnc_test.log
+echo -e "\n\nTesting -ssl handshake, authentication, initialization...\n" >> "$LOG_FILE"
 
 PORT=`x11vnc -ssl TMP -display :0 -localhost -bg -o server.log`
 PORT=`echo "$PORT" | grep -m 1 "PORT=" | sed -e 's/PORT=//'`
@@ -105,13 +119,13 @@ else
     X11VNC_TEST_FAIL=1
 fi
 killall x11vnc > /dev/null 2> /dev/null
-cat server.log client.log >> x11vnc_test.log
+cat server.log client.log >> "$LOG_FILE"
 
 
 # Testing with a password changes the security type from TLSNone to TLSVnc
-echo -e "\n\nTesting -ssl with a password...\n" >> x11vnc_test.log
+echo -e "\n\nTesting -ssl with a password...\n" >> "$LOG_FILE"
 
-x11vnc -storepasswd wolfprov passwd 2>> x11vnc_test.log
+x11vnc -storepasswd wolfprov passwd 2>> "$LOG_FILE"
 
 PORT=`x11vnc -ssl TMP -display :0 -localhost -bg -o server.log -rfbauth passwd`
 PORT=`echo "$PORT" | grep -m 1 "PORT=" | sed -e 's/PORT=//'`
@@ -128,7 +142,7 @@ else
     X11VNC_TEST_FAIL=1
 fi
 killall x11vnc > /dev/null 2> /dev/null
-cat server.log client.log >> x11vnc_test.log
+cat server.log client.log >> "$LOG_FILE"
 
 
 # HTTP HTTPS
@@ -140,9 +154,9 @@ echo "<html><body>Use WolfSSL!</body></html>" > index.html
 PORT=`x11vnc -ssl TMP -display :0 -localhost -httpdir . -https 5678 -bg -o server.log`
 PORT=`echo "$PORT" | grep -m 1 -Eo "http://localhost:[0-9]+" server.log | sed -e 's/http:\/\/localhost://'`
 
-echo -e "\n\nTesting -https with http...\n" >> x11vnc_test.log
+echo -e "\n\nTesting -https with http...\n" >> "$LOG_FILE"
 
-if OPENSSL_CONF='' OPENSSL_MODULES='' curl -ks "http://localhost:$PORT/index.html" >> x11vnc_test.log
+if OPENSSL_CONF='' OPENSSL_MODULES='' curl -ks "http://localhost:$PORT/index.html" >> "$LOG_FILE"
 then
     echo "[ PASSED ] -https with an http request"
 else
@@ -151,9 +165,9 @@ else
 fi
 
 
-echo -e "\n\nTesting -https with https...\n" >> x11vnc_test.log
+echo -e "\n\nTesting -https with https...\n" >> "$LOG_FILE"
 
-if OPENSSL_CONF='' OPENSSL_MODULES='' curl -ks "https://localhost:5678/index.html" >> x11vnc_test.log
+if OPENSSL_CONF='' OPENSSL_MODULES='' curl -ks "https://localhost:5678/index.html" >> "$LOG_FILE"
 then
     echo "[ PASSED ] -https with an https request"
 else
@@ -161,13 +175,10 @@ else
     X11VNC_TEST_FAIL=1
 fi
 
-killall x11vnc > /dev/null 2> /dev/null
-killall Xvfb > /dev/null 2> /dev/null
-cat server.log >> x11vnc_test.log
+killall x11vnc > /dev/null 2> /dev/null || true
+killall Xvfb > /dev/null 2> /dev/null || true
+cat server.log >> "$LOG_FILE"
 
-$GITHUB_WORKSPACE/.github/scripts/check-workflow-result.sh $X11VNC_TEST_FAIL "$WOLFPROV_FORCE_FAIL_STR" x11vnc
-X11VNC_TEST_FAIL=$?
-
-if [[ $X11VNC_TEST_FAIL -eq 1 ]]; then cat x11vnc_test.log; fi
-
+printf "\n\nX11VNC_TEST_FAIL: $X11VNC_TEST_FAIL\n\n"
 exit $X11VNC_TEST_FAIL
+

--- a/.github/workflows/build-wolfprovider.yml
+++ b/.github/workflows/build-wolfprovider.yml
@@ -70,51 +70,12 @@ jobs:
           git remote add upstream https://github.com/wolfSSL/wolfProvider.git || true
           git fetch upstream --tags --no-recurse-submodules
 
-      - name: Restore wolfSSL packages
-        uses: actions/cache@v4
-        id: wolfssl_cache
-        with:
-          path: |
-            ${{ env.WOLFSSL_PACKAGES_PATH }}/*.deb
-            ${{ env.WOLFSSL_PACKAGES_PATH }}/*.dsc
-            ${{ env.WOLFSSL_PACKAGES_PATH }}/*.tar.gz
-          key: wolfssl-debian-packages-${{ inputs.wolfssl_ref }}
-
-      - name: Install wolfSSL packages from cache
-        if: steps.wolfssl_cache.outputs.cache-hit == 'true'
-        run: |
-          printf "Installing wolfSSL packages from cache:\n"
-          ls -la ${{ env.WOLFSSL_PACKAGES_PATH }}
-          apt install --reinstall -y ${{ env.WOLFSSL_PACKAGES_PATH }}/*wolfssl*.deb
-
+      # Build wolfSSL packages and install
+      # Note we do not use the cache currently. This is a future optimization.
       # TODO: roll this step into utils-wolfssl.sh
       - name: Build wolfSSL packages and install
-        # if: steps.wolfssl_cache.outputs.cache-hit != 'true'
         run: | 
           $GITHUB_WORKSPACE/debian/install-wolfssl.sh --tag ${{ inputs.wolfssl_ref }} ${{ env.WOLFSSL_PACKAGES_PATH }}
-
-      # Check for cached OpenSSL packages
-      # WARNING: for Debian, openssl_ref is ignored since we build from Debian baseline
-      - name: Checking OpenSSL packages in cache
-        uses: actions/cache@v4
-        id: openssl_cache
-        continue-on-error: true
-        with:
-          path: |
-            ${{ env.OPENSSL_PACKAGES_PATH }}
-          key: openssl-debian-packages-${{ inputs.openssl_ref }}${{ inputs.replace_default && '-replace-default' || '' }}
-          lookup-only: false
-
-      # Install OpenSSL packages from cache if available
-      - name: Install OpenSSL packages from cache
-        if: ${{ steps.openssl_cache.outputs.cache-hit == 'true' }}
-        run: |
-          printf "Installing OpenSSL packages from cache:\n"
-          ls -la ${{ env.OPENSSL_PACKAGES_PATH }}
-          apt install --reinstall -y \
-            ${{ env.OPENSSL_PACKAGES_PATH }}/openssl_*.deb \
-            ${{ env.OPENSSL_PACKAGES_PATH }}/libssl3_*.deb \
-            ${{ env.OPENSSL_PACKAGES_PATH }}/libssl-dev_*.deb
 
       - name: Build wolfProvider
         run: |
@@ -138,7 +99,7 @@ jobs:
           ls -la ${{ env.WOLFSSL_PACKAGES_PATH }}
           ls -la ${{ env.OPENSSL_PACKAGES_PATH }}
 
-      - name: Save to cache
+      - name: Save all packages to cache for use by other workflows
         uses: actions/cache/save@v4
         continue-on-error: true
         with:
@@ -166,15 +127,3 @@ jobs:
             ${{ env.WOLFPROV_PACKAGES_PATH }}/*.dsc
             ${{ env.WOLFPROV_PACKAGES_PATH }}/*.tar.gz
           retention-days: 1
-
-      # TODO: upload wolfSSL artifacts, after building
-      # - name: Upload wolfSSL artifacts
-      #   uses: actions/upload-artifact@v4
-      #   with:
-      #     name: wolfssl-debian-packages-${{ inputs.wolfssl_ref }}
-      #     path: |
-      #       ${{ env.WOLFPROV_PACKAGES_PATH }}/*wolfssl*.deb
-      #       ${{ env.WOLFPROV_PACKAGES_PATH }}/*wolfssl*.dsc
-      #       ${{ env.WOLFPROV_PACKAGES_PATH }}/*wolfssl*.tar.gz
-      #     retention-days: 1
-

--- a/.github/workflows/x11vnc.yml
+++ b/.github/workflows/x11vnc.yml
@@ -122,4 +122,22 @@ jobs:
         run: |
           export ${{ matrix.force_fail }}
           export WOLFPROV_FORCE_FAIL_STR="${{ matrix.force_fail }}"
-          $GITHUB_WORKSPACE/.github/scripts/x11vnc/test_x11vnc.sh
+          export X11VNC_TEST_LOG=/tmp/x11vnc-test.log
+          export X11VNC_TEST_STATUS=0
+          if ! $GITHUB_WORKSPACE/.github/scripts/x11vnc/test_x11vnc.sh $X11VNC_TEST_LOG; then
+            X11VNC_TEST_STATUS=1
+          fi
+          
+          if $GITHUB_WORKSPACE/.github/scripts/check-workflow-result.sh $X11VNC_TEST_STATUS "$WOLFPROV_FORCE_FAIL_STR" x11vnc; then
+            X11VNC_TEST_STATUS=0
+          else
+            X11VNC_TEST_STATUS=1
+          fi
+
+      - name: Show x11vnc test log on failure
+        run: |
+          if [ $X11VNC_TEST_STATUS -ne 0 ]; then
+            cat $X11VNC_TEST_LOG
+          fi
+          exit $X11VNC_TEST_STATUS
+

--- a/.github/workflows/xmlsec.yml
+++ b/.github/workflows/xmlsec.yml
@@ -3,7 +3,7 @@ name: xmlsec Tests
 # START OF COMMON SECTION
 on:
   push:
-    branches: [ '**' ] # 'master', 'main', 'release/**' ]
+    branches: [ 'master', 'main', 'release/**' ]
   pull_request:
     branches: [ '*' ]
 

--- a/scripts/utils-openssl.sh
+++ b/scripts/utils-openssl.sh
@@ -121,20 +121,20 @@ clone_openssl() {
 }
 
 is_openssl_patched() {
-    if [ ! -f "${OPENSSL_SOURCE_DIR}/crypto/provider_predefined.c" ]; then
+    # Return 0 if patched, 1 if not
+    local dir="${OPENSSL_SOURCE_DIR:?OPENSSL_SOURCE_DIR not set}"
+    local file="${dir%/}/crypto/provider_predefined.c"
+
+    # File must exist to be patched
+    [[ -f "$file" ]] || return 1
+
+    # Any time we see libwolfprov, we're patched
+    if grep -q 'libwolfprov' -- "$file"; then
         return 0
     fi
 
-    # Check if $OPENSSL_SOURCE_DIR is a git repository
-    if [ -d ${OPENSSL_SOURCE_DIR}/.git ]; then
-        pushd ${OPENSSL_SOURCE_DIR} &> /dev/null
-        patch_applied=$(git diff --quiet "crypto/provider_predefined.c" 2>/dev/null && echo 1 || echo 0)
-        popd &> /dev/null
-    else
-        # Not a git repo, may have been downloaded separately (from Debian sources)
-        patch_applied=$(grep -q "libwolfprov" "${OPENSSL_SOURCE_DIR}/crypto/provider_predefined.c" && echo 1 || echo 0)
-    fi
-    return $patch_applied
+    # Not patched
+    return 1
 }
 
 check_openssl_replace_default_mismatch() {

--- a/src/wp_wolfprov.c
+++ b/src/wp_wolfprov.c
@@ -1242,8 +1242,9 @@ int wolfssl_provider_init(const OSSL_CORE_HANDLE* handle,
     if (ok) {
         if (wolfSSL_Debugging_ON() != 0) {
             WOLFPROV_MSG(WP_LOG_PROVIDER,
-              "WARNING: wolfProvider built with debug but underlying wolfSSL is not!"
-              "Building wolfSSl with debug is highly recommended, proceeding...");
+              "WARNING: wolfProvider built with debug but underlying wolfSSL is not!");
+            WOLFPROV_MSG(WP_LOG_PROVIDER,
+              "\tBuilding wolfSSl with debug is highly recommended, proceeding...");
         }
         else {
             wolfSSL_SetLoggingPrefix("wolfSSL");


### PR DESCRIPTION
- Fix build script function return values were not correct when using Debian source
- Remove GH action caching of Debian packages to avoid issues encountered with stale values (will revisit later)
- Use `--enable-wolfprovider` when building libwolfssl.deb to avoid test failures in OSPs
- More robust error handling in x11vnc yaml and test script
- Add newline in log in wolfprov init