### PR TITLE
fix wp_ecx_get_security_bits to return the correct security bits for x448 and x25519

### DIFF
--- a/src/wp_ecx_kmgmt.c
+++ b/src/wp_ecx_kmgmt.c
@@ -511,11 +511,15 @@ static int wp_ecx_get_security_bits(wp_Ecx* ecx)
 {
     int bits = 0;
 
-    if (ecx->data->bits >= 456) {
-        bits = 224;
-    }
-    else if (ecx->data->bits >= 256) {
-        bits = 128;
+    switch (ecx->data->keyType) {
+        case WP_KEY_TYPE_X448:
+        case WP_KEY_TYPE_ED448:
+            bits = 224;
+            break;
+        case WP_KEY_TYPE_X25519:
+        case WP_KEY_TYPE_ED25519:
+            bits = 128;
+            break;
     }
 
     return bits;

--- a/test/test_ecx.c
+++ b/test/test_ecx.c
@@ -26,11 +26,11 @@
 #include <wolfssl/wolfcrypt/ed25519.h>
 #include <wolfssl/wolfcrypt/ed448.h>
 
-#if defined(WP_HAVE_ED25519) || defined(WP_HAVE_ECD448)
-
 #ifndef ARRAY_SIZE
     #define ARRAY_SIZE(a)   ((sizeof(a)/sizeof(a[0])))
 #endif
+
+#if defined(WP_HAVE_ED25519) || defined(WP_HAVE_ED448)
 
 #ifndef MAX
     #define MAX(a,b)       ((a) > (b) ? (a) : (b))
@@ -656,7 +656,6 @@ static int test_ecx_null_sign_init_ex(OSSL_LIB_CTX *libCtx)
 
 #ifndef WP_HAVE_ED25519
     (void)libCtx;
-    (void)provider_name;
     PRINT_MSG("Skipping test - WP_HAVE_ED25519 not defined");
     return 0;
 #endif
@@ -895,5 +894,89 @@ int test_ecx_dup(void *data)
     return err;
 }
 
-#endif /* defined(WP_HAVE_ED25519) || defined(WP_HAVE_ECD444) */
+#endif /* defined(WP_HAVE_ED25519) || defined(WP_HAVE_ED448) */
+
+#if defined(WP_HAVE_X25519) || defined(WP_HAVE_X448)
+
+/*
+ * Check that the correct security bits are provided for x25519 and x448
+ */
+int test_ecx_x_security_bits(void *data)
+{
+    int err = 0;
+    (void)data;
+
+    EVP_PKEY *pkey_ossl = NULL;
+    EVP_PKEY *pkey_wolf = NULL;
+    EVP_PKEY_CTX *ctx_ossl = NULL;
+    EVP_PKEY_CTX *ctx_wolf = NULL;
+
+    struct {
+        const char *name;
+        int expectedBits;
+    } types[] = {
+#ifdef WP_HAVE_X25519
+        { "X25519", 128 },
+#endif
+#ifdef WP_HAVE_X448
+        { "X448", 224 },
+#endif
+    };
+
+    for (unsigned i = 0; i < ARRAY_SIZE(types) && err == 0; i++) {
+        if (err == 0) {
+            ctx_ossl = EVP_PKEY_CTX_new_from_name(osslLibCtx, types[i].name,
+                NULL);
+            err = ctx_ossl == NULL;
+        }
+        if (err == 0) {
+            ctx_wolf = EVP_PKEY_CTX_new_from_name(wpLibCtx, types[i].name,
+                NULL);
+            err = ctx_wolf == NULL;
+        }
+        if (err == 0) {
+            err = EVP_PKEY_keygen_init(ctx_ossl) != 1;
+        }
+        if (err == 0) {
+            err = EVP_PKEY_keygen_init(ctx_wolf) != 1;
+        }
+        if (err == 0) {
+            pkey_ossl = NULL;
+            err = EVP_PKEY_generate(ctx_ossl, &pkey_ossl) != 1;
+        }
+        if (err == 0) {
+            pkey_wolf = NULL;
+            err = EVP_PKEY_generate(ctx_wolf, &pkey_wolf) != 1;
+        }
+        if (err == 0) {
+            int sec_ossl = EVP_PKEY_get_security_bits(pkey_ossl);
+            int sec_wolf = EVP_PKEY_get_security_bits(pkey_wolf);
+            if (sec_ossl != sec_wolf) {
+                PRINT_MSG("EVP_PKEY_get_security_bits mismatch for %s:"
+                    " OpenSSL %d, wolfProvider %d", types[i].name, sec_ossl,
+                    sec_wolf);
+                err = 1;
+            }
+            else if (sec_wolf != types[i].expectedBits) {
+                PRINT_MSG("EVP_PKEY_get_security_bits failed for %s:"
+                    " expected %d, got %d", types[i].name,
+                    types[i].expectedBits, sec_wolf);
+                err = 1;
+            }
+        }
+
+        EVP_PKEY_free(pkey_ossl);
+        EVP_PKEY_free(pkey_wolf);
+        EVP_PKEY_CTX_free(ctx_ossl);
+        EVP_PKEY_CTX_free(ctx_wolf);
+        pkey_ossl = NULL;
+        pkey_wolf = NULL;
+        ctx_ossl = NULL;
+        ctx_wolf = NULL;
+    }
+
+    return err;
+}
+
+#endif /* defined(WP_HAVE_X25519) || defined(WP_HAVE_X448) */
 

--- a/test/unit.c
+++ b/test/unit.c
@@ -472,6 +472,9 @@ TEST_CASE test_case[] = {
 #endif
     TEST_DECL(test_ecx_dup, NULL),
 #endif
+#if defined(WP_HAVE_X25519) || defined(WP_HAVE_X448)
+    TEST_DECL(test_ecx_x_security_bits, NULL),
+#endif
 
     TEST_DECL(test_pkcs7_x509_sign_verify, NULL),
     TEST_DECL(test_x509_cert, NULL),

--- a/test/unit.h
+++ b/test/unit.h
@@ -470,6 +470,10 @@ int test_ecx_x25519_raw_priv_roundtrip(void *data);
 int test_ecx_dup(void *data);
 #endif
 
+#if defined(WP_HAVE_X25519) || defined(WP_HAVE_X448)
+int test_ecx_x_security_bits(void *data);
+#endif
+
 int test_pkcs7_x509_sign_verify(void *data);
 int test_x509_cert(void *data);
 


### PR DESCRIPTION
fix wp_ecx_get_security_bits threasholds so x25519 returns 128 and x448 returns 224