### PR TITLE
ci: fix nightly OSP after wolfSSL v5.9.2 bump (rolling deb-tag fallback + resolve-ref retry)

### DIFF
--- a/.github/workflows/build-wolfprovider.yml
+++ b/.github/workflows/build-wolfprovider.yml
@@ -136,6 +136,27 @@ jobs:
             return 1
           }
 
+          # Prefer the version-pinned snapshot tag; fall back to rolling only on a definitive not-found.
+          pick_wolfssl_tag() {
+            local base="$1"
+            local suffix="$2"
+            local img err attempt
+            [ -z "$suffix" ] && { echo "$base"; return; }
+            img="${base}${suffix}"
+            for attempt in 1 2 3; do
+              if err=$(oras manifest fetch "$img" 2>&1 >/dev/null); then
+                echo "$img"; return
+              fi
+              case "$err" in
+                *"not found"*|*"failed to resolve"*) echo "$base"; return ;;
+              esac
+              echo "manifest fetch $img failed (attempt $attempt): $err" >&2
+              [ "$attempt" -lt 3 ] && sleep $((attempt * 10))
+            done
+            # Transient errors exhausted: keep the pinned tag so the pull fails loudly, not a silent version swap.
+            echo "$img"
+          }
+
           # Pull the wolfSSL deb pinned to this job's wolfssl_ref when it is
           # a stable tag (vX.Y.Z-stable), so a v5.8.4-stable job gets the
           # v5.8.4 debs and a v5.9.1-stable job gets the v5.9.1 debs. Any
@@ -146,14 +167,12 @@ jobs:
           esac
 
           if [ "${{ inputs.fips_ref }}" = "FIPS" ]; then
-            echo "Pulling FIPS wolfSSL packages (fips${WOLFSSL_TAG_SUFFIX})..."
-            oras_pull_with_retry "ghcr.io/wolfssl/wolfprovider/debs:fips${WOLFSSL_TAG_SUFFIX}" \
-              ${{ env.WOLFSSL_PACKAGES_PATH }}
+            WOLFSSL_TAG=$(pick_wolfssl_tag "ghcr.io/wolfssl/wolfprovider/debs:fips" "${WOLFSSL_TAG_SUFFIX}")
           else
-            echo "Pulling non-FIPS wolfSSL packages (nonfips${WOLFSSL_TAG_SUFFIX})..."
-            oras_pull_with_retry "ghcr.io/wolfssl/wolfprovider/debs:nonfips${WOLFSSL_TAG_SUFFIX}" \
-              ${{ env.WOLFSSL_PACKAGES_PATH }}
+            WOLFSSL_TAG=$(pick_wolfssl_tag "ghcr.io/wolfssl/wolfprovider/debs:nonfips" "${WOLFSSL_TAG_SUFFIX}")
           fi
+          echo "Pulling wolfSSL packages (${WOLFSSL_TAG})..."
+          oras_pull_with_retry "${WOLFSSL_TAG}" ${{ env.WOLFSSL_PACKAGES_PATH }}
 
           # Pull OpenSSL packages based on replace_default setting
           if [ "${{ inputs.replace_default }}" = "true" ]; then

--- a/scripts/resolve-ref.sh
+++ b/scripts/resolve-ref.sh
@@ -18,10 +18,30 @@ if [[ "$REF" =~ ^[0-9a-f]{40}$ ]]; then
 else
     api_url="https://api.github.com/repos/$REPO/commits/$REF"
 
+    curl_args=(-fsSL)
     if [[ -n "${GITHUB_TOKEN:-}" ]]; then
-        sha=$(curl -fsSL -H "Authorization: Bearer $GITHUB_TOKEN" -H "Accept: application/vnd.github+json" "$api_url" | jq -r .sha)
-    else
-        sha=$(curl -fsSL "$api_url" | jq -r .sha)
+        curl_args+=(-H "Authorization: Bearer $GITHUB_TOKEN" -H "Accept: application/vnd.github+json")
+    fi
+
+    body=""
+    for attempt in 1 2 3 4 5; do
+        if body=$(curl "${curl_args[@]}" "$api_url"); then
+            break
+        fi
+        body=""
+        # GitHub rate-limits with 429/403; back off before retrying.
+        [[ "$attempt" -lt 5 ]] && sleep $((attempt * 10))
+    done
+
+    if [[ -z "$body" ]]; then
+        echo "resolve-ref: failed to resolve $REF in $REPO after retries" >&2
+        exit 1
+    fi
+
+    sha=$(echo "$body" | jq -r .sha)
+    if [[ -z "$sha" || "$sha" == "null" ]]; then
+        echo "resolve-ref: no sha for $REF in $REPO" >&2
+        exit 1
     fi
     echo "$sha"
 fi


### PR DESCRIPTION
Nightly CI broke after wolfSSL released v5.9.2: version discovery started labeling the latest ref v5.9.2-stable, but build-wolfprovider.yml then tried to pull a per-version deb tag (:fips-v5.9.2-stable) that was never published to ghcr, so the pull 404'd and took down all 39 Wave 1 OSP suites. I added a pick_wolfssl_tag helper that falls back to the rolling :fips/:nonfips tag (which is that version) when no per-version snapshot exists, self-healing for every future bump, while still failing loudly rather than silently swapping versions on a transient registry error.