### PR TITLE
Add openssl metadata to normal builds

### DIFF
--- a/scripts/utils-openssl.sh
+++ b/scripts/utils-openssl.sh
@@ -211,6 +211,12 @@ patch_openssl() {
         printf "Done.\n"
 
         popd &> /dev/null
+    else
+        printf "\tPatching OpenSSL version only ... "
+        pushd ${OPENSSL_SOURCE_DIR} &> /dev/null
+        patch_openssl_version
+        printf "Done.\n"
+        popd &> /dev/null
     fi
 }
 


### PR DESCRIPTION
Enable the insertion of our WP metadata into `openssl-source/VERSION.dat` for all builds. This allows us to confirm the identity and build time of the openssl binary (versus the system version).

See the `wolfProvider-nonfips` and build date in the example below:
```
$ LD_LIBRARY_PATH=./openssl-install/lib ./openssl-install/bin/openssl version -a
OpenSSL 3.5.2+wolfProvider-nonfips 29 Sep 2025 (Library: OpenSSL 3.5.2+wolfProvider-nonfips 29 Sep 2025)
built on: Mon Sep 29 17:06:00 2025 UTC
```