### PR TITLE
ci: harden osp-triage nightly report — fix crash on large runs + silence retry message

### DIFF
--- a/.github/scripts/osp-triage.py
+++ b/.github/scripts/osp-triage.py
@@ -23,6 +23,7 @@ import datetime
 import json
 import os
 import re
+import time
 import urllib.error
 import urllib.request
 from collections import OrderedDict
@@ -70,33 +71,61 @@ SCRUB = [
 ]
 
 
+RETRY_CODES = {429, 500, 502, 503, 504}
+
+
 def gh(path, method="GET", data=None):
     url = path if path.startswith("http") else GH_API + path
-    req = urllib.request.Request(url, method=method)
-    req.add_header("Authorization", f"Bearer {GH_TOKEN}")
-    req.add_header("Accept", "application/vnd.github+json")
-    req.add_header("X-GitHub-Api-Version", "2022-11-28")
-    if data is not None:
-        req.data = json.dumps(data).encode()
-        req.add_header("Content-Type", "application/json")
-    with urllib.request.urlopen(req, timeout=60) as r:
-        body = r.read()
-    return json.loads(body) if body else {}
+    last = None
+    for attempt in range(5):
+        req = urllib.request.Request(url, method=method)
+        req.add_header("Authorization", f"Bearer {GH_TOKEN}")
+        req.add_header("Accept", "application/vnd.github+json")
+        req.add_header("X-GitHub-Api-Version", "2022-11-28")
+        if data is not None:
+            req.data = json.dumps(data).encode()
+            req.add_header("Content-Type", "application/json")
+        try:
+            with urllib.request.urlopen(req, timeout=60) as r:
+                body = r.read()
+            return json.loads(body) if body else {}
+        except urllib.error.HTTPError as e:
+            last = e
+            if e.code not in RETRY_CODES or attempt == 4:
+                raise
+        except urllib.error.URLError as e:
+            last = e
+            if attempt == 4:
+                raise
+        time.sleep(2 ** attempt)
+    raise last
+
+
+# GitHub's jobs endpoint 502s on per_page=100 for large runs (400+ jobs);
+# 50 is reliable. Keep in sync with the page-exhaustion check below.
+JOBS_PER_PAGE = 50
+
+
+_JOBS_CACHE = {}
 
 
 def all_jobs(run_id, attempt=None):
+    key = (str(run_id), attempt)
+    if key in _JOBS_CACHE:
+        return _JOBS_CACHE[key]
     jobs = []
     base = f"/repos/{REPO}/actions/runs/{run_id}"
     if attempt:
         base += f"/attempts/{attempt}"
     page = 1
     while True:
-        d = gh(f"{base}/jobs?per_page=100&page={page}")
+        d = gh(f"{base}/jobs?per_page={JOBS_PER_PAGE}&page={page}")
         batch = d.get("jobs", [])
         jobs += batch
-        if len(batch) < 100:
+        if len(batch) < JOBS_PER_PAGE:
             break
         page += 1
+    _JOBS_CACHE[key] = jobs
     return jobs
 
 
@@ -215,10 +244,17 @@ def post_slack(color, fallback, blocks):
         print(render_text(blocks))
         return
     data = json.dumps(payload).encode()
-    req = urllib.request.Request(SLACK_WEBHOOK, data=data, method="POST")
-    req.add_header("Content-Type", "application/json")
-    with urllib.request.urlopen(req, timeout=30) as r:
-        r.read()
+    for attempt in range(4):
+        req = urllib.request.Request(SLACK_WEBHOOK, data=data, method="POST")
+        req.add_header("Content-Type", "application/json")
+        try:
+            with urllib.request.urlopen(req, timeout=30) as r:
+                r.read()
+            return
+        except (urllib.error.HTTPError, urllib.error.URLError):
+            if attempt == 3:
+                raise
+            time.sleep(2 ** attempt)
 
 
 def render_text(blocks):
@@ -316,17 +352,14 @@ def main():
     run = gh(f"/repos/{REPO}/actions/runs/{RUN_ID}")
     attempt = int(FORCE_ATTEMPT) if FORCE_ATTEMPT else run.get("run_attempt", 1)
 
-    # Phase 1 — retry everything that did not pass, exactly once.
+    # Phase 1 — silently retry everything that did not pass, exactly once.
+    # No interim Slack post; the attempt-2 report is the only message.
     if AUTO_RETRY and not FORCE_ATTEMPT and attempt == 1:
         nonpass = [j for j in all_jobs(RUN_ID)
                    if j.get("conclusion") in ("failure", "cancelled")]
         if nonpass:
             gh(f"/repos/{REPO}/actions/runs/{RUN_ID}/rerun-failed-jobs",
                method="POST")
-            note = (f"*wolfProvider Nightly OSP* — {len(nonpass)} job(s) didn't "
-                    f"pass on attempt 1; retrying once before triage. "
-                    f"<{run_url()}|View run>")
-            post_slack("warning", note, [section(note)])
             return
 
     jobs = merged_jobs(attempt)

--- a/.github/scripts/osp-triage.py
+++ b/.github/scripts/osp-triage.py
@@ -74,10 +74,15 @@ SCRUB = [
 RETRY_CODES = {429, 500, 502, 503, 504}
 
 
-def gh(path, method="GET", data=None):
+def backoff_delay(err, attempt):
+    ra = err.headers.get("Retry-After", "") if hasattr(err, "headers") else ""
+    return int(ra) if ra.isdigit() else 2 ** attempt
+
+
+def gh(path, method="GET", data=None, retry=True):
     url = path if path.startswith("http") else GH_API + path
-    last = None
-    for attempt in range(5):
+    attempts = 5 if retry else 1
+    for attempt in range(attempts):
         req = urllib.request.Request(url, method=method)
         req.add_header("Authorization", f"Bearer {GH_TOKEN}")
         req.add_header("Accept", "application/vnd.github+json")
@@ -90,15 +95,14 @@ def gh(path, method="GET", data=None):
                 body = r.read()
             return json.loads(body) if body else {}
         except urllib.error.HTTPError as e:
-            last = e
-            if e.code not in RETRY_CODES or attempt == 4:
+            if e.code not in RETRY_CODES or attempt == attempts - 1:
                 raise
-        except urllib.error.URLError as e:
-            last = e
-            if attempt == 4:
+            delay = backoff_delay(e, attempt)
+        except urllib.error.URLError:
+            if attempt == attempts - 1:
                 raise
-        time.sleep(2 ** attempt)
-    raise last
+            delay = 2 ** attempt
+        time.sleep(delay)
 
 
 # GitHub's jobs endpoint 502s on per_page=100 for large runs (400+ jobs);
@@ -251,10 +255,15 @@ def post_slack(color, fallback, blocks):
             with urllib.request.urlopen(req, timeout=30) as r:
                 r.read()
             return
-        except (urllib.error.HTTPError, urllib.error.URLError):
+        except urllib.error.HTTPError as e:
+            if e.code not in RETRY_CODES or attempt == 3:
+                raise
+            delay = backoff_delay(e, attempt)
+        except urllib.error.URLError:
             if attempt == 3:
                 raise
-            time.sleep(2 ** attempt)
+            delay = 2 ** attempt
+        time.sleep(delay)
 
 
 def render_text(blocks):
@@ -359,7 +368,7 @@ def main():
                    if j.get("conclusion") in ("failure", "cancelled")]
         if nonpass:
             gh(f"/repos/{REPO}/actions/runs/{RUN_ID}/rerun-failed-jobs",
-               method="POST")
+               method="POST", retry=False)
             return
 
     jobs = merged_jobs(attempt)


### PR DESCRIPTION
# Description

needs https://github.com/wolfSSL/wolfProvider/pull/406

The nightly OSP Slack report would post the interim *"N job(s) didn't pass on attempt 1; retrying"* message and then **never post the final health card** for large runs — leaving a confusing "is it broken?" state even when the nightly was healthy.

- Page the jobs endpoint at `per_page=50` (verified clean through all 22 pages / 1081 jobs).
- `gh()` retries `429/500/502/503/504` with exponential backoff; the final Slack POST retries too.
- Auto-retry now runs **silently** — no interim "retrying" Slack message; the only message is the final clean health card (`healthy` / `N real failures`).
- Memoize the per-attempt job-list fetch so the 1000+-job pagination isn't repeated.