### PR TITLE
Add bounds check on KRB5KDF constant length to prevent buffer overflow

### DIFF
--- a/src/wp_krb5kdf.c
+++ b/src/wp_krb5kdf.c
@@ -479,6 +479,9 @@ static int wp_kdf_krb5kdf_derive(wp_Krb5kdfCtx* ctx, unsigned char* key,
     if (ok && (ctx->constant == NULL || ctx->constantSz == 0)) {
         ok = 0;
     }
+    if (ok && (ctx->constantSz > AES_BLOCK_SIZE)) {
+        ok = 0;
+    }
     if (ok) {
         XMEMSET(key, 0, keyLen);
 

--- a/test/test_krb5kdf.c
+++ b/test/test_krb5kdf.c
@@ -90,6 +90,12 @@ static int test_krb5kdf_error_cases(OSSL_LIB_CTX* libCtx)
     unsigned char constant[] = {
         0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88
     };
+    /* Constant longer than the cipher block size. */
+    unsigned char constantLong[] = {
+        0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88,
+        0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88,
+        0x99
+    };
 
     PRINT_MSG("Testing KRB5KDF error case - AES-128-CBC with 32-byte key");
     /* This should fail since AES-128 key size is 16 bytes */
@@ -123,6 +129,15 @@ static int test_krb5kdf_error_cases(OSSL_LIB_CTX* libCtx)
         return 1;
     }
     PRINT_MSG("Negative test passed - KRB5KDF correctly rejected 0 length constant");
+
+    PRINT_MSG("Testing KRB5KDF error case - constant longer than block size");
+    err = test_krb5kdf_calc(libCtx, key, 16, "AES-128-CBC",
+        inKey16, sizeof(inKey16), constantLong, sizeof(constantLong));
+    if (err == 0) {
+        PRINT_MSG("FAILED: KRB5KDF accepted constant longer than block size");
+        return 1;
+    }
+    PRINT_MSG("Negative test passed - KRB5KDF correctly rejected oversized constant");
 
     return 0;
 }


### PR DESCRIPTION
## Summary
`wp_kdf_krb5kdf_derive` passes `ctx->constantSz` to `n_fold`, which does `XMEMCPY(block, constant, constant_len)` into the fixed 16-byte stack buffer `block[AES_BLOCK_SIZE]`. A constant longer than the block size overflows the stack (and triggers a `size_t` underflow in a later `XMEMSET`). `n_fold`'s documented precondition requires `constant_len <= blocksize`, but the caller never enforced an upper bound. OpenSSL's KRB5KDF guards against this; we now do too.

## Changes
- `src/wp_krb5kdf.c`: reject `constantSz > AES_BLOCK_SIZE` before calling `n_fold`.
- `test/test_krb5kdf.c`: negative test with an oversized constant; runs against both wolfProvider and OpenSSL (both must reject).

## Testing
Full suite passes; `test_krb5kdf` confirms both providers reject the oversized constant.

Fixes fenrir F-4076