### PR TITLE
coverity Fixes

### DIFF
--- a/src/wp_aes_block.c
+++ b/src/wp_aes_block.c
@@ -507,9 +507,6 @@ static int wp_aes_block_update(wp_AesBlockCtx *ctx, unsigned char *out,
             (ctx->tls_version == 0)) {
             nextBlocks -= AES_BLOCK_SIZE;
         }
-        if (outSize < oLen) {
-            ok = 0;
-        }
     }
     if (ok && (nextBlocks > 0)) {
         if (!wp_aes_block_doit(ctx, out, in, nextBlocks)) {

--- a/src/wp_des.c
+++ b/src/wp_des.c
@@ -457,9 +457,6 @@ static int wp_des3_block_update(wp_Des3BlockCtx *ctx, unsigned char *out,
             (ctx->tls_version == 0)) {
             nextBlocks -= DES_BLOCK_SIZE;
         }
-        if (outSize < oLen) {
-            ok = 0;
-        }
     }
     if (ok && (nextBlocks > 0)) {
         if (!wp_des3_block_doit(ctx, out, in, nextBlocks)) {

--- a/src/wp_dh_exch.c
+++ b/src/wp_dh_exch.c
@@ -158,6 +158,7 @@ static wp_DhCtx* wp_dh_dupctx(wp_DhCtx* src)
             wp_dh_free(dst->peer);
             wp_dh_free(dst->key);
             OPENSSL_free(dst);
+            dst = NULL;
         }
     }
 
@@ -369,7 +370,7 @@ static int wp_dh_derive(wp_DhCtx* ctx, unsigned char* secret,
         }
     }
 
-    if ((!done) && ok) {
+    if ((!done) && ok && (out != NULL)) {
         /* DH key exchange derivation using wolfSSL. */
         ok = wp_dh_derive_secret(ctx, out, &outLen, maxLen);
     }

--- a/src/wp_dh_kmgmt.c
+++ b/src/wp_dh_kmgmt.c
@@ -784,7 +784,7 @@ static int wp_dh_get_params(wp_Dh* dh, OSSL_PARAM params[])
         if (p != NULL) {
             /* When buffer is NULL, return the size irrespective of type */
             if (p->data == NULL) {
-                ok = wp_params_set_mp(params, OSSL_PKEY_PARAM_FFC_P, &dh->key.g, 1);
+                ok = wp_params_set_mp(params, OSSL_PKEY_PARAM_FFC_P, &dh->key.p, 1);
             }
             /* When buffer is non-NULL, type must be int or uint */
             else 

--- a/src/wp_ecdh_exch.c
+++ b/src/wp_ecdh_exch.c
@@ -159,6 +159,7 @@ static wp_EcdhCtx* wp_ecdh_dup(wp_EcdhCtx* src)
             wp_ecc_free(src->peer);
             wp_ecc_free(src->key);
             OPENSSL_free(dst);
+            dst = NULL;
         }
     }
 

--- a/src/wp_ecx_exch.c
+++ b/src/wp_ecx_exch.c
@@ -117,6 +117,7 @@ static wp_EcxCtx* wp_ecx_dupctx(wp_EcxCtx* src)
         if (!ok) {
             wp_ecx_free(src->key);
             OPENSSL_free(dst);
+            dst = NULL;
         }
     }
 

--- a/src/wp_kdf_exch.c
+++ b/src/wp_kdf_exch.c
@@ -134,6 +134,7 @@ static wp_KdfCtx* wp_kdf_ctx_dup(wp_KdfCtx* src)
 
         if (!ok) {
             OPENSSL_free(dst);
+            dst = NULL;
         }
     }
 

--- a/src/wp_mac_kmgmt.c
+++ b/src/wp_mac_kmgmt.c
@@ -318,7 +318,7 @@ static int wp_mac_has(const wp_Mac* mac, int selection)
     if (mac == NULL) {
        ok = 0;
     }
-    if ((selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY) != 0) {
+    if (ok && ((selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY) != 0)) {
         ok &= mac->key != NULL;
     }
 
@@ -387,7 +387,7 @@ static int wp_mac_import(wp_Mac *mac, int selection, const OSSL_PARAM params[])
         ok = 0;
     }
     p = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_PROPERTIES);
-    if (p != NULL) {
+    if (ok && (p != NULL)) {
         OPENSSL_free(mac->properties);
         mac->properties = NULL;
         if (!OSSL_PARAM_get_utf8_string(p, &mac->properties, 0)) {
@@ -495,7 +495,7 @@ static int wp_mac_export(wp_Mac *mac, int selection, OSSL_CALLBACK *paramCb,
                 ok = 0;
             }
         }
-        if (ok && !wp_mac_export_priv_key(mac, params, &paramsSz, data, &idx)) {
+        if (ok && (data != NULL) && !wp_mac_export_priv_key(mac, params, &paramsSz, data, &idx)) {
             ok = 0;
         }
     }

--- a/src/wp_mac_sig.c
+++ b/src/wp_mac_sig.c
@@ -82,6 +82,7 @@ static wp_MacSigCtx* wp_mac_ctx_new(WOLFPROV_CTX* provCtx,
         if (propQuery != NULL) {
             p = OPENSSL_strdup(propQuery);
             if (p == NULL) {
+                OPENSSL_free(ctx);
                 ctx = NULL;
                 ok = 0;
             }
@@ -342,7 +343,7 @@ static const OSSL_PARAM *wp_mac_settable_ctx_params(wp_MacSigCtx *ctx,
         OSSL_PARAM_int(OSSL_MAC_PARAM_DIGEST_ONESHOT, NULL),
         OSSL_PARAM_size_t(OSSL_MAC_PARAM_TLS_DATA_SIZE, NULL),
         OSSL_PARAM_END
-    };    
+    };
     return settable_ctx_params;
 }
 


### PR DESCRIPTION
https://scan7.scan.coverity.com/#/project-view/55019/16638

This patch should resolve most of the Coverity defects I got on the first scan (ignoring test files and at least 3 false positive). This was not using --enable-all, so there will likely be more issues. Some of these fixes may be pointless and should have been marked as a false positive, but they seemed like actual issues upon first glance.

List of Coverity issues:
```
CID,Type,Impact,First Detected,Owner,Classification,Severity,Action,Component,Category
1658851,Logically dead code,Medium,09/22/25,Unassigned,Pending,Unspecified,Undecided,Other,Control flow issues
1658846,Logically dead code,Medium,09/22/25,Unassigned,Pending,Minor,Undecided,Other,Control flow issues
1658830,Explicit null dereferenced,Medium,09/22/25,Unassigned,Pending,Moderate,Undecided,Other,Null pointer dereferences
1658839,Use after free,High,09/22/25,Unassigned,Bug,Moderate,Undecided,Other,Memory - illegal accesses
1658838,Copy-paste error,Medium,09/22/25,Unassigned,Bug,Moderate,Undecided,Other,Incorrect expression
1658848,Use after free,High,09/22/25,Unassigned,Bug,Moderate,Undecided,Other,Memory - illegal accesses
1658836,Use after free,High,09/22/25,Unassigned,Bug,Moderate,Undecided,Other,Memory - illegal accesses
1658847,Use after free,High,09/22/25,Unassigned,Bug,Moderate,Undecided,Other,Memory - illegal accesses
1658831,Dereference after null check,Medium,09/22/25,Unassigned,Pending,Minor,Undecided,Other,Null pointer dereferences
1658840,Explicit null dereferenced,Medium,09/22/25,Unassigned,Pending,Unspecified,Undecided,Other,Null pointer dereferences
1658842,Dereference after null check,Medium,09/22/25,Unassigned,Pending,Unspecified,Undecided,Other,Null pointer dereferences
1658835,Resource leak,High,09/22/25,Unassigned,Bug,Moderate,Undecided,Other,Resource leaks
1658834,Explicit null dereferenced,Medium,09/22/25,Unassigned,Pending,Moderate,Undecided,Other,Null pointer dereferences
1658845,Dereference after null check,Medium,09/22/25,Unassigned,Pending,Moderate,Undecided,Other,Null pointer dereferences
```

- I removed code in wp_aes_block.c and wp_des.c because I'm fairly certain its logically dead code since the condition can never be true. ( oLen is set to AES_BLOCK_SIZE and outSize is guaranteed to be at least that size)

- wp _ecdh_exch.c, wp_ecx_exch.c, and wp_kdf_exch.c: set dst = NULL after OPENSSL_FREE(dst) to prevent use after free.

- wp_mac_kmgmt.c: added ok && condition check to prevent operations when previous steps failed and data != null to prevent null pointer dereference.

-wp_dh_kmgmt.c
&dh->key.g was supposed to be &dh->key.p (wrong DH parameter)


- wp_mac_sig.c:  proper cleanup of error paths

## Summary
- Fixed 12 Coverity issues across 9 source files
