### PR TITLE
fips-baseline: re-add SSHKDF to default and FIPS providers

### DIFF
--- a/patches/openssl-fips-baseline/providers/defltprov/3.0.0-3.1.x.c
+++ b/patches/openssl-fips-baseline/providers/defltprov/3.0.0-3.1.x.c
@@ -141,6 +141,7 @@ static const OSSL_ALGORITHM deflt_kdfs[] = {
     { PROV_NAMES_PBKDF2, "provider=default", ossl_kdf_pbkdf2_functions },
     { PROV_NAMES_TLS1_PRF, "provider=default", ossl_kdf_tls1_prf_functions },
     { PROV_NAMES_KBKDF, "provider=default", ossl_kdf_kbkdf_functions },
+    { PROV_NAMES_SSHKDF, "provider=default", ossl_kdf_sshkdf_functions },
     { NULL, NULL, NULL }
 };
 

--- a/patches/openssl-fips-baseline/providers/defltprov/3.2.0-3.3.x.c
+++ b/patches/openssl-fips-baseline/providers/defltprov/3.2.0-3.3.x.c
@@ -141,6 +141,7 @@ static const OSSL_ALGORITHM deflt_kdfs[] = {
     { PROV_NAMES_PBKDF2, "provider=default", ossl_kdf_pbkdf2_functions },
     { PROV_NAMES_TLS1_PRF, "provider=default", ossl_kdf_tls1_prf_functions },
     { PROV_NAMES_KBKDF, "provider=default", ossl_kdf_kbkdf_functions },
+    { PROV_NAMES_SSHKDF, "provider=default", ossl_kdf_sshkdf_functions },
     { NULL, NULL, NULL }
 };
 

--- a/patches/openssl-fips-baseline/providers/defltprov/3.4.0-3.4.x.c
+++ b/patches/openssl-fips-baseline/providers/defltprov/3.4.0-3.4.x.c
@@ -134,6 +134,7 @@ static const OSSL_ALGORITHM deflt_kdfs[] = {
     { PROV_NAMES_PBKDF2, "provider=default", ossl_kdf_pbkdf2_functions },
     { PROV_NAMES_TLS1_PRF, "provider=default", ossl_kdf_tls1_prf_functions },
     { PROV_NAMES_KBKDF, "provider=default", ossl_kdf_kbkdf_functions },
+    { PROV_NAMES_SSHKDF, "provider=default", ossl_kdf_sshkdf_functions },
     { NULL, NULL, NULL }
 };
 

--- a/patches/openssl-fips-baseline/providers/defltprov/3.5.0+.c
+++ b/patches/openssl-fips-baseline/providers/defltprov/3.5.0+.c
@@ -164,6 +164,7 @@ static const OSSL_ALGORITHM deflt_kdfs[] = {
     { PROV_NAMES_TLS1_PRF, "provider=default", ossl_kdf_tls1_prf_functions },
     { PROV_NAMES_KBKDF, "provider=default", ossl_kdf_kbkdf_functions },
     { PROV_NAMES_KRB5KDF, "provider=default", ossl_kdf_krb5kdf_functions },
+    { PROV_NAMES_SSHKDF, "provider=default", ossl_kdf_sshkdf_functions },
     { NULL, NULL, NULL }
 };
 

--- a/patches/openssl-fips-baseline/providers/fips/fipsprov/3.0.0-3.1.x.c
+++ b/patches/openssl-fips-baseline/providers/fips/fipsprov/3.0.0-3.1.x.c
@@ -308,6 +308,7 @@ static const OSSL_ALGORITHM fips_kdfs[] = {
     { PROV_NAMES_TLS1_PRF, FIPS_DEFAULT_PROPERTIES,
       ossl_kdf_tls1_prf_functions },
     { PROV_NAMES_KBKDF, FIPS_DEFAULT_PROPERTIES, ossl_kdf_kbkdf_functions },
+    { PROV_NAMES_SSHKDF, FIPS_DEFAULT_PROPERTIES, ossl_kdf_sshkdf_functions },
     { NULL, NULL, NULL }
 };
 

--- a/patches/openssl-fips-baseline/providers/fips/fipsprov/3.2.0-3.3.x.c
+++ b/patches/openssl-fips-baseline/providers/fips/fipsprov/3.2.0-3.3.x.c
@@ -308,6 +308,7 @@ static const OSSL_ALGORITHM fips_kdfs[] = {
     { PROV_NAMES_TLS1_PRF, FIPS_DEFAULT_PROPERTIES,
       ossl_kdf_tls1_prf_functions },
     { PROV_NAMES_KBKDF, FIPS_DEFAULT_PROPERTIES, ossl_kdf_kbkdf_functions },
+    { PROV_NAMES_SSHKDF, FIPS_DEFAULT_PROPERTIES, ossl_kdf_sshkdf_functions },
     { NULL, NULL, NULL }
 };
 

--- a/patches/openssl-fips-baseline/providers/fips/fipsprov/3.4.0-3.4.x.c
+++ b/patches/openssl-fips-baseline/providers/fips/fipsprov/3.4.0-3.4.x.c
@@ -314,6 +314,7 @@ static const OSSL_ALGORITHM fips_kdfs[] = {
     { PROV_NAMES_TLS1_PRF, FIPS_DEFAULT_PROPERTIES,
       ossl_kdf_tls1_prf_functions },
     { PROV_NAMES_KBKDF, FIPS_DEFAULT_PROPERTIES, ossl_kdf_kbkdf_functions },
+    { PROV_NAMES_SSHKDF, FIPS_DEFAULT_PROPERTIES, ossl_kdf_sshkdf_functions },
     { NULL, NULL, NULL }
 };
 

--- a/patches/openssl-fips-baseline/providers/fips/fipsprov/3.5.0-3.5.1.c
+++ b/patches/openssl-fips-baseline/providers/fips/fipsprov/3.5.0-3.5.1.c
@@ -343,6 +343,7 @@ static const OSSL_ALGORITHM fips_kdfs[] = {
     { PROV_NAMES_TLS1_PRF, FIPS_DEFAULT_PROPERTIES,
       ossl_kdf_tls1_prf_functions },
     { PROV_NAMES_KBKDF, FIPS_DEFAULT_PROPERTIES, ossl_kdf_kbkdf_functions },
+    { PROV_NAMES_SSHKDF, FIPS_DEFAULT_PROPERTIES, ossl_kdf_sshkdf_functions },
     { NULL, NULL, NULL }
 };
 

--- a/patches/openssl-fips-baseline/providers/fips/fipsprov/3.5.2+.c
+++ b/patches/openssl-fips-baseline/providers/fips/fipsprov/3.5.2+.c
@@ -343,6 +343,7 @@ static const OSSL_ALGORITHM fips_kdfs[] = {
     { PROV_NAMES_TLS1_PRF, FIPS_DEFAULT_PROPERTIES,
       ossl_kdf_tls1_prf_functions },
     { PROV_NAMES_KBKDF, FIPS_DEFAULT_PROPERTIES, ossl_kdf_kbkdf_functions },
+    { PROV_NAMES_SSHKDF, FIPS_DEFAULT_PROPERTIES, ossl_kdf_sshkdf_functions },
     { NULL, NULL, NULL }
 };
 


### PR DESCRIPTION
Follow-up to #382. The fips-baseline patches strip SSHKDF from the default and FIPS provider tables, but it's FIPS-compliant (SHA-2 only) and stock OpenSSL 3 ships it in both. Restoring it across the four defltprov and five fipsprov variants so applications built against fips-baseline OpenSSL can still `EVP_KDF_fetch("SSHKDF")` -- specifically RHEL openssh, which goes through that fetch on every key exchange via Patch964.