### PR TITLE
cmd_test: default WOLFPROV_FORCE_FAIL to 0 in ecc-cmd-test.sh

### DIFF
--- a/scripts/cmd_test/ecc-cmd-test.sh
+++ b/scripts/cmd_test/ecc-cmd-test.sh
@@ -40,6 +40,8 @@ echo "This is test data for ECC signing and verification." > ecc_outputs/test_da
 CURVES=("prime256v1" "secp384r1" "secp521r1")
 PROVIDER_NAMES=("libwolfprov" "default")
 
+WOLFPROV_FORCE_FAIL=${WOLFPROV_FORCE_FAIL:-0}
+
 # Function to validate key
 validate_key() {
     local curve=$1


### PR DESCRIPTION
## Problem

When `WOLFPROV_FORCE_FAIL` is unset (the normal case), `scripts/cmd_test/ecc-cmd-test.sh` emits a shell error on every ECC key test:

```
[PASS] libwolfprov can use ECC key (prime256v1)
ecc-cmd-test.sh: line 259: [: -ne: unary operator expected
```

The guard for the force-fail re-run uses an unquoted numeric test:

```sh
if [ $WOLFPROV_FORCE_FAIL -ne 0 ]; then
```

With the variable unset, this expands to `[ -ne 0 ]`, producing `unary operator expected`. The condition still evaluates false, so the re-run is correctly skipped and **test results are unaffected** (the suite still reports PASS) — but the stderr noise is alarming and can trip CI that treats stderr as failure.

## Fix

Initialize the variable with a default at the top of the script, matching the pattern `rsa-cmd-test.sh` already uses (`WOLFPROV_FORCE_FAIL=${WOLFPROV_FORCE_FAIL:-0}`). One line; force-fail mode (`WOLFPROV_FORCE_FAIL=1`) behaves exactly as before.

## Verification

Reproduced and confirmed fixed end-to-end in a Yocto image build (wolfSSL FIPS + wolfProvider): 12 `unary operator expected` lines before, 0 after, with the full command-line suite still PASS. Reported by a customer running the cmd-test suite on-target.