### PR TITLE
feat: route configurable devId through key init calls

### DIFF
--- a/include/wolfprovider/internal.h
+++ b/include/wolfprovider/internal.h
@@ -146,6 +146,7 @@ typedef struct WOLFPROV_CTX {
    wolfSSL_Mutex rng_mutex;
 #endif
    BIO_METHOD *coreBioMethod;
+   int devId;
 } WOLFPROV_CTX;
 
 #if defined(WP_HAVE_SEED_SRC) && defined(WP_HAVE_RANDOM)

--- a/src/wp_dh_kmgmt.c
+++ b/src/wp_dh_kmgmt.c
@@ -396,7 +396,7 @@ static wp_Dh* wp_dh_new(WOLFPROV_CTX *provCtx)
         int ok = 1;
         int rc;
 
-        rc = wc_InitDhKey_ex(&dh->key, NULL, INVALID_DEVID);
+        rc = wc_InitDhKey_ex(&dh->key, NULL, provCtx->devId);
         if (rc != 0) {
             WOLFPROV_MSG_DEBUG_RETCODE(WP_LOG_LEVEL_DEBUG, "wc_InitDhKey_ex", rc);
             ok = 0;

--- a/src/wp_ecc_kmgmt.c
+++ b/src/wp_ecc_kmgmt.c
@@ -334,7 +334,7 @@ static wp_Ecc* wp_ecc_new(WOLFPROV_CTX *provCtx)
         int ok = 1;
         int rc;
 
-        rc = wc_ecc_init_ex(&ecc->key, NULL, INVALID_DEVID);
+        rc = wc_ecc_init_ex(&ecc->key, NULL, provCtx->devId);
         if (rc != 0) {
             WOLFPROV_MSG_DEBUG_RETCODE(WP_LOG_LEVEL_DEBUG, "wc_ecc_init_ex", rc);
             ok = 0;

--- a/src/wp_ecx_kmgmt.c
+++ b/src/wp_ecx_kmgmt.c
@@ -1203,13 +1203,14 @@ static wp_EcxGenCtx* wp_ecx_gen_init(WOLFPROV_CTX* provCtx,
         int rc;
         int ok = 1;
 
-        rc = wc_InitRng(&ctx->rng);
+        /* provCtx assigned before RNG init: ctx->provCtx->devId must be valid */
+        ctx->provCtx = provCtx;
+        rc = wc_InitRng_ex(&ctx->rng, NULL, ctx->provCtx->devId);
         if (rc != 0) {
-            WOLFPROV_MSG_DEBUG_RETCODE(WP_LOG_LEVEL_DEBUG, "wc_InitRng", rc);
+            WOLFPROV_MSG_DEBUG_RETCODE(WP_LOG_LEVEL_DEBUG, "wc_InitRng_ex", rc);
             ok = 0;
         }
         if (ok) {
-            ctx->provCtx = provCtx;
             ctx->name = name;
             if (!wp_ecx_gen_set_params(ctx, params)) {
                 wc_FreeRng(&ctx->rng);

--- a/src/wp_rsa_kmgmt.c
+++ b/src/wp_rsa_kmgmt.c
@@ -464,9 +464,9 @@ static wp_Rsa* wp_rsa_base_new(WOLFPROV_CTX* provCtx, int type)
         int ok = 1;
         int rc;
 
-        rc = wc_InitRsaKey(&rsa->key, NULL);
+        rc = wc_InitRsaKey_ex(&rsa->key, NULL, provCtx->devId);
         if (rc != 0) {
-            WOLFPROV_MSG_DEBUG_RETCODE(WP_LOG_LEVEL_DEBUG, "wc_InitRsaKey", rc);
+            WOLFPROV_MSG_DEBUG_RETCODE(WP_LOG_LEVEL_DEBUG, "wc_InitRsaKey_ex", rc);
             ok = 0;
         }
 
@@ -1533,7 +1533,7 @@ static wp_RsaGenCtx* wp_rsa_base_gen_init(WOLFPROV_CTX* provCtx,
         int ok = 1;
         int rc;
 
-        rc = wc_InitRng_ex(&ctx->rng, NULL, INVALID_DEVID);
+        rc = wc_InitRng_ex(&ctx->rng, NULL, provCtx->devId);
         if (rc != 0) {
             WOLFPROV_MSG_DEBUG_RETCODE(WP_LOG_LEVEL_DEBUG, "wc_InitRng_ex", rc);
             ok = 0;

--- a/src/wp_wolfprov.c
+++ b/src/wp_wolfprov.c
@@ -49,6 +49,7 @@ static const OSSL_PARAM wolfssl_param_types[] = {
     OSSL_PARAM_DEFN(OSSL_PROV_PARAM_VERSION, OSSL_PARAM_UTF8_PTR, NULL, 0),
     OSSL_PARAM_DEFN(OSSL_PROV_PARAM_BUILDINFO, OSSL_PARAM_UTF8_PTR, NULL, 0),
     OSSL_PARAM_DEFN(OSSL_PROV_PARAM_STATUS, OSSL_PARAM_INTEGER, NULL, 0),
+    OSSL_PARAM_int("wolfprovider_devid", NULL),
     OSSL_PARAM_END
 };
 
@@ -218,6 +219,9 @@ static WOLFPROV_CTX* wolfssl_prov_ctx_new(void)
     WP_CHECK_FIPS_ALGO_PTR(WP_CAST_ALGO_DRBG);
 
     ctx = (WOLFPROV_CTX*)OPENSSL_zalloc(sizeof(*ctx));
+    if (ctx != NULL) {
+        ctx->devId = INVALID_DEVID;
+    }
     if ((ctx != NULL) && (wc_InitRng(&ctx->rng) != 0)) {
         OPENSSL_free(ctx);
         ctx = NULL;
@@ -368,6 +372,49 @@ static int wolfprov_get_params(void* provCtx, OSSL_PARAM params[])
             ok = 0;
         }
     }
+    WOLFPROV_LEAVE(WP_LOG_COMP_PROVIDER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    return ok;
+}
+
+/*
+ * Get the table of parameters that can be set on wolfProv.
+ *
+ * @param [in] provCtx  Unused.
+ * @return  Table of settable parameters.
+ */
+static const OSSL_PARAM* wolfprov_settable_params(void* provCtx)
+{
+    static const OSSL_PARAM settable[] = {
+        OSSL_PARAM_int("wolfprovider_devid", NULL),
+        OSSL_PARAM_END
+    };
+    (void)provCtx;
+    return settable;
+}
+
+/*
+ * Set parameters on the provider context.
+ *
+ * @param [in] provCtx  Provider context.
+ * @param [in] params   Parameters to set.
+ * @return  1 on success.
+ * @return  0 on failure.
+ */
+static int wolfprov_set_params(void* provCtx, const OSSL_PARAM params[])
+{
+    int ok = 1;
+    const OSSL_PARAM* p;
+    WOLFPROV_CTX* ctx = (WOLFPROV_CTX*)provCtx;
+
+    WOLFPROV_ENTER(WP_LOG_COMP_PROVIDER, "wolfprov_set_params");
+
+    p = OSSL_PARAM_locate_const(params, "wolfprovider_devid");
+    if (p != NULL) {
+        if (!OSSL_PARAM_get_int(p, &ctx->devId)) {
+            ok = 0;
+        }
+    }
+
     WOLFPROV_LEAVE(WP_LOG_COMP_PROVIDER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }
@@ -1214,6 +1261,8 @@ static const OSSL_DISPATCH wolfprov_dispatch_table[] = {
     { OSSL_FUNC_PROVIDER_TEARDOWN,        (DFUNC)wolfprov_teardown            },
     { OSSL_FUNC_PROVIDER_GETTABLE_PARAMS, (DFUNC)wolfprov_gettable_params     },
     { OSSL_FUNC_PROVIDER_GET_PARAMS,      (DFUNC)wolfprov_get_params          },
+    { OSSL_FUNC_PROVIDER_SETTABLE_PARAMS, (DFUNC)wolfprov_settable_params     },
+    { OSSL_FUNC_PROVIDER_SET_PARAMS,      (DFUNC)wolfprov_set_params          },
     { OSSL_FUNC_PROVIDER_QUERY_OPERATION, (DFUNC)wolfprov_query               },
     { OSSL_FUNC_PROVIDER_GET_CAPABILITIES,
                                          (DFUNC)wolfssl_prov_get_capabilities },


### PR DESCRIPTION
## Summary

wolfProvider currently hardcodes `INVALID_DEVID` in all key initialization
calls, silently bypassing wolfCrypt's device callback layer. This makes it
impossible to route OpenSSL operations through a wolfHSM server (or any
other wolfCrypt device callback) via the provider interface.

This PR closes that gap for RSA, ECC, and DH:

- Adds `int devId` to `WOLFPROV_CTX`, initialized to `INVALID_DEVID` (no behavior change for existing users)
- Exposes `wolfprovider_devid` as a settable `OSSL_PARAM` so callers can configure the device ID at runtime
- Routes `devId` through RSA (`wc_InitRsaKey_ex`), ECC (`wc_ecc_init_ex`), and DH (`wc_InitDhKey_ex`) key init calls
- Routes `devId` through the ECX gen-context RNG init (`wc_InitRng_ex`)

## Known gap

ECX key init functions (`wc_curve25519_init`, `wc_ed25519_init`, `wc_ed448_init`) use `WP_ECX_INIT` function pointers typed as `int(*)(void*)`, which carry no `devId` parameter. Routing devId through ECX key init requires changing the table shape and all four call sites — that is a larger, separate change. The RNG used during ECX key generation does use `devId` after this PR.

`wc_curve448_init_ex` does not exist in wolfCrypt as of wolfSSL 5.x, so curve448 cannot be fixed without a wolfCrypt change.

## Behavior for existing users

`devId` defaults to `INVALID_DEVID`, so all existing behavior is unchanged unless the caller explicitly sets `wolfprovider_devid` via `OSSL_PROVIDER_set_params`.

## Test plan

- [ ] Existing wolfProvider test suite passes (no regression)
- [ ] RSA sign/verify routes through wolfHSM device callback when `wolfprovider_devid` is set to `WH_DEV_ID`
- [ ] ECC sign/verify routes through wolfHSM device callback when `wolfprovider_devid` is set
- [ ] DH key agreement routes through wolfHSM device callback when `wolfprovider_devid` is set
- [ ] Setting `wolfprovider_devid` to `INVALID_DEVID` restores direct wolfCrypt behavior