### PR TITLE
Fix sssd issue in CI

### DIFF
--- a/.github/workflows/sssd.yml
+++ b/.github/workflows/sssd.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sssd_ref: [ 'master', '2.9.1' ]
+        sssd_ref: [ '2.9.1' ]
         wolfssl_ref: [ 'master', 'v5.8.0-stable' ]
         openssl_ref: [ 'openssl-3.5.0' ]
         force_fail: ['WOLFPROV_FORCE_FAIL=1', '']


### PR DESCRIPTION
Add newly required `libndr-krb5pac-dev` for sssd build and test.