### PR TITLE
dh: don't export FFC_Q for PKCS#3 keys (fix OpenSSL 3.6.3 DH interop)

### DIFF
--- a/src/wp_dh_kmgmt.c
+++ b/src/wp_dh_kmgmt.c
@@ -1280,8 +1280,10 @@ static size_t wp_dh_export_group_alloc_size(wp_Dh* dh)
     name = wp_dh_get_group_name(dh);
     if (name == NULL) {
         sz  = mp_unsigned_bin_size(&dh->key.p) +
-              mp_unsigned_bin_size(&dh->key.g) +
-              mp_unsigned_bin_size(&dh->key.q);
+              mp_unsigned_bin_size(&dh->key.g);
+        if (!mp_iszero(&dh->key.q)) {
+            sz += mp_unsigned_bin_size(&dh->key.q);
+        }
     }
 
     return sz;
@@ -1323,7 +1325,9 @@ static int wp_dh_export_group(wp_Dh* dh, OSSL_PARAM params[], int* pIdx,
                 &dh->key.g, data, idx))) {
             ok = 0;
         }
-        if (ok && (!wp_param_set_mp(&params[i++], OSSL_PKEY_PARAM_FFC_Q,
+        /* PKCS#3 DH keys carry no q; exporting q=0 fails peer subgroup checks */
+        if (ok && (!mp_iszero(&dh->key.q)) &&
+                (!wp_param_set_mp(&params[i++], OSSL_PKEY_PARAM_FFC_Q,
                 &dh->key.q, data, idx))) {
             ok = 0;
         }


### PR DESCRIPTION
## Problem

CI fails on `openssl-3.6.3` (every 3.6.3 job red, 3.0.17 green) in unit test # 78 `test_dh_pkey`, at `EVP_PKEY_derive_set_peer()`.

OpenSSL 3.6.3 ships the fix for **CVE-2026-42770** ("FFC-DH peer validation uses attacker-supplied `q`"): `EVP_PKEY_derive_set_peer()` now validates the peer DH key's subgroup membership using its `q` parameter.

`test_dh_pkey` imports a **plain PKCS#3 DH key** (`DH_set0_pqg(dh, p, NULL, g)` — no `q`, custom non-named prime). When OpenSSL pulls the wolfProvider peer key across the provider bridge, it calls `wp_dh_export` → `wp_dh_export_group`, which **unconditionally exported `FFC_Q`** — handing OpenSSL `q=0`. The new check then validated the peer against a bogus zero subgroup order and rejected it.

`test_dh_pgen_pkey` was unaffected because its generated params carry a real (non-zero) `q`.

## Fix

Only export `FFC_Q` when the key actually has one, using the file's existing `!mp_iszero(&dh->key.q)` idiom (already used at lines 904, 1696):

- `wp_dh_export_group` — skip the `FFC_Q` param when `q` is zero.
- `wp_dh_export_group_alloc_size` — size the buffer to match.

A PKCS#3 DH key genuinely has no `q`; exporting `q=0` was always semantically wrong — OpenSSL just never used it until 3.6.3. Named-group and DHX keys (real `q`) are unaffected.