### PR TITLE
Add cache built OpenSSL/wolfSSL deps in PR builders to speedup builds in CI

### DIFF
--- a/.github/actions/cache-build-deps/action.yml
+++ b/.github/actions/cache-build-deps/action.yml
@@ -1,0 +1,62 @@
+name: Cache build dependencies
+description: Restore cached OpenSSL/wolfSSL installs keyed by resolved commit SHA so build-wolfprovider.sh skips configure+make on a hit.
+
+inputs:
+  variant:
+    description: Token capturing every build-config dimension that changes the produced binaries (compiler, debug, replace-default, seed-src, fips). Distinct configs must use distinct variants.
+    required: true
+  openssl_ref:
+    description: OpenSSL tag/branch/sha, resolved to a SHA for the cache key.
+    required: true
+  wolfssl_ref:
+    description: wolfSSL tag/branch/sha, resolved to a SHA for the cache key. Ignored when wolfssl_fixed_key is set.
+    required: false
+    default: ''
+  wolfssl_fixed_key:
+    description: Verbatim wolfSSL cache key, used instead of resolving wolfssl_ref (FIPS bundle case - fixed stable version with no git ref).
+    required: false
+    default: ''
+  cache_openssl_source:
+    description: Also cache openssl-source. Required for --replace-default / --fips-baseline builds whose mismatch checks read the patched source.
+    required: false
+    default: 'false'
+  github_token:
+    description: Token passed to resolve-ref.sh to avoid GitHub API rate limits.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve OpenSSL ref
+      id: openssl-ref
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.github_token }}
+      run: echo "sha=$("${GITHUB_WORKSPACE}/scripts/resolve-ref.sh" "${{ inputs.openssl_ref }}" openssl/openssl)" >> "$GITHUB_OUTPUT"
+
+    - name: Resolve wolfSSL ref
+      id: wolfssl-ref
+      if: inputs.wolfssl_fixed_key == ''
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.github_token }}
+      run: echo "sha=$("${GITHUB_WORKSPACE}/scripts/resolve-ref.sh" "${{ inputs.wolfssl_ref }}" wolfssl/wolfssl)" >> "$GITHUB_OUTPUT"
+
+    - name: Cache OpenSSL install
+      uses: actions/cache@v4
+      with:
+        path: openssl-install
+        key: openssl-install-${{ inputs.variant }}-${{ steps.openssl-ref.outputs.sha }}-${{ hashFiles('scripts/utils-openssl.sh', 'scripts/utils-wolfssl.sh', 'scripts/build-wolfprovider.sh') }}
+
+    - name: Cache OpenSSL source
+      if: inputs.cache_openssl_source == 'true'
+      uses: actions/cache@v4
+      with:
+        path: openssl-source
+        key: openssl-source-${{ inputs.variant }}-${{ steps.openssl-ref.outputs.sha }}-${{ hashFiles('scripts/utils-openssl.sh', 'scripts/utils-wolfssl.sh', 'scripts/build-wolfprovider.sh') }}
+
+    - name: Cache wolfSSL install
+      uses: actions/cache@v4
+      with:
+        path: wolfssl-install
+        key: wolfssl-install-${{ inputs.variant }}-${{ inputs.wolfssl_fixed_key || steps.wolfssl-ref.outputs.sha }}-${{ hashFiles('scripts/utils-openssl.sh', 'scripts/utils-wolfssl.sh', 'scripts/build-wolfprovider.sh') }}

--- a/.github/workflows/cmdline.yml
+++ b/.github/workflows/cmdline.yml
@@ -50,6 +50,14 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Cache build dependencies
+        uses: ./.github/actions/cache-build-deps
+        with:
+          variant: cmdline${{ matrix.debug != '' && '-debug' || '' }}
+          openssl_ref: ${{ matrix.openssl_ref }}
+          wolfssl_ref: ${{ matrix.wolfssl_ref }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build wolfProvider
         run: |
           ${{ matrix.debug }} OPENSSL_TAG=${{ matrix.openssl_ref }} WOLFSSL_TAG=${{ matrix.wolfssl_ref }} ./scripts/build-wolfprovider.sh

--- a/.github/workflows/fips-ready.yml
+++ b/.github/workflows/fips-ready.yml
@@ -47,13 +47,30 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Cache build dependencies
+        uses: ./.github/actions/cache-build-deps
+        with:
+          variant: fips-ready
+          openssl_ref: ${{ matrix.openssl_ref }}
+          wolfssl_fixed_key: wolfssl-fips-${{ matrix.wolfssl_bundle_ref }}-${{ matrix.openssl_ref }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Cache FIPS Ready Bundle zip
+        uses: actions/cache@v4
+        with:
+          path: wolfssl-fips-ready.zip
+          key: wolfssl-fips-bundle-${{ matrix.wolfssl_bundle_ref }}
+
       - name: Download FIPS Ready Bundle
         run: |
-          # Download FIPS ready bundle from wolfSSL website
-          BUNDLE_URL="https://www.wolfssl.com/wolfssl-${{matrix.wolfssl_bundle_ref}}-gplv3-fips-ready.zip"
-          
-          wget -O wolfssl-fips-ready.zip "$BUNDLE_URL"
-          unzip wolfssl-fips-ready.zip
+          # Bundle is a fixed stable release; only fetch on a cache miss. The
+          # build script's bundle copy still needs the extracted tree present,
+          # so unzip runs every time.
+          if [ ! -f wolfssl-fips-ready.zip ]; then
+            BUNDLE_URL="https://www.wolfssl.com/wolfssl-${{matrix.wolfssl_bundle_ref}}-gplv3-fips-ready.zip"
+            wget -O wolfssl-fips-ready.zip "$BUNDLE_URL"
+          fi
+          unzip -o wolfssl-fips-ready.zip
 
           # Find the extracted directory (build script requires directory, not zip)
           BUNDLE_DIR=$(find . -maxdepth 1 -type d -name "*fips-ready*" | head -n 1)

--- a/.github/workflows/seed-src.yml
+++ b/.github/workflows/seed-src.yml
@@ -49,6 +49,14 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Cache build dependencies
+        uses: ./.github/actions/cache-build-deps
+        with:
+          variant: seed-src
+          openssl_ref: ${{ matrix.openssl_ref }}
+          wolfssl_ref: ${{ matrix.wolfssl_ref }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build and test wolfProvider with SEED-SRC
         run: |
              # Force wolfSSL to not use getrandom syscall via ac_cv_func_getrandom=no.

--- a/.github/workflows/simple.yml
+++ b/.github/workflows/simple.yml
@@ -56,6 +56,15 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Cache build dependencies
+        uses: ./.github/actions/cache-build-deps
+        with:
+          variant: simple${{ matrix.replace_default != '' && '-rd' || '' }}
+          openssl_ref: ${{ matrix.openssl_ref }}
+          wolfssl_ref: ${{ matrix.wolfssl_ref }}
+          cache_openssl_source: ${{ matrix.replace_default != '' }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build and test wolfProvider
         run: |
              OPENSSL_TAG=${{ matrix.openssl_ref }} \

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -57,6 +57,14 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Cache build dependencies
+        uses: ./.github/actions/cache-build-deps
+        with:
+          variant: smoke
+          openssl_ref: ${{ needs.discover_versions.outputs.openssl_latest_ref }}
+          wolfssl_ref: ${{ matrix.wolfssl_ref || needs.discover_versions.outputs.wolfssl_latest_ref }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build and test wolfProvider
         run: |
           # Resolve "stable" matrix row to the discovered latest tag.


### PR DESCRIPTION
# Description

Adds a reusable composite action `.github/actions/cache-build-deps` that caches
the built `openssl-install` / `wolfssl-install` (and `openssl-source` for
patched builds) keyed by resolved commit SHA, so `build-wolfprovider.sh` skips
the OpenSSL/wolfSSL configure+make on a cache hit. Wired into the normal-PR
from-source builders: `cmdline`, `simple`, `smoke-test`, `seed-src`,
`fips-ready`.

Pattern mirrors the existing `multi-compiler.yml` cache (resolve-ref -> SHA ->
`actions/cache`): a stable tag resolves to a fixed SHA (cached across runs);
`master` resolves to current HEAD (rebuilt only when upstream moves). The unit
under test (`wolfprov-install`) is never cached.

### Measured effect (verified on this PR: cold run 1 -> warm run 2)

| Workflow | cold avg (from scratch) | warm avg (cache hit) | speedup |
|---|---|---|---|
| cmdline | 283 s | 52 s | 5.4x |
| simple (incl. replace-default rows) | ~262 s | 41 s | 6.4x |
| smoke-test | 308 s | 49 s | 6.3x |
| seed-src | 298 s | 38 s | 7.8x |
| fips-ready | ~300 s | 44 s | ~7x |

Per heavy config the from-scratch dep build is ~5:30-5:50; on a warm cache the
build step drops to ~30-50 s (about 5 min saved per cached job). All builders
passed on both the cold and warm runs.

## Validation

- Warm-run log confirms `master` rows hit on the resolved HEAD SHA
  ("Cache hit ... Cache restored successfully"): master is reused when the commit
  is unchanged and rebuilds when it moves; stable tags hit unconditionally.
- Replace-default / FIPS-baseline rows (`simple.yml`) also cache `openssl-source`
  so the source-reading mismatch checks pass on a hit.
- Variant token encodes every build-config dimension (compiler/debug/
  replace-default/seed-src/fips) so no wrong-config cache hit.
- FIPS bundle cached by stable version; `wget` only runs on a cache miss.