### PR TITLE
Prep wolfProvider 1.2.0 release

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,40 @@
+# wolfProvider version 1.2.0 (June 08, 2026)
+
+Release 1.2.0 has been developed according to wolfSSL's development and QA
+process and successfully passed the quality criteria.
+
+PR stands for Pull Request, and PR <NUMBER> references a GitHub pull request
+number where the code change was added.
+
+## New Feature Additions
+* Add SSHKDF implementation (PR 382)
+* Add proper TLS MAC handling (PR 360)
+
+## Enhancements and Optimizations
+* Add FIPS integration and general integration guides to distribution packages
+* Add OpenSSL FIPS baseline patches, replace-default patch assets, and provider configs to distribution packages
+* Add helper scripts for FIPS patching, replace-default test exports, reference resolution, and install verification to distribution packages
+* Improve replace-default provider behavior for re-entrant use
+* Improve ECC signing and verification digest size checks
+* Add KBKDF and KRB5 KDF validation and hardening improvements (PR 376, PR 380, PR 395)
+* Improve Debian package builds for seed-src, debug, and local source handling (PR 383, PR 384)
+* Migrate CI package artifact storage to GHCR ORAS with integrity checks (PR 362)
+* Improve OSP CI dispatch and test dependency publishing workflows (PR 400, PR 401, PR 402, PR 403)
+
+## Bug Fixes
+* Fix DRBG size cast issue (PR 386)
+* Fix constant-time compare and TLS padding handling with negative tests (PR 385)
+* Fix missing AES initialization in KRB5 KDF (PR 378)
+* Fix PSS defaults pointer dereference
+* Fix UKM memory leak in DH/ECDH free paths
+* Fix AEAD random IV handling
+* Fix aarch64 compile issue (PR 373)
+* Fix DH/ECDH string length checks and related robustness issues
+* Fix ECX get_params handling to restore unclamped private key bytes (PR 389)
+* Fix seed-src clear_seed state handling (PR 389)
+* Fix HMAC, CMAC, RSA, TLS, and KDF bounds, cleanup, and return-code checks (PR 377, PR 387, PR 389)
+* Fix SSSD CI issue (PR 393)
+
 # wolfProvider version 1.1.1 (February 09, 2026)
 
 Release 1.1.1 has been developed according to wolfSSL's development and QA

--- a/Makefile.am
+++ b/Makefile.am
@@ -18,6 +18,10 @@ EXTRA_DIST+=ChangeLog.md
 EXTRA_DIST+=README.md
 EXTRA_DIST+=IDE
 EXTRA_DIST+=examples
+EXTRA_DIST+=docs
+EXTRA_DIST+=patches
+EXTRA_DIST+=provider.conf
+EXTRA_DIST+=provider-fips.conf
 
 include src/include.am
 include include/include.am
@@ -46,4 +50,3 @@ test: check
 # The '--with-wolfssl' doesn't get propagated during a distcheck either, but it
 # is necessary when they are installed somewhere other than /usr/local.
 AM_DISTCHECK_CONFIGURE_FLAGS=CPPFLAGS="-I@abs_top_srcdir@/include" --with-openssl=@OPENSSL_INSTALL_DIR@ --with-wolfssl=@WOLFSSL_INSTALL_DIR@
-

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Information on how to configure, build, and test wolfProvider can be found here:
 * TLS1 PRF
 * KBKDF
 * KRB5 KDF
+* SSHKDF
 
 ### Random
 * CTR-DRBG

--- a/configure.ac
+++ b/configure.ac
@@ -5,7 +5,7 @@
 
 AC_COPYRIGHT([Copyright (C) 2024 wolfSSL Inc.])
 AC_PREREQ([2.69])
-AC_INIT([wolfprov], [1.1.1])
+AC_INIT([wolfprov], [1.2.0])
 AC_CONFIG_AUX_DIR([build-aux])
 
 AC_CONFIG_HEADERS([include/config.h])
@@ -226,4 +226,3 @@ echo "   * Dynamic provider:           $ENABLED_DYNAMIC_PROVIDER"
 echo "   * Replace default:            $ENABLED_REPLACE_DEFAULT"
 echo ""
 echo "---"
-

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+libwolfprov (1.2.0-1) unstable; urgency=medium
+
+  * Release version 1.2.0-1
+
+ -- WolfSSL Developer <support@wolfssl.com>  Mon, 08 Jun 2026 11:33:41 -0700
+
 libwolfprov (1.1.1-1) unstable; urgency=medium
 
   * Release version 1.1.1-1

--- a/docs/INTEGRATION_GUIDE.md
+++ b/docs/INTEGRATION_GUIDE.md
@@ -206,12 +206,6 @@ This should list wolfProvider among the available providers.
 make test
 ```
 
-### Run Command Line Tests
-
-```bash
-./scripts/run-tests.sh
-```
-
 If any tests fail, enable debug logging (see the [Debugging](#debugging) section) and review the output for details.
 
 ---

--- a/scripts/include.am
+++ b/scripts/include.am
@@ -1,8 +1,10 @@
 dist_noinst_SCRIPTS += scripts/build-wolfprovider.sh
-dist_noinst_SCRIPTS += scripts/test-openssl.sh
-dist_noinst_SCRIPTS += scripts/test-wp-cs.sh
+dist_noinst_SCRIPTS += scripts/env-setup
+dist_noinst_SCRIPTS += scripts/patch-libcrypto-exports.sh
+dist_noinst_SCRIPTS += scripts/patch-openssl-fips.sh
+dist_noinst_SCRIPTS += scripts/resolve-ref.sh
 dist_noinst_SCRIPTS += scripts/utils-openssl.sh
 dist_noinst_SCRIPTS += scripts/utils-wolfssl.sh
 dist_noinst_SCRIPTS += scripts/utils-wolfprovider.sh
 dist_noinst_SCRIPTS += scripts/utils-general.sh
-dist_noinst_SCRIPTS += scripts/env-setup
+dist_noinst_SCRIPTS += scripts/verify-install.sh


### PR DESCRIPTION
Summary:
- Bump wolfProvider to 1.2.0
- Add release notes and Debian changelog entry
- Include release docs, patches, configs, and helper scripts in dist

Testing:
- git diff --check