### PR TITLE
Use WC_MIN_DIGEST_SIZE for min digest len check on ECDSA

### DIFF
--- a/src/wp_ecdsa_sig.c
+++ b/src/wp_ecdsa_sig.c
@@ -32,8 +32,12 @@
 
 #ifdef WP_HAVE_ECDSA
 
-/* SHA-1 digest size; literal because WC_SHA_DIGEST_SIZE is !NO_SHA-gated. */
-#define WP_ECDSA_MIN_HASH_LEN 20
+/* WC_MIN_DIGEST_SIZE was introduced in wolfSSL v5.9.1. Fall back to the
+ * SHA-1 digest size on older releases so the raw-ECDSA minimum matches the
+ * behavior FIPS 186-4 requires. */
+#ifndef WC_MIN_DIGEST_SIZE
+#define WC_MIN_DIGEST_SIZE 20
+#endif
 
 /**
  * ECDSA signature context.
@@ -287,7 +291,7 @@ static int wp_ecdsa_sign(wp_EcdsaSigCtx *ctx, unsigned char *sig,
             ok = 0;
         }
         else if ((hashType == WC_HASH_TYPE_NONE) &&
-                 (tbsLen < WP_ECDSA_MIN_HASH_LEN)) {
+                 (tbsLen < WC_MIN_DIGEST_SIZE)) {
             ok = 0;
         }
         else if ((ok = wp_ecc_check_usage(ctx->ecc))) {
@@ -384,7 +388,7 @@ static int wp_ecdsa_verify(wp_EcdsaSigCtx *ctx, const unsigned char *sig,
             ok = 0;
         }
         else if ((hashType == WC_HASH_TYPE_NONE) &&
-                 (tbsLen < WP_ECDSA_MIN_HASH_LEN)) {
+                 (tbsLen < WC_MIN_DIGEST_SIZE)) {
             ok = 0;
         }
         else {

--- a/test/test_ecc.c
+++ b/test/test_ecc.c
@@ -24,6 +24,13 @@
 #include <openssl/core_names.h>
 #include <openssl/param_build.h>
 
+#include <wolfssl/wolfcrypt/hash.h>
+
+/* Mirror the fallback used in src/wp_ecdsa_sig.c for wolfSSL < v5.9.1. */
+#ifndef WC_MIN_DIGEST_SIZE
+#define WC_MIN_DIGEST_SIZE 20
+#endif
+
 #ifdef WP_HAVE_ECC
 
 #if defined(WP_HAVE_ECDSA) || defined(WP_HAVE_ECDH)
@@ -1196,17 +1203,23 @@ int test_ecdsa_p256_pkey(void *data)
     return err;
 }
 
-/* Raw EVP_PKEY_verify must reject sub-SHA-1 inputs. */
+/* Raw EVP_PKEY_verify must reject inputs below WC_MIN_DIGEST_SIZE. */
 int test_ecdsa_verify_undersized_hash(void *data)
 {
-    static const size_t sizes[]      = { 0, 19, 20, 32 };
-    static const int    expectFail[] = { 1,  1,  0,  0 };
+    /* Boundaries track WC_MIN_DIGEST_SIZE so the assertions stay valid for
+     * whatever hash set the wolfSSL build enabled (typically 20 for SHA-1,
+     * but 16 when MD5 is on or 28+ in FIPS 186-5 builds). */
+    static const size_t sizes[]      = { 0,
+                                         WC_MIN_DIGEST_SIZE - 1,
+                                         WC_MIN_DIGEST_SIZE,
+                                         WC_MAX_DIGEST_SIZE };
+    static const int    expectFail[] = { 1, 1, 0, 0 };
     int err;
     size_t i;
     EVP_PKEY *pkey = NULL;
     unsigned char ecdsaSig[80];
     size_t ecdsaSigLen;
-    unsigned char buf[32];
+    unsigned char buf[WC_MAX_DIGEST_SIZE];
     const unsigned char *p = ecc_key_der_256;
 
     (void)data;


### PR DESCRIPTION
Use WC_MIN_DIGEST_SIZE instead of hardcoded 20 for min digest len check.