### PR TITLE
Add bounds check on AES-CTS input length to prevent integer overflow

### DIFF
--- a/src/wp_aes_stream.c
+++ b/src/wp_aes_stream.c
@@ -590,6 +590,13 @@ static int wp_aes_stream_doit(wp_AesStreamCtx *ctx, unsigned char *out,
         if (inLen < AES_BLOCK_SIZE) {
             ok = 0;
         }
+        /* The CTS helpers cast the block count to int, so an inLen past
+         * 0x7FFFFFFF overflows blocks*AES_BLOCK_SIZE. Not reachable via
+         * EVP_CipherUpdate (its inl is int) - defense in depth for a caller
+         * driving OSSL_FUNC_cipher_update directly. */
+        if (inLen > 0x7FFFFFFFU) {
+            ok = 0;
+        }
         if (ok) {
             if (ctx->enc) {
                 ok = wp_aes_cts_encrypt(ctx, out, in, inLen);


### PR DESCRIPTION
The AES-CTS encrypt/decrypt helpers in `wp_aes_stream.c` compute the block count as a signed `int`, so an `inLen` above `0x7FFFFFFF` overflows `blocks * AES_BLOCK_SIZE`. The corrupted (negative) value then explodes `inLen` via `inLen -= blocks * AES_BLOCK_SIZE`, leading to an out-of-bounds `XMEMCPY` into the 32-byte `ctsBlock` stack buffer.

Adds an upper-bound guard in `wp_aes_stream_doit` (next to the existing lower-bound check) covering both the encrypt and decrypt paths.

Not reachable through `EVP_CipherUpdate` (its `inl` is `int`, so input is already capped at `INT_MAX`); the guard is defense in depth for a caller driving `OSSL_FUNC_cipher_update` directly. No new test — triggering would require a >2 GB input that the EVP API can't pass; existing CTS KAT/KRB/error-case tests pass unchanged.

Fixes Fenrir F-4380 and F-4381