### PR TITLE
rsa key validation test and additions to rsa fromdata test

### DIFF
--- a/src/wp_rsa_kmgmt.c
+++ b/src/wp_rsa_kmgmt.c
@@ -203,6 +203,11 @@ static const char* wp_rsa_param_key[WP_RSA_PARAM_NUMS_CNT] = {
     OSSL_PKEY_PARAM_RSA_EXPONENT1, OSSL_PKEY_PARAM_RSA_EXPONENT2,
     OSSL_PKEY_PARAM_RSA_COEFFICIENT1
 };
+#define WP_RSA_PARAM_KEY_FACTOR_INDEX1 3
+#define WP_RSA_PARAM_KEY_FACTOR_INDEX2 4
+#define WP_RSA_PARAM_KEY_EXPONENT_INDEX1 5
+#define WP_RSA_PARAM_KEY_EXPONENT_INDEX2 6
+#define WP_RSA_PARAM_KEY_COEFFICIENT_INDEX 7
 
 /**
  * RSA PSS parameters.
@@ -1186,6 +1191,29 @@ static int wp_rsa_match(const wp_Rsa* rsa1, const wp_Rsa* rsa2, int selection)
     return ok;
 }
 
+/* These are the primes used by OSSL to reject an RSA N with a small GCD */
+static const mp_digit validate_primes[] = {
+   0x0002, 0x0003, 0x0005, 0x0007, 0x000B, 0x000D, 0x0011, 0x0013,
+   0x0017, 0x001D, 0x001F, 0x0025, 0x0029, 0x002B, 0x002F, 0x0035,
+   0x003B, 0x003D, 0x0043, 0x0047, 0x0049, 0x004F, 0x0053, 0x0059,
+   0x0061, 0x0065, 0x0067, 0x006B, 0x006D, 0x0071, 0x007F, 0x0083,
+   0x0089, 0x008B, 0x0095, 0x0097, 0x009D, 0x00A3, 0x00A7, 0x00AD,
+   0x00B3, 0x00B5, 0x00BF, 0x00C1, 0x00C5, 0x00C7, 0x00D3, 0x00DF,
+   0x00E3, 0x00E5, 0x00E9, 0x00EF, 0x00F1, 0x00FB, 0x0101, 0x0107,
+   0x010D, 0x010F, 0x0115, 0x0119, 0x011B, 0x0125, 0x0133, 0x0137,
+   0x0139, 0x013D, 0x014B, 0x0151, 0x015B, 0x015D, 0x0161, 0x0167,
+   0x016F, 0x0175, 0x017B, 0x017F, 0x0185, 0x018D, 0x0191, 0x0199,
+   0x01A3, 0x01A5, 0x01AF, 0x01B1, 0x01B7, 0x01BB, 0x01C1, 0x01C9,
+   0x01CD, 0x01CF, 0x01D3, 0x01DF, 0x01E7, 0x01EB, 0x01F3, 0x01F7,
+   0x01FD, 0x0209, 0x020B, 0x021D, 0x0223, 0x022D, 0x0233, 0x0239,
+   0x023B, 0x0241, 0x024B, 0x0251, 0x0257, 0x0259, 0x025F, 0x0265,
+   0x0269, 0x026B, 0x0277, 0x0281, 0x0283, 0x0287, 0x028D, 0x0293,
+   0x0295, 0x02A1, 0x02A5, 0x02AB, 0x02B3, 0x02BD, 0x02C5, 0x02CF,
+   0x02D7, 0x02DD, 0x02E3, 0x02E7, 0x02EF,
+};
+#define VALIDATE_PRIMES_SIZE XELEM_CNT(validate_primes)
+wc_static_assert(VALIDATE_PRIMES_SIZE == 133);
+
 /**
  * Validate the RSA key.
  *
@@ -1214,25 +1242,228 @@ static int wp_rsa_validate(const wp_Rsa* rsa, int selection, int checkType)
             WOLFPROV_MSG_DEBUG_RETCODE(WP_LOG_LEVEL_DEBUG, "wc_CheckRsaKey", rc);
             ok = 0;
         }
+
+        /* wc_CheckRsaKey runs the private key operation and only bounds-checks
+         * d (d < n). Check d*e = 1 mod lcm(p-1,q-1) to match OSSL */
+        if (ok && !mp_iszero((mp_int*)&rsa->key.p) &&
+                  !mp_iszero((mp_int*)&rsa->key.q)) {
+            mp_int m;   /* p-1 then q-1 */
+            mp_int r;   /* d*e mod m    */
+
+            if (mp_init(&m) != MP_OKAY) {
+                ok = 0;
+            }
+            else if (mp_init(&r) != MP_OKAY) {
+                mp_clear(&m);
+                ok = 0;
+            }
+            else {
+                if (mp_sub_d((mp_int*)&rsa->key.p, 1, &m) != MP_OKAY ||
+                        mp_mulmod((mp_int*)&rsa->key.d, (mp_int*)&rsa->key.e,
+                                  &m, &r) != MP_OKAY || !mp_isone(&r)) {
+                    ok = 0;
+                }
+                else if (mp_sub_d((mp_int*)&rsa->key.q, 1, &m) != MP_OKAY ||
+                        mp_mulmod((mp_int*)&rsa->key.d, (mp_int*)&rsa->key.e,
+                                  &m, &r) != MP_OKAY || !mp_isone(&r)) {
+                    ok = 0;
+                }
+                mp_forcezero(&r);
+                mp_forcezero(&m);
+                mp_clear(&r);
+                mp_clear(&m);
+            }
+        }
     }
     else
 #endif
     if (checkPriv) {
-        if (mp_isone(&rsa->key.d) || mp_iszero((mp_int*)&rsa->key.d) ||
-            (mp_cmp((mp_int*)&rsa->key.d, (mp_int*)&rsa->key.n) != MP_LT)) {
+        if (mp_iszero((mp_int*)&rsa->key.d) ||
+                (mp_cmp((mp_int*)&rsa->key.d, (mp_int*)&rsa->key.n) != MP_LT)) {
             ok = 0;
         }
     }
     else if (checkPub) {
-        if (mp_iseven(&rsa->key.e) || mp_iszero((mp_int*)&rsa->key.e) ||
-            mp_isone(&rsa->key.e)) {
+        int nbits = mp_count_bits((mp_int*)&rsa->key.n);
+        mp_int res;
+
+        if (mp_iszero((mp_int*)&rsa->key.e) || mp_iszero((mp_int*)&rsa->key.n) ||
+                mp_isone((mp_int*)&rsa->key.e) || mp_isone((mp_int*)&rsa->key.n) ||
+                mp_iseven((mp_int*)&rsa->key.e) || mp_iseven((mp_int*)&rsa->key.n)) {
             ok = 0;
         }
+
+        if (ok && nbits > OPENSSL_RSA_MAX_MODULUS_BITS) {
+            ok = 0;
+        }
+
+#ifdef HAVE_FIPS
+        if (ok && (wolfProvider_GetFipsChecks() & WP_FIPS_CHECK_RSA_KEY_SIZE)) {
+            /* n must have at least 112 bits of security, and
+             * 2^16 < e < 2^256 */
+            int ebits = mp_count_bits((mp_int*)&rsa->key.e);
+            if (nbits < 2048 || ebits <= 16 || ebits >= 257) {
+                ok = 0;
+            }
+        }
+#endif
+
+        /* Reject a modulus that shares a small prime factor */
+        if (ok && mp_init(&res) != MP_OKAY) {
+            ok = 0;
+        }
+        else if (ok) {
+            unsigned int prime;
+            for(prime = 0; prime < VALIDATE_PRIMES_SIZE; prime++) {
+                if (mp_set_int(&res, validate_primes[prime]) != MP_OKAY ||
+                        mp_mod((mp_int*)&rsa->key.n, &res, &res) != MP_OKAY ||
+                        mp_iszero(&res)) {
+                    ok = 0;
+                    break;
+                }
+            }
+
+            mp_clear(&res);
+        }
+
+#if (!defined(WOLFSSL_SP_MATH) && !defined(WOLFSSL_SP_MATH_ALL)) || \
+    defined(WOLFSSL_SP_PRIME_GEN)
+        /* Reject prime n since it is not composite.
+         * Note this does not catch a prime power (p^k), which OSSL
+         *   also rejects. */
+        if (ok) {
+            int isPrime = MP_NO;
+            if (mp_prime_is_prime((mp_int*)&rsa->key.n, 5, &isPrime) != MP_OKAY ||
+                    isPrime == MP_YES) {
+                ok = 0;
+            }
+        }
+#endif
     }
 
     WOLFPROV_LEAVE(WP_LOG_COMP_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
+
+/**
+ * Copy an unsigned value from an OSSL param into a provided RSA key parameter.
+ * Negative values result in an error.
+ *
+ * @param [out] mp         RSA key parameter.
+ * @param [in]  param      Parameter to copy value from.
+ * @return  Size of mp in bits on success.
+ * @return  -1 on failure.
+ */
+static int wp_rsa_import_store_unsigned(mp_int* mp, const OSSL_PARAM* param)
+{
+    int ok;
+    int bits = -1;
+    const unsigned char* data;
+
+    WOLFPROV_ENTER(WP_LOG_COMP_RSA, "wp_rsa_import_store_unsigned");
+
+#if OPENSSL_VERSION_NUMBER <= 0x30100080L
+    ok = param->data != NULL && param->data_type == OSSL_PARAM_UNSIGNED_INTEGER;
+#else
+    ok = param->data != NULL && (param->data_type == OSSL_PARAM_INTEGER ||
+            param->data_type == OSSL_PARAM_UNSIGNED_INTEGER);
+#endif /* OPENSSL_VERSION_NUMBER <= 3.1.8 */
+
+    if (ok && !wp_mp_read_unsigned_bin_le(mp, param->data, param->data_size)) {
+        WOLFPROV_MSG(WP_LOG_COMP_RSA,
+            "Failed to read %s from parameters", param->key);
+        ok = 0;
+    }
+
+    if (ok) {
+        bits = mp_count_bits(mp);
+    }
+
+    /* OSSL accepts negative values for these params, but this doesn't work well
+     * in wolfProvider so reject it. */
+    if (ok && param->data_type == OSSL_PARAM_INTEGER) {
+        data = (const unsigned char*)param->data;
+        /* Assume little-endian when determining sign */
+        if (param->data_size > 0 && (data[param->data_size - 1] & 0x80) != 0) {
+            WOLFPROV_MSG(WP_LOG_COMP_RSA, "Negative value for %s rejected",
+                param->key);
+            ok = 0;
+        }
+    }
+
+    WOLFPROV_LEAVE(WP_LOG_COMP_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    return ok ? bits : -1;
+}
+
+/**
+ * Based on the index into wp_rsa_param_key, increment the appropriate counter.
+ *
+ * @param [in]  index      Index associated with wp_rsa_param_key.
+ * @param [out] primes     Count of prime parameters.
+ * @param [out] exps       Count of exponent parameters.
+ * @param [out] coeffs     Count of coefficient parameters.
+ */
+static void wp_rsa_import_increment_crt_counts(int index, int *primes,
+    int *exps, int *coeffs)
+{
+    if (index >= WP_RSA_PARAM_KEY_FACTOR_INDEX1 &&
+            index <= WP_RSA_PARAM_KEY_FACTOR_INDEX2) {
+        *primes += 1;
+    }
+    else if (index >= WP_RSA_PARAM_KEY_EXPONENT_INDEX1 &&
+                index <= WP_RSA_PARAM_KEY_EXPONENT_INDEX2) {
+        *exps += 1;
+    }
+    else if (index == WP_RSA_PARAM_KEY_COEFFICIENT_INDEX) {
+        *coeffs += 1;
+    }
+}
+
+/**
+ * Verify the RSA CRT parameters supplied for a private key import are complete.
+ *
+ * @param [in]  primes     Count of prime factor parameters provided.
+ * @param [in]  exps       Count of CRT exponent parameters provided.
+ * @param [in]  coeffs     Count of CRT coefficient parameters provided.
+ * @return  1 when the CRT parameters are acceptable
+ * @return  0 when the provided factors/CRT parameters are incomplete or
+ *          unsupported.
+ */
+static int wp_rsa_import_verify_crt(int primes, int exps, int coeffs)
+{
+    int ok = 1;
+
+    (void)exps;
+    (void)coeffs;
+
+    if (primes > 0) {
+#if (OPENSSL_VERSION_NUMBER < 0x30100040L && OPENSSL_VERSION_NUMBER > 0x30000120L) \
+    || (OPENSSL_VERSION_NUMBER < 0x300000C0L)
+        if (primes < 2 || primes != exps || primes != coeffs + 1) {
+#else
+        if (primes < 2) {
+#endif /* (Ver < 3.1.4 && Ver > 3.0.18) || (Ver < 3.0.12) */
+            WOLFPROV_MSG(WP_LOG_COMP_RSA,
+                "RSA factors provided but CRT parameters incomplete");
+            ok = 0;
+        }
+        /* TODO: multi-prime checks */
+        else if (primes > 2) {
+            WOLFPROV_MSG(WP_LOG_COMP_RSA, "RSA multi-prime import failed");
+            ok = 0;
+        }
+    }
+
+    return ok;
+}
+
+#if OPENSSL_VERSION_NUMBER >= 0x30400000L
+    #define wp_rsa_import_check_bits(bits, nbits)   \
+        ((bits) != -1 && (bits) <= (nbits))
+#else
+    #define wp_rsa_import_check_bits(bits, nbits)   \
+        ((bits) != -1)
+#endif /* OPENSSL_VERSION_NUMBER >= 3.4.0 */
 
 /**
  * Import the key data into RSA key object from parameters.
@@ -1251,20 +1482,39 @@ static int wp_rsa_import_key_data(wp_Rsa* rsa, const OSSL_PARAM params[],
     int cnt = 0;
     mp_int* mp = NULL;
     const OSSL_PARAM* p = NULL;
+    const OSSL_PARAM* n;
+    const OSSL_PARAM* e;
+    const OSSL_PARAM* d = NULL;
+    int bits = -1;
+    int nbits = -1;
+    int primes = 0;
+    int exps = 0;
+    int coeffs = 0;
 
     WOLFPROV_ENTER(WP_LOG_COMP_RSA, "wp_rsa_import_key_data");
 
     /* N and E params are the only ones required by OSSL, so match that.
      * See ossl_rsa_fromdata() and RSA_set0_key() in OpenSSL. */
-    if (OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_RSA_N) == NULL ||
-        OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_RSA_E) == NULL) {
+    if ((n = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_RSA_N)) == NULL ||
+            n->data == NULL ||
+            (e = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_RSA_E)) == NULL ||
+            e->data == NULL) {
         WOLFPROV_MSG(WP_LOG_COMP_RSA, "Param N or E is missing");
         ok = 0;
     }
+    if (ok && priv) {
+        d = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_RSA_D);
+    }
 
     if (ok) {
-        cnt = wp_params_count(params);
         rsa->key.type = priv ? RSA_PRIVATE : RSA_PUBLIC;
+        mp = &rsa->key.n;
+        nbits = wp_rsa_import_store_unsigned(mp, n);
+        ok = nbits != -1;
+    }
+
+    if (ok && d != NULL) {
+        cnt = wp_params_count(params);
 
         for (i = 0; i < cnt; i++) {
             /* Use the table to look up the offset in the rsa struct */
@@ -1273,6 +1523,8 @@ static int wp_rsa_import_key_data(wp_Rsa* rsa, const OSSL_PARAM params[],
             for (j = 0; j < (int)ARRAY_SIZE(wp_rsa_param_key); j++) {
                 if (XSTRCMP(p->key, wp_rsa_param_key[j]) == 0) {
                     index = j;
+                    wp_rsa_import_increment_crt_counts(index, &primes, &exps,
+                                                                       &coeffs);
                     break;
                 }
             }
@@ -1284,20 +1536,38 @@ static int wp_rsa_import_key_data(wp_Rsa* rsa, const OSSL_PARAM params[],
             }
 
             /* Read the value into the rsa struct */
-            if (ok) {
+            if (ok && p != n) {
                 mp = (mp_int*)(((byte*)&rsa->key) + wp_rsa_offset[index]);
-                if (!wp_mp_read_unsigned_bin_le(mp, p->data, p->data_size)) {
-                    WOLFPROV_MSG(WP_LOG_COMP_RSA,
-                        "Failed to read %s from parameters", p->key);
+                bits = wp_rsa_import_store_unsigned(mp, p);
+                ok = wp_rsa_import_check_bits(bits, nbits);
+
+                /* Reject a provided CRT parameter (dP, dQ, u) that is zero.
+                 * The key validation could otherwise pass with a 0 param */
+                if (ok && (((index >= WP_RSA_PARAM_KEY_EXPONENT_INDEX1 &&
+                        index <= WP_RSA_PARAM_KEY_EXPONENT_INDEX2) ||
+                        index == WP_RSA_PARAM_KEY_COEFFICIENT_INDEX) &&
+                        mp_iszero(mp))) {
                     ok = 0;
                 }
             }
         }
+
+        /* Verify the received RSA CRT parameters */
+        if (ok) {
+            ok = wp_rsa_import_verify_crt(primes, exps, coeffs);
+        }
+    }
+    else if (ok && d == NULL) {
+        mp = &rsa->key.e;
+        bits = wp_rsa_import_store_unsigned(mp, e);
+        ok = wp_rsa_import_check_bits(bits, nbits);
     }
 
     WOLFPROV_LEAVE(WP_LOG_COMP_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
+
+#undef wp_rsa_import_check_bits
 
 /**
  * Import the key into RSA key object from parameters.

--- a/test/test_rsa.c
+++ b/test/test_rsa.c
@@ -24,6 +24,7 @@
 
 #include <openssl/store.h>
 #include <openssl/core_names.h>
+#include <openssl/param_build.h>
 
 #ifdef WP_HAVE_RSA
 
@@ -1563,12 +1564,17 @@ int test_rsa_fromdata(void* data)
 #ifdef EVP_PKEY_PRIVATE_KEY
             EVP_PKEY_PRIVATE_KEY, /* added in 3.0.12 and 3.1.4 */
 #endif
+            EVP_PKEY_KEY_PARAMETERS,
         };
 
         /* Parameter data fields */
         unsigned long rsa_n = 0xbc747fc5;
         unsigned long rsa_e = 0x10001;
         unsigned long rsa_d = 0x7b133399;
+#if OPENSSL_VERSION_NUMBER >= 0x30200010L
+        unsigned long rsa_p = 0x397;
+        unsigned long rsa_q = 0x3a9;
+#endif
         const char *foo = "some string";
         size_t foo_l = strlen(foo);
         const char bar[] = "some other string";
@@ -1625,6 +1631,40 @@ int test_rsa_fromdata(void* data)
             { "bar", OSSL_PARAM_UTF8_STRING, (void *)&bar, sizeof(bar) - 1, 0 },
             OSSL_PARAM_END
         };
+#if OPENSSL_VERSION_NUMBER >= 0x30200010L
+        OSSL_PARAM params_null[] = {
+            OSSL_PARAM_ulong("n", NULL),
+            OSSL_PARAM_ulong("e", NULL),
+            OSSL_PARAM_ulong("d", NULL),
+            { "foo", OSSL_PARAM_UTF8_PTR, NULL, foo_l, 0 },
+            { "bar", OSSL_PARAM_UTF8_STRING, NULL, sizeof(bar) - 1, 0 },
+            OSSL_PARAM_END
+        };
+        OSSL_PARAM params_nedpq[] = {
+            OSSL_PARAM_ulong("n", &rsa_n),
+            OSSL_PARAM_ulong("e", &rsa_e),
+            OSSL_PARAM_ulong("d", &rsa_d),
+            OSSL_PARAM_ulong("rsa-factor1", &rsa_p),
+            OSSL_PARAM_ulong("rsa-factor2", &rsa_q),
+            OSSL_PARAM_END
+        };
+        OSSL_PARAM params_nepq_null[] = {
+            OSSL_PARAM_ulong("n", &rsa_n),
+            OSSL_PARAM_ulong("e", &rsa_e),
+            OSSL_PARAM_ulong("d", NULL),
+            OSSL_PARAM_ulong("rsa-factor1", &rsa_p),
+            OSSL_PARAM_ulong("rsa-factor2", &rsa_q),
+            OSSL_PARAM_END
+        };
+        OSSL_PARAM params_nedq_null[] = {
+            OSSL_PARAM_ulong("n", &rsa_n),
+            OSSL_PARAM_ulong("e", &rsa_e),
+            OSSL_PARAM_ulong("d", &rsa_d),
+            OSSL_PARAM_ulong("rsa-factor1", NULL),
+            OSSL_PARAM_ulong("rsa-factor2", &rsa_q),
+            OSSL_PARAM_END
+        };
+#endif /* OPENSSL_VERSION_NUMBER >= 3.2.1 */
         OSSL_PARAM* params_table[] = {
             params_none,
             params_n,
@@ -1636,6 +1676,12 @@ int test_rsa_fromdata(void* data)
             params_ned,
             params_extra_ulong,
             params_extra_str,
+#if OPENSSL_VERSION_NUMBER >= 0x30200010L
+            params_null,
+            params_nedpq,
+            params_nepq_null,
+            params_nedq_null,
+#endif /* OPENSSL_VERSION_NUMBER >= 3.2.1 */
         };
 
         for (unsigned i = 0; i < ARRAY_SIZE(selections); i++) {
@@ -2589,6 +2635,408 @@ int test_rsa_kem(void *data)
         PRINT_MSG("Test wolfProvider RSA KEM encapsulate/decapsulate");
         err = test_rsa_kem_helper(wpLibCtx);
     }
+
+    return err;
+}
+
+static const char* const rsaIntegrityParamKeys[] = {
+    OSSL_PKEY_PARAM_RSA_FACTOR1,       /* p    */
+    OSSL_PKEY_PARAM_RSA_FACTOR2,       /* q    */
+    OSSL_PKEY_PARAM_RSA_N,             /* n    */
+    OSSL_PKEY_PARAM_RSA_E,             /* e    */
+    OSSL_PKEY_PARAM_RSA_D,             /* d    */
+    OSSL_PKEY_PARAM_RSA_EXPONENT1,     /* dP   */
+    OSSL_PKEY_PARAM_RSA_EXPONENT2,     /* dQ   */
+    OSSL_PKEY_PARAM_RSA_COEFFICIENT1   /* qInv */
+};
+#define RSA_INTEGRITY_COMP_CNT XELEM_CNT(rsaIntegrityParamKeys)
+
+/* For this function err may be set to one of three states:
+ *  1  -> will be interpreted as a true error
+ *  0  -> no error
+ *  -1 -> this is a 'soft error', meaning it is expected and subsequent logic
+ *      should be skipped */
+static int test_rsa_key_integrity_helper(BIGNUM** comps, int expect_wolf_reject)
+{
+    int err = 0;
+    int ossl_err;
+    int wolf_err;
+    unsigned int i;
+    OSSL_PARAM* params = NULL;
+    OSSL_PARAM_BLD* bld = NULL;
+    EVP_PKEY_CTX* ctx_ossl = NULL;
+    EVP_PKEY_CTX* ctx_wolf = NULL;
+    EVP_PKEY* pkey_ossl = NULL;
+    EVP_PKEY* pkey_wolf = NULL;
+
+    bld = OSSL_PARAM_BLD_new();
+    err = bld == NULL;
+
+    if (err == 0) {
+        for (i = 0; i < RSA_INTEGRITY_COMP_CNT; i++) {
+            err |= OSSL_PARAM_BLD_push_BN(bld, rsaIntegrityParamKeys[i],
+                                          comps[i]) != 1;
+        }
+    }
+    if (err == 0) {
+        params = OSSL_PARAM_BLD_to_param(bld);
+        err = params == NULL;
+    }
+
+    if (err == 0) {
+        ctx_ossl = EVP_PKEY_CTX_new_from_name(osslLibCtx, "RSA", NULL);
+        ctx_wolf = EVP_PKEY_CTX_new_from_name(wpLibCtx, "RSA", NULL);
+        err = (ctx_ossl == NULL) || (ctx_wolf == NULL);
+    }
+    if (err == 0) {
+        err |= EVP_PKEY_fromdata_init(ctx_ossl) != 1;
+        err |= EVP_PKEY_fromdata_init(ctx_wolf) != 1;
+    }
+    if (err == 0) {
+        ossl_err = EVP_PKEY_fromdata(ctx_ossl, &pkey_ossl, EVP_PKEY_KEYPAIR,
+                                                                        params);
+        wolf_err = EVP_PKEY_fromdata(ctx_wolf, &pkey_wolf, EVP_PKEY_KEYPAIR,
+                                                                        params);
+
+        if (expect_wolf_reject) {
+            /* OSSL accepts negative parameters but wolfProvider is unable to,
+             * so expect a rejection from wolf for now */
+            if (wolf_err != 0) {
+                PRINT_MSG("Expected wolfProvider to reject key (WOLF %d)",
+                                                                    wolf_err);
+                err = 1;
+            }
+            else {
+                PRINT_MSG("wolfProvider rejected key as expected");
+                err = -1;
+            }
+        }
+        else if (ossl_err != wolf_err) {
+            PRINT_MSG("EVP_PKEY_fromdata status mismatch (OSSL %d WOLF %d)",
+                                                            ossl_err, wolf_err);
+            err = 1;
+        }
+        else if (wolf_err == 0) {
+            PRINT_MSG("Successfully failed to load keys");
+            err = -1;
+        }
+        else if (wolf_err == 1) {
+            if (EVP_PKEY_eq(pkey_ossl, pkey_wolf) != 1 ||
+                    EVP_PKEY_parameters_eq(pkey_ossl, pkey_wolf) != 1) {
+                PRINT_MSG("EVP_PKEY_eq / EVP_PKEY_parameters_eq failed");
+                err = 1;
+            }
+        }
+    }
+
+    if (err == 0) {
+        EVP_PKEY_CTX_free(ctx_ossl);
+        EVP_PKEY_CTX_free(ctx_wolf);
+        ctx_ossl = EVP_PKEY_CTX_new_from_pkey(osslLibCtx, pkey_ossl, NULL);
+        ctx_wolf = EVP_PKEY_CTX_new_from_pkey(wpLibCtx, pkey_wolf, NULL);
+        err = (ctx_ossl == NULL) || (ctx_wolf == NULL);
+    }
+    if (err == 0) {
+        ossl_err = EVP_PKEY_param_check(ctx_ossl) != 1;
+        wolf_err = EVP_PKEY_param_check(ctx_wolf) != 1;
+        if (ossl_err != wolf_err){
+            PRINT_MSG("param_check err: OSSL %d WOLF %d", ossl_err, wolf_err);
+            err |= 1;
+        }
+
+        ossl_err = EVP_PKEY_public_check(ctx_ossl) != 1;
+        wolf_err = EVP_PKEY_public_check(ctx_wolf) != 1;
+        if (ossl_err != wolf_err){
+            PRINT_MSG("public_check err: OSSL %d WOLF %d", ossl_err, wolf_err);
+            err |= 1;
+        }
+
+        ossl_err = EVP_PKEY_private_check(ctx_ossl) != 1;
+        wolf_err = EVP_PKEY_private_check(ctx_wolf) != 1;
+        if (ossl_err != wolf_err){
+            PRINT_MSG("private_check err: OSSL %d WOLF %d", ossl_err, wolf_err);
+            err |= 1;
+        }
+
+#ifdef WOLFSSL_RSA_KEY_CHECK
+        ossl_err = EVP_PKEY_pairwise_check(ctx_ossl) != 1;
+        wolf_err = EVP_PKEY_pairwise_check(ctx_wolf) != 1;
+        if (ossl_err != wolf_err){
+            PRINT_MSG("pairwise_check err: OSSL %d WOLF %d", ossl_err, wolf_err);
+            err |= 1;
+        }
+#endif
+    }
+
+    EVP_PKEY_free(pkey_ossl);
+    EVP_PKEY_free(pkey_wolf);
+    EVP_PKEY_CTX_free(ctx_ossl);
+    EVP_PKEY_CTX_free(ctx_wolf);
+    OSSL_PARAM_free(params);
+    OSSL_PARAM_BLD_free(bld);
+
+    return err == 1;
+}
+
+/* A valid RSA private key must supply at least two prime factors.
+ * Assert both providers reject a single factor */
+static int test_rsa_key_integrity_single_factor(BIGNUM* p,
+    BIGNUM* n, BIGNUM* e, BIGNUM* d)
+{
+    int err = 0;
+    int ossl_err;
+    int wolf_err;
+    OSSL_PARAM* params = NULL;
+    OSSL_PARAM_BLD* bld = NULL;
+    EVP_PKEY_CTX* ctx_ossl = NULL;
+    EVP_PKEY_CTX* ctx_wolf = NULL;
+    EVP_PKEY* pkey_ossl = NULL;
+    EVP_PKEY* pkey_wolf = NULL;
+
+    bld = OSSL_PARAM_BLD_new();
+    err = bld == NULL;
+
+    if (err == 0) {
+        err |= OSSL_PARAM_BLD_push_BN(bld, OSSL_PKEY_PARAM_RSA_N, n) != 1;
+        err |= OSSL_PARAM_BLD_push_BN(bld, OSSL_PKEY_PARAM_RSA_E, e) != 1;
+        err |= OSSL_PARAM_BLD_push_BN(bld, OSSL_PKEY_PARAM_RSA_D, d) != 1;
+        err |= OSSL_PARAM_BLD_push_BN(bld, OSSL_PKEY_PARAM_RSA_FACTOR1, p) != 1;
+    }
+
+    if (err == 0) {
+        params = OSSL_PARAM_BLD_to_param(bld);
+        err = params == NULL;
+    }
+    if (err == 0) {
+        ctx_ossl = EVP_PKEY_CTX_new_from_name(osslLibCtx, "RSA", NULL);
+        ctx_wolf = EVP_PKEY_CTX_new_from_name(wpLibCtx, "RSA", NULL);
+        err = (ctx_ossl == NULL) || (ctx_wolf == NULL);
+    }
+    if (err == 0) {
+        err |= EVP_PKEY_fromdata_init(ctx_ossl) != 1;
+        err |= EVP_PKEY_fromdata_init(ctx_wolf) != 1;
+    }
+    if (err == 0) {
+        ossl_err = EVP_PKEY_fromdata(ctx_ossl, &pkey_ossl, EVP_PKEY_KEYPAIR,
+                                                                        params);
+        wolf_err = EVP_PKEY_fromdata(ctx_wolf, &pkey_wolf, EVP_PKEY_KEYPAIR,
+                                                                        params);
+        if (ossl_err != wolf_err) {
+            PRINT_MSG("Single-factor status mismatch (OSSL %d WOLF %d)",
+                                                            ossl_err, wolf_err);
+            err = 1;
+        }
+        else if (wolf_err == 1) {
+            PRINT_MSG("Single-factor key was accepted, expected rejection");
+            err = 1;
+        }
+        else {
+            PRINT_MSG("Single-factor key rejected by both as expected");
+        }
+    }
+
+    EVP_PKEY_free(pkey_ossl);
+    EVP_PKEY_free(pkey_wolf);
+    EVP_PKEY_CTX_free(ctx_ossl);
+    EVP_PKEY_CTX_free(ctx_wolf);
+    OSSL_PARAM_free(params);
+    OSSL_PARAM_BLD_free(bld);
+
+    return err;
+}
+
+int test_rsa_key_integrity(void* data)
+{
+    int err = 0;
+    PKCS8_PRIV_KEY_INFO* p8inf = NULL;
+    EVP_PKEY* pkey = NULL;
+    BIGNUM* p = NULL;
+    BIGNUM* q = NULL;
+    BIGNUM* n = NULL;
+    BIGNUM* e = NULL;
+    BIGNUM* d = NULL;
+    BIGNUM* dP = NULL;
+    BIGNUM* dQ = NULL;
+    BIGNUM* u = NULL;
+    BIGNUM* bignums[RSA_INTEGRITY_COMP_CNT];
+    char names[RSA_INTEGRITY_COMP_CNT] = { 'p', 'q', 'n', 'e', 'd',
+                                           'P', 'Q', 'u' };
+    size_t loop;
+    BIGNUM* num = NULL;
+    BN_ULONG num_val;
+    const unsigned char* pder = rsa_key_der_2048_pkcs8;
+    long savedFipsChecks;
+
+    (void)data;
+
+    /* turn off FIPS checks when OSSL is not in FIPS mode */
+    savedFipsChecks = wolfProvider_GetFipsChecks();
+    if (!EVP_default_properties_is_fips_enabled(osslLibCtx)) {
+        wolfProvider_SetFipsChecks(0);
+    }
+
+    /* steal parameters from existing key so they can be fuzzed */
+    p8inf = d2i_PKCS8_PRIV_KEY_INFO(NULL, (const unsigned char **)&pder,
+                                            sizeof(rsa_key_der_2048_pkcs8));
+    err = p8inf == NULL;
+    if (err == 0) {
+        pkey = EVP_PKCS82PKEY_ex(p8inf, osslLibCtx, NULL);
+        err = pkey == NULL;
+    }
+    if (err == 0) {
+        err |= EVP_PKEY_get_bn_param(pkey, OSSL_PKEY_PARAM_RSA_FACTOR1, &p) != 1;
+        err |= EVP_PKEY_get_bn_param(pkey, OSSL_PKEY_PARAM_RSA_FACTOR2, &q) != 1;
+        err |= EVP_PKEY_get_bn_param(pkey, OSSL_PKEY_PARAM_RSA_N, &n) != 1;
+        err |= EVP_PKEY_get_bn_param(pkey, OSSL_PKEY_PARAM_RSA_E, &e) != 1;
+        err |= EVP_PKEY_get_bn_param(pkey, OSSL_PKEY_PARAM_RSA_D, &d) != 1;
+        err |= EVP_PKEY_get_bn_param(pkey, OSSL_PKEY_PARAM_RSA_EXPONENT1, &dP)
+            != 1;
+        err |= EVP_PKEY_get_bn_param(pkey, OSSL_PKEY_PARAM_RSA_EXPONENT2, &dQ)
+            != 1;
+        err |= EVP_PKEY_get_bn_param(pkey, OSSL_PKEY_PARAM_RSA_COEFFICIENT1, &u)
+            != 1;
+        err |= (p == NULL) || (q == NULL) || (n == NULL) ||
+            (e == NULL) || (d == NULL) || (dP == NULL) || (dQ == NULL) ||
+            (u == NULL);
+        bignums[0] = p;
+        bignums[1] = q;
+        bignums[2] = n;
+        bignums[3] = e;
+        bignums[4] = d;
+        bignums[5] = dP;
+        bignums[6] = dQ;
+        bignums[7] = u;
+    }
+    if (err == 0) {
+        PRINT_MSG("Validate with valid key");
+        err = test_rsa_key_integrity_helper(bignums, 0);
+    }
+
+    if (err == 0) {
+        num = BN_new();
+        err = num == NULL;
+    }
+
+    for (loop = 0; err == 0 && loop < ARRAY_SIZE(bignums); loop++) {
+        PRINT_MSG("Validate with %c -= 1, 2", names[loop]);
+
+        for (num_val = 1; err == 0 && num_val <= 2; num_val++) {
+            BIGNUM* bignum = bignums[loop];
+            err = BN_set_word(num, num_val) != 1;
+
+            PRINT_MSG("%llu:", (unsigned long long)num_val);
+            if (BN_sub(bignum, bignum, num) != 1) {
+                err = 1;
+            }
+            else if ((err = test_rsa_key_integrity_helper(bignums,
+                    0)) == 0) {
+                err = BN_add(bignum, bignum, num) != 1;
+            }
+        }
+    }
+
+    for (loop = 0; err == 0 && loop < ARRAY_SIZE(bignums); loop++) {
+        PRINT_MSG("Validate with %c = 0, 1, 2, 3", names[loop]);
+
+        for (num_val = 0; err == 0 && num_val <= 3; num_val++) {
+            BIGNUM* bignum = bignums[loop];
+            int expect_reject;
+            err = BN_copy(num, bignum) == NULL;
+
+            PRINT_MSG("%llu:", (unsigned long long)num_val);
+            if (err != 1 && BN_set_word(bignum, num_val) != 1) {
+                err = 1;
+            }
+
+            if (err != 1) {
+                /* wolfProvider rejects a zero CRT param (dP, dQ, u) at load,
+                 * whereas OSSL loads it and only fails the pairwise check. */
+                expect_reject = BN_is_zero(bignum) && (names[loop] == 'P' ||
+                        names[loop] == 'Q' || names[loop] == 'u');
+
+                err = test_rsa_key_integrity_helper(bignums, expect_reject) != 0;
+            }
+            if (err != 1 && BN_copy(bignum, num) == NULL) {
+                err = 1;
+            }
+        }
+    }
+
+/* OSSL_PARAM_BLD does not support negative BN's until after 3.1.8 */
+#if OPENSSL_VERSION_NUMBER > 0x30100080L
+    for (loop = 0; err == 0 && loop < ARRAY_SIZE(bignums); loop++) {
+        BIGNUM* bignum = bignums[loop];
+        BN_set_negative(bignum, 1);
+
+        PRINT_MSG("Validate with negative %c", names[loop]);
+
+        /* Negative RSA params don't work with wolfProvider, so expect rejection
+         * for now
+         * (OSSL does accept negative parameters for some reason) */
+        if (err != 1 &&
+                test_rsa_key_integrity_helper(bignums, 1) != 0) {
+            err = 1;
+        }
+
+        BN_set_negative(bignum, 0);
+    }
+#endif /* OPENSSL_VERSION_NUMBER > 3.1.8 */
+
+/* A component larger than the modulus n should be caught as invalid */
+#if OPENSSL_VERSION_NUMBER >= 0x30400000L
+    if (err == 0) {
+        BIGNUM* big = BN_new();
+        err = (big == NULL) || (BN_lshift(big, n, 1) != 1);
+
+        if (err == 0) {
+            PRINT_MSG("Validate with oversized p");
+            bignums[0] = big;
+            err = test_rsa_key_integrity_helper(bignums, 0);
+            bignums[0] = p;
+        }
+        if (err == 0) {
+            PRINT_MSG("Validate with oversized q");
+            bignums[1] = big;
+            err = test_rsa_key_integrity_helper(bignums, 0);
+            bignums[1] = q;
+        }
+        if (err == 0) {
+            PRINT_MSG("Validate with oversized d");
+            bignums[4] = big;
+            err = test_rsa_key_integrity_helper(bignums, 0);
+            bignums[4] = d;
+        }
+
+        BN_free(big);
+    }
+#endif /* OPENSSL_VERSION_NUMBER >= 3.4.0 */
+
+    if (err == 0) {
+        PRINT_MSG("Validate rejection of a single prime factor");
+        err = test_rsa_key_integrity_single_factor(p, n, e, d);
+    }
+
+    if (err == 0) {
+        BIGNUM* nulls[RSA_INTEGRITY_COMP_CNT] = { NULL };
+        PRINT_MSG("Validate with NULL values");
+        /* Ordinarily this would pass, but an error is now expected since
+         * 0-valued CRT params return an error */
+        err = test_rsa_key_integrity_helper(nulls, 1);
+    }
+
+    wolfProvider_SetFipsChecks(savedFipsChecks);
+
+    BN_free(p);
+    BN_free(q);
+    BN_free(n);
+    BN_free(e);
+    BN_free(d);
+    BN_free(dP);
+    BN_free(dQ);
+    BN_free(u);
+    BN_free(num);
+    PKCS8_PRIV_KEY_INFO_free(p8inf);
+    EVP_PKEY_free(pkey);
 
     return err;
 }

--- a/test/unit.c
+++ b/test/unit.c
@@ -346,6 +346,7 @@ TEST_CASE test_case[] = {
     TEST_DECL(test_rsa_kem_prefix_match, NULL),
     TEST_DECL(test_rsa_pss_mgf1_get_params, NULL),
     TEST_DECL(test_rsa_kem, NULL),
+    TEST_DECL(test_rsa_key_integrity, NULL),
 #endif /* WP_HAVE_RSA */
 #ifdef WP_HAVE_EC_P192
     #ifdef WP_HAVE_ECKEYGEN

--- a/test/unit.h
+++ b/test/unit.h
@@ -308,6 +308,7 @@ int test_rsa_param_prefix_match(void* data);
 int test_rsa_kem_prefix_match(void* data);
 int test_rsa_pss_mgf1_get_params(void *data);
 int test_rsa_kem(void *data);
+int test_rsa_key_integrity(void* data);
 #endif /* WP_HAVE_RSA */
 
 #ifdef WP_HAVE_DH


### PR DESCRIPTION
Adding tests for rsa key validation as well as adding some more cases to the rsa fromdata test.

This test is kind of slow due to the additions.

Bugs:
* WP segfaults when NULL is provided for param->data field  (fixed)
* General failure of rsa key validation (mostly fixed)
    - public key should have a few other tests
* WP accepts any type of parameter value for rsa fields  (fixed)

Additions:
* Prime check in wp_rsa_validate against 133 primes. Later uses mp_prime_is_prime to check if n is composite.
* The 'selection' variable used for rsa key importing was mostly unused, added section to make use of it.
    - This is to follow OSSL's implementation closer. Involved checking for D param, not just N and E.
* No param may have more bits than the modulus.
* Added checks that all CRT parameters are provided.
    - These checks vary between OSSL versions
* Verify that d*e is logically equivalent to 1 mod( lcm(p-1, q-1))

Problems?
* ~Should negative values be stored as 0? OSSL stores them as a negative and fails later but WP must store these values as unsigned.~ What a hassle! Fail when a negative value is received even though OpenSSL would succeed for the same input.
* OpenSSL can store the absence of a CRT parameter (dQ, dP, u) wolfProvider cannot. Reject when a CRTp equal to 0 is provided, otherwise the key check could pass on wolfProvider.