### PR TITLE
ci: ORAS-backed OpenSSL/wolfSSL dep cache for from-source builders

### DIFF
--- a/.github/actions/oras-build-deps-push/action.yml
+++ b/.github/actions/oras-build-deps-push/action.yml
@@ -1,0 +1,51 @@
+name: ORAS build deps push
+description: Push freshly built OpenSSL/wolfSSL installs to ghcr.io (ORAS) after a cache miss, so the next job reuses them. Consumes the outputs of the oras-build-deps action; run it after the build step.
+
+inputs:
+  registry:
+    description: OCI repo from the oras-build-deps action output.
+    required: true
+  openssl_install_tag:
+    required: true
+  wolfssl_install_tag:
+    required: true
+  openssl_source_tag:
+    required: false
+    default: ''
+  openssl_hit:
+    required: true
+  wolfssl_hit:
+    required: true
+  openssl_source_hit:
+    required: false
+    default: 'true'
+  cache_openssl_source:
+    required: false
+    default: 'false'
+
+runs:
+  using: composite
+  steps:
+    # Push only where a write-scoped token exists: canonical repo on a push
+    # event or a same-repo PR. Fork PRs lack write scope, so skip entirely
+    # instead of burning retries on a doomed push.
+    - name: Push OpenSSL install
+      if: github.repository == 'wolfSSL/wolfProvider' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && inputs.openssl_hit != 'true'
+      shell: bash
+      run: |
+        "${GITHUB_WORKSPACE}/scripts/oras-build-deps.sh" push \
+          "${{ inputs.registry }}:${{ inputs.openssl_install_tag }}" openssl-install openssl-source
+
+    - name: Push wolfSSL install
+      if: github.repository == 'wolfSSL/wolfProvider' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && inputs.wolfssl_hit != 'true'
+      shell: bash
+      run: |
+        "${GITHUB_WORKSPACE}/scripts/oras-build-deps.sh" push \
+          "${{ inputs.registry }}:${{ inputs.wolfssl_install_tag }}" wolfssl-install wolfssl-source
+
+    - name: Push OpenSSL source
+      if: github.repository == 'wolfSSL/wolfProvider' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && inputs.cache_openssl_source == 'true' && inputs.openssl_source_hit != 'true'
+      shell: bash
+      run: |
+        "${GITHUB_WORKSPACE}/scripts/oras-build-deps.sh" push \
+          "${{ inputs.registry }}:${{ inputs.openssl_source_tag }}" openssl-source openssl-source

--- a/.github/actions/oras-build-deps/action.yml
+++ b/.github/actions/oras-build-deps/action.yml
@@ -1,0 +1,238 @@
+name: ORAS build deps
+description: Pull prebuilt OpenSSL/wolfSSL installs from ghcr.io (ORAS) keyed by resolved commit SHA, falling back to actions/cache, so build-wolfprovider.sh skips configure+make on a hit.
+
+inputs:
+  variant:
+    description: Token capturing every build-config dimension that changes the produced binaries (compiler, debug, replace-default, seed-src, fips). Distinct configs must use distinct variants. Installs bake in an absolute prefix/rpath, so a variant must also be unique per runner image - do not reuse a variant across the container/non-container boundary (e.g. multi-compiler uses -bookworm, nightly uses -${OS}).
+    required: true
+  openssl_ref:
+    description: OpenSSL tag/branch/sha, resolved to a SHA for the artifact key.
+    required: true
+  wolfssl_ref:
+    description: wolfSSL tag/branch/sha, resolved to a SHA for the artifact key. Ignored when wolfssl_fixed_key is set.
+    required: false
+    default: ''
+  wolfssl_fixed_key:
+    description: Verbatim wolfSSL key, used instead of resolving wolfssl_ref (FIPS bundle case - fixed stable version with no git ref).
+    required: false
+    default: ''
+  cache_openssl_source:
+    description: Also fetch openssl-source. Required for --replace-default / --fips-baseline builds whose mismatch checks read the patched source.
+    required: false
+    default: 'false'
+  extra_key:
+    description: Extra key segment folded into the artifact tag and fallback cache key. Use for build flags defined in the workflow file (e.g. sanitizer CFLAGS) so a flag change invalidates the artifact.
+    required: false
+    default: ''
+  github_token:
+    description: Token passed to resolve-ref.sh and oras login to avoid GitHub API rate limits.
+    required: true
+
+outputs:
+  registry:
+    description: ghcr.io OCI repo the artifacts live in.
+    value: ${{ steps.tags.outputs.registry }}
+  openssl_install_tag:
+    description: Tag for the openssl-install artifact.
+    value: ${{ steps.tags.outputs.openssl_install_tag }}
+  wolfssl_install_tag:
+    description: Tag for the wolfssl-install artifact.
+    value: ${{ steps.tags.outputs.wolfssl_install_tag }}
+  openssl_source_tag:
+    description: Tag for the openssl-source artifact.
+    value: ${{ steps.tags.outputs.openssl_source_tag }}
+  openssl_hit:
+    description: Set to 'true' when openssl-install was pulled from ORAS.
+    value: ${{ steps.pull-openssl.outputs.hit }}
+  wolfssl_hit:
+    description: Set to 'true' when wolfssl-install was pulled from ORAS.
+    value: ${{ steps.pull-wolfssl.outputs.hit }}
+  openssl_source_hit:
+    description: Set to 'true' when openssl-source was pulled from ORAS.
+    value: ${{ steps.pull-openssl-source.outputs.hit }}
+  cache_openssl_source:
+    description: Echo of the cache_openssl_source input, for the push action.
+    value: ${{ inputs.cache_openssl_source }}
+
+runs:
+  using: composite
+  steps:
+    # Standalone assignment (not echo "$(...)") so a resolver failure trips
+    # set -e and fails the step instead of writing an empty SHA that would
+    # collapse distinct commits onto one poisoned cache tag.
+    - name: Resolve OpenSSL ref
+      id: openssl-ref
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.github_token }}
+        REF: ${{ inputs.openssl_ref }}
+      run: |
+        sha=$("${GITHUB_WORKSPACE}/scripts/resolve-ref.sh" "$REF" openssl/openssl)
+        [ -n "$sha" ] || { echo "resolve-ref: empty sha for $REF" >&2; exit 1; }
+        echo "sha=$sha" >> "$GITHUB_OUTPUT"
+
+    - name: Resolve wolfSSL ref
+      id: wolfssl-ref
+      if: inputs.wolfssl_fixed_key == ''
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.github_token }}
+        REF: ${{ inputs.wolfssl_ref }}
+      run: |
+        sha=$("${GITHUB_WORKSPACE}/scripts/resolve-ref.sh" "$REF" wolfssl/wolfssl)
+        [ -n "$sha" ] || { echo "resolve-ref: empty sha for $REF" >&2; exit 1; }
+        echo "sha=$sha" >> "$GITHUB_OUTPUT"
+
+    - name: Compute artifact tags
+      id: tags
+      shell: bash
+      env:
+        VARIANT: ${{ inputs.variant }}
+        OPENSSL_SHA: ${{ steps.openssl-ref.outputs.sha }}
+        WOLFSSL_KEY: ${{ inputs.wolfssl_fixed_key || steps.wolfssl-ref.outputs.sha }}
+        # Short build-logic hash; a build-script change invalidates the artifact.
+        SCRIPTS_HASH: ${{ hashFiles('scripts/utils-*.sh', 'scripts/build-wolfprovider.sh', 'scripts/patch-*.sh', 'patches/**') }}
+        EXTRA_KEY: ${{ inputs.extra_key }}
+      run: |
+        v=$(echo "$VARIANT" | tr '[:upper:]' '[:lower:]')
+        sh="${SCRIPTS_HASH:0:12}"
+        # extra_key (sanitizer/PQC flags) only changes the wolfSSL build, so
+        # fold it into the wolfSSL tag only - stock OpenSSL stays shared across
+        # flag values. Hash it (not a prefix) so flag strings cannot collide.
+        wsh="$sh"
+        [ -n "$EXTRA_KEY" ] && wsh="${sh}-$(printf '%s' "$EXTRA_KEY" | sha256sum | cut -c1-12)"
+        {
+          echo "registry=ghcr.io/wolfssl/wolfprovider/build-deps"
+          echo "openssl_install_tag=openssl-${v}-${OPENSSL_SHA}-${sh}"
+          echo "openssl_source_tag=openssl-source-${v}-${OPENSSL_SHA}-${sh}"
+          # wolfSSL is keyed independently of OpenSSL on purpose: the wolfSSL
+          # build never includes real OpenSSL headers (those are gated behind
+          # TEST_OPENSSL_COEXIST, which this build does not set), so one wolfSSL
+          # build is reused across every OpenSSL version (e.g. openssl-version).
+          echo "wolfssl_install_tag=wolfssl-${v}-${WOLFSSL_KEY}-${wsh}"
+        } >> "$GITHUB_OUTPUT"
+
+    # Gated to the canonical repo (mirrors the debs pull gate) so the package
+    # stays private: only pushes need a write token, which forks lack. Fork
+    # PRs run in the base repo, so this gate is still true for them - they run
+    # the pull steps, miss on the private package, and fall back to
+    # actions/cache + source build.
+    # Best-effort: if oras cannot be fetched or verified, skip the install and
+    # continue - the pull steps then miss and the job falls back to
+    # actions/cache + source build rather than the whole canonical CI dying.
+    - name: Install ORAS
+      if: github.repository == 'wolfSSL/wolfProvider'
+      shell: bash
+      run: |
+        command -v oras >/dev/null 2>&1 && { oras version; exit 0; }
+        ORAS_VERSION="1.2.2"
+        ORAS_CHECKSUM="bff970346470e5ef888e9f2c0bf7f8ee47283f5a45207d6e7a037da1fb0eae0d"
+        tgz="oras_${ORAS_VERSION}_linux_amd64.tar.gz"
+        rm -f "$tgz"
+        ok=""
+        for attempt in 1 2 3; do
+          if curl -fsSLO "https://github.com/oras-project/oras/releases/download/v${ORAS_VERSION}/${tgz}"; then ok=1; break; fi
+          echo "ORAS download attempt $attempt failed."
+          [ "$attempt" -lt 3 ] && sleep $((attempt * 10))
+        done
+        if [ -z "$ok" ]; then
+          echo "ORAS download failed; continuing without ORAS (pulls miss and fall back)"
+          exit 0
+        fi
+        if ! echo "${ORAS_CHECKSUM}  ${tgz}" | sha256sum -c -; then
+          echo "ORAS checksum mismatch; refusing to install, continuing without ORAS (pulls fall back)"
+          rm -f "$tgz"
+          exit 0
+        fi
+        mkdir -p "$GITHUB_WORKSPACE/.bin"
+        tar xzf "$tgz" -C "$GITHUB_WORKSPACE/.bin/" oras
+        echo "$GITHUB_WORKSPACE/.bin" >> "$GITHUB_PATH"
+        rm -f "$tgz"
+        "$GITHUB_WORKSPACE/.bin/oras" version
+
+    # Login is only needed to PUSH (canonical repo, write token). Pulls of a
+    # public build-deps package work anonymously, so a login failure must not
+    # break the pull path - keep it best-effort.
+    - name: Login to ghcr.io (best-effort)
+      if: github.repository == 'wolfSSL/wolfProvider'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github_token }}
+        OWNER: ${{ github.repository_owner }}
+      run: |
+        echo "$GH_TOKEN" | oras login --username "$OWNER" --password-stdin ghcr.io \
+          || echo "oras login failed; continuing (private-package pulls just miss and fall back)"
+
+    # Pull openssl-source first when required, so the install pull can refuse a
+    # hit that lacks its matching source (which would otherwise skip the build
+    # yet fail the replace-default mismatch check with no way to self-heal).
+    - name: Pull OpenSSL source
+      id: pull-openssl-source
+      if: github.repository == 'wolfSSL/wolfProvider' && inputs.cache_openssl_source == 'true'
+      shell: bash
+      run: |
+        if "${GITHUB_WORKSPACE}/scripts/oras-build-deps.sh" pull \
+             "${{ steps.tags.outputs.registry }}:${{ steps.tags.outputs.openssl_source_tag }}" openssl-source; then
+          echo "hit=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "hit=false" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Pull OpenSSL install
+      id: pull-openssl
+      if: github.repository == 'wolfSSL/wolfProvider'
+      shell: bash
+      env:
+        NEED_SOURCE: ${{ inputs.cache_openssl_source }}
+        SOURCE_HIT: ${{ steps.pull-openssl-source.outputs.hit }}
+      run: |
+        # A cached install without its matching source (replace-default) would
+        # skip the build yet fail the patched-source mismatch check; force a
+        # full rebuild so both are regenerated together.
+        if [ "$NEED_SOURCE" = "true" ] && [ "$SOURCE_HIT" != "true" ]; then
+          echo "openssl-source missing; forcing openssl rebuild"
+          echo "hit=false" >> "$GITHUB_OUTPUT"
+        elif "${GITHUB_WORKSPACE}/scripts/oras-build-deps.sh" pull \
+             "${{ steps.tags.outputs.registry }}:${{ steps.tags.outputs.openssl_install_tag }}" openssl-install; then
+          echo "hit=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "hit=false" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Pull wolfSSL install
+      id: pull-wolfssl
+      if: github.repository == 'wolfSSL/wolfProvider'
+      shell: bash
+      run: |
+        if "${GITHUB_WORKSPACE}/scripts/oras-build-deps.sh" pull \
+             "${{ steps.tags.outputs.registry }}:${{ steps.tags.outputs.wolfssl_install_tag }}" wolfssl-install; then
+          echo "hit=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "hit=false" >> "$GITHUB_OUTPUT"
+        fi
+
+    # Fallback: when ORAS misses, restore PR #412's actions/cache so a warm
+    # GH cache still skips the build. On an ORAS hit these steps are skipped.
+    # Source is restored before install so install can be gated on source
+    # being present (same replace-default coupling as the ORAS pulls).
+    - name: Cache OpenSSL source (fallback)
+      id: src-fallback
+      if: inputs.cache_openssl_source == 'true' && steps.pull-openssl-source.outputs.hit != 'true'
+      uses: actions/cache@v4
+      with:
+        path: openssl-source
+        key: openssl-source-${{ inputs.variant }}-${{ steps.openssl-ref.outputs.sha }}-${{ hashFiles('scripts/utils-*.sh', 'scripts/build-wolfprovider.sh', 'scripts/patch-*.sh', 'patches/**') }}
+
+    - name: Cache OpenSSL install (fallback)
+      if: steps.pull-openssl.outputs.hit != 'true' && (inputs.cache_openssl_source != 'true' || steps.pull-openssl-source.outputs.hit == 'true' || steps.src-fallback.outputs.cache-hit == 'true')
+      uses: actions/cache@v4
+      with:
+        path: openssl-install
+        key: openssl-install-${{ inputs.variant }}-${{ steps.openssl-ref.outputs.sha }}-${{ hashFiles('scripts/utils-*.sh', 'scripts/build-wolfprovider.sh', 'scripts/patch-*.sh', 'patches/**') }}
+
+    - name: Cache wolfSSL install (fallback)
+      if: steps.pull-wolfssl.outputs.hit != 'true'
+      uses: actions/cache@v4
+      with:
+        path: wolfssl-install
+        key: wolfssl-install-${{ inputs.variant }}-${{ inputs.wolfssl_fixed_key || steps.wolfssl-ref.outputs.sha }}-${{ hashFiles('scripts/utils-*.sh', 'scripts/build-wolfprovider.sh', 'scripts/patch-*.sh', 'patches/**') }}${{ inputs.extra_key != '' && format('-{0}', inputs.extra_key) || '' }}

--- a/.github/actions/oras-build-deps/action.yml
+++ b/.github/actions/oras-build-deps/action.yml
@@ -211,7 +211,7 @@ runs:
           echo "hit=false" >> "$GITHUB_OUTPUT"
         fi
 
-    # Fallback: when ORAS misses, restore PR #412's actions/cache so a warm
+    # Fallback: when ORAS misses, restore the actions/cache entry so a warm
     # GH cache still skips the build. On an ORAS hit these steps are skipped.
     # Source is restored before install so install can be gated on source
     # being present (same replace-default coupling as the ORAS pulls).

--- a/.github/workflows/_discover-versions.yml
+++ b/.github/workflows/_discover-versions.yml
@@ -50,16 +50,31 @@ jobs:
       openssl_latest_ref_array: ${{ steps.resolve.outputs.openssl_latest_ref_array }}
       openssl_all_releases_array: ${{ steps.resolve.outputs.openssl_all_releases_array }}
     steps:
-      - name: Install ORAS
+      - name: Install ORAS (best-effort)
         run: |
-          set -euo pipefail
+          set -uo pipefail
           ORAS_VERSION="1.2.2"
           ORAS_CHECKSUM="bff970346470e5ef888e9f2c0bf7f8ee47283f5a45207d6e7a037da1fb0eae0d"
-          curl -fsSLO "https://github.com/oras-project/oras/releases/download/v${ORAS_VERSION}/oras_${ORAS_VERSION}_linux_amd64.tar.gz"
-          echo "${ORAS_CHECKSUM}  oras_${ORAS_VERSION}_linux_amd64.tar.gz" | sha256sum -c -
-          tar xzf "oras_${ORAS_VERSION}_linux_amd64.tar.gz" oras
+          tgz="oras_${ORAS_VERSION}_linux_amd64.tar.gz"
+          ok=""
+          for attempt in 1 2 3 4 5; do
+            if curl -fsSLO "https://github.com/oras-project/oras/releases/download/v${ORAS_VERSION}/${tgz}"; then ok=1; break; fi
+            echo "ORAS download attempt $attempt failed; retrying..."
+            sleep $((attempt * 5))
+          done
+          # Best-effort: if oras can't be fetched/verified, the .deb probe below
+          # simply misses and falls back to the upstream latest tag.
+          if [ -z "$ok" ]; then
+            echo "::warning::ORAS download failed after retries; version probe falls back to upstream latest"
+            exit 0
+          fi
+          if ! echo "${ORAS_CHECKSUM}  ${tgz}" | sha256sum -c -; then
+            echo "::warning::ORAS checksum mismatch; skipping install"
+            rm -f "$tgz"; exit 0
+          fi
+          tar xzf "$tgz" oras
           sudo mv oras /usr/local/bin/oras
-          rm -f "oras_${ORAS_VERSION}_linux_amd64.tar.gz"
+          rm -f "$tgz"
           oras version
 
       - name: Login to ghcr.io (best-effort)
@@ -72,6 +87,38 @@ jobs:
         id: resolve
         run: |
           set -euo pipefail
+
+          # Retry wrapper for flaky external calls (git ls-remote, Docker Hub)
+          # so a single network blip does not fail the whole shared job. Echoes
+          # the first non-empty result from up to 3 attempts.
+          retry_out() {
+            local out attempt
+            for attempt in 1 2 3; do
+              if out=$("$@" 2>/dev/null) && [ -n "$out" ]; then
+                printf '%s' "$out"
+                return 0
+              fi
+              echo "retry $attempt/3: '$*' failed; retrying..." >&2
+              sleep $((attempt * 5))
+            done
+            return 1
+          }
+          ls_wolfssl_stable() {
+            git ls-remote --tags --refs https://github.com/wolfSSL/wolfssl.git 'v*-stable' \
+              | awk -F/ '{print $NF}' | sort -V | tail -n 1
+          }
+          probe_ossl_bookworm() {
+            docker run --rm debian:bookworm sh -c \
+              'apt-get update -qq >/dev/null 2>&1 && apt-cache madison openssl | head -1' \
+              | awk '{print $3}'
+          }
+          ls_openssl_all() {
+            git ls-remote --tags --refs https://github.com/openssl/openssl.git 'openssl-3.*' \
+              | awk -F/ '{print $NF}' \
+              | grep -E '^openssl-3\.[0-9]+\.[0-9]+$' \
+              | sort -V \
+              | awk -v floor="$OSSL_FLOOR" '$0 == floor {p=1} p'
+          }
 
           # wolfSSL: probe the .deb on ghcr.io.
           WOLFSSL_DEB_REF=""
@@ -91,10 +138,9 @@ jobs:
           rm -rf "$PROBE_DIR"
 
           # wolfSSL: latest upstream -stable tag.
-          WOLFSSL_LATEST=$(git ls-remote --tags --refs https://github.com/wolfSSL/wolfssl.git 'v*-stable' \
-                            | awk -F/ '{print $NF}' | sort -V | tail -n 1)
+          WOLFSSL_LATEST=$(retry_out ls_wolfssl_stable) || true
           if [ -z "${WOLFSSL_LATEST:-}" ]; then
-            echo "::error::Could not resolve latest wolfSSL -stable tag"
+            echo "::error::Could not resolve latest wolfSSL -stable tag after retries"
             exit 1
           fi
 
@@ -105,11 +151,9 @@ jobs:
           fi
 
           # OpenSSL: Bookworm stock (matches the wolfprov .deb).
-          OSSL_RAW=$(docker run --rm debian:bookworm sh -c \
-            'apt-get update -qq >/dev/null 2>&1 && apt-cache madison openssl | head -1' \
-            | awk '{print $3}')
+          OSSL_RAW=$(retry_out probe_ossl_bookworm) || true
           if [ -z "${OSSL_RAW:-}" ]; then
-            echo "::error::Could not resolve Bookworm OpenSSL version"
+            echo "::error::Could not resolve Bookworm OpenSSL version after retries"
             exit 1
           fi
           OSSL=$(echo "$OSSL_RAW" | sed 's/-.*//')
@@ -117,13 +161,9 @@ jobs:
           # OpenSSL: all upstream release tags >= floor.
           # Floor 3.0.6 -- 3.0.3-3.0.5 have an ECX EVP_PKEY_cmp bug.
           OSSL_FLOOR="openssl-3.0.6"
-          OSSL_ALL=$(git ls-remote --tags --refs https://github.com/openssl/openssl.git 'openssl-3.*' \
-                     | awk -F/ '{print $NF}' \
-                     | grep -E '^openssl-3\.[0-9]+\.[0-9]+$' \
-                     | sort -V \
-                     | awk -v floor="$OSSL_FLOOR" '$0 == floor {p=1} p')
+          OSSL_ALL=$(retry_out ls_openssl_all) || true
           if [ -z "${OSSL_ALL:-}" ]; then
-            echo "::error::Could not resolve upstream OpenSSL release tags (floor=$OSSL_FLOOR)"
+            echo "::error::Could not resolve upstream OpenSSL release tags (floor=$OSSL_FLOOR) after retries"
             exit 1
           fi
           OSSL_ALL_JSON=$(printf '%s\n' "$OSSL_ALL" | jq -R . | jq -s -c .)

--- a/.github/workflows/cmdline.yml
+++ b/.github/workflows/cmdline.yml
@@ -34,6 +34,9 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     name: Command line test
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      packages: write
     timeout-minutes: 20
     strategy:
       fail-fast: false
@@ -50,9 +53,27 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Cache build dependencies
+        id: deps
+        uses: ./.github/actions/oras-build-deps
+        with:
+          variant: cmdline${{ matrix.debug != '' && '-debug' || '' }}
+          openssl_ref: ${{ matrix.openssl_ref }}
+          wolfssl_ref: ${{ matrix.wolfssl_ref }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build wolfProvider
         run: |
           ${{ matrix.debug }} OPENSSL_TAG=${{ matrix.openssl_ref }} WOLFSSL_TAG=${{ matrix.wolfssl_ref }} ./scripts/build-wolfprovider.sh
+
+      - name: Push build dependencies
+        uses: ./.github/actions/oras-build-deps-push
+        with:
+          registry: ${{ steps.deps.outputs.registry }}
+          openssl_install_tag: ${{ steps.deps.outputs.openssl_install_tag }}
+          wolfssl_install_tag: ${{ steps.deps.outputs.wolfssl_install_tag }}
+          openssl_hit: ${{ steps.deps.outputs.openssl_hit }}
+          wolfssl_hit: ${{ steps.deps.outputs.wolfssl_hit }}
 
       - name: Run tests
         run: |

--- a/.github/workflows/fips-ready.yml
+++ b/.github/workflows/fips-ready.yml
@@ -34,6 +34,9 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     name: FIPS Ready Bundle Test
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      packages: write
     timeout-minutes: 20
     strategy:
       fail-fast: false
@@ -46,6 +49,15 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
+
+      - name: Cache build dependencies
+        id: deps
+        uses: ./.github/actions/oras-build-deps
+        with:
+          variant: fips-ready
+          openssl_ref: ${{ matrix.openssl_ref }}
+          wolfssl_fixed_key: wolfssl-fips-${{ matrix.wolfssl_bundle_ref }}-${{ matrix.openssl_ref }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download FIPS Ready Bundle
         run: |
@@ -68,8 +80,18 @@ jobs:
 
       - name: Build wolfProvider with FIPS Ready Bundle
         run: |
+          OPENSSL_TAG=${{ matrix.openssl_ref }} \
           ./scripts/build-wolfprovider.sh --fips-bundle="$FIPS_BUNDLE_PATH" \
           --fips-check=ready --wolfssl-ver=v${{matrix.wolfssl_bundle_ref}}-stable
+
+      - name: Push build dependencies
+        uses: ./.github/actions/oras-build-deps-push
+        with:
+          registry: ${{ steps.deps.outputs.registry }}
+          openssl_install_tag: ${{ steps.deps.outputs.openssl_install_tag }}
+          wolfssl_install_tag: ${{ steps.deps.outputs.wolfssl_install_tag }}
+          openssl_hit: ${{ steps.deps.outputs.openssl_hit }}
+          wolfssl_hit: ${{ steps.deps.outputs.wolfssl_hit }}
 
       - name: Run FIPS Command Tests
         run: |

--- a/.github/workflows/libtss2.yml
+++ b/.github/workflows/libtss2.yml
@@ -18,6 +18,9 @@ jobs:
   test_tpm2_tss:
     needs: discover_versions
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      packages: write
     container:
       image: ghcr.io/wolfssl/wolfprovider-test-deps:bookworm
       env:
@@ -49,11 +52,29 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Cache build dependencies
+        id: deps
+        uses: ./.github/actions/oras-build-deps
+        with:
+          variant: libtss2
+          openssl_ref: ${{ matrix.openssl_ref }}
+          wolfssl_ref: ${{ matrix.wolfssl_ref }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build wolfProvider
         run: |
           OPENSSL_TAG=${{ matrix.openssl_ref }} \
           WOLFSSL_TAG=${{ matrix.wolfssl_ref }} \
             ./scripts/build-wolfprovider.sh
+
+      - name: Push build dependencies
+        uses: ./.github/actions/oras-build-deps-push
+        with:
+          registry: ${{ steps.deps.outputs.registry }}
+          openssl_install_tag: ${{ steps.deps.outputs.openssl_install_tag }}
+          wolfssl_install_tag: ${{ steps.deps.outputs.wolfssl_install_tag }}
+          openssl_hit: ${{ steps.deps.outputs.openssl_hit }}
+          wolfssl_hit: ${{ steps.deps.outputs.wolfssl_hit }}
 
       - name: Checkout tpm2-tss
         uses: actions/checkout@v4

--- a/.github/workflows/multi-compiler.yml
+++ b/.github/workflows/multi-compiler.yml
@@ -29,6 +29,9 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     name: Build with compiler ${{ matrix.CC }}, wolfssl ${{ matrix.wolfssl_ref }}, OpenSSL ${{ matrix.openssl_ref }}
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      packages: write
     container:
       image: ghcr.io/wolfssl/wolfprovider-test-deps:bookworm
       env:
@@ -77,43 +80,14 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Get OpenSSL commit hash
-        id: openssl-ref
-        run: |
-          sha=$(./scripts/resolve-ref.sh "${{ matrix.openssl_ref }}" "openssl/openssl")
-          echo "ref=$sha" >> "$GITHUB_OUTPUT"
-        env:
-          # Used token to bypass rate limits
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Get WolfSSL commit hash
-        id: wolfssl-ref
-        run: |
-          sha=$(./scripts/resolve-ref.sh "${{ matrix.wolfssl_ref }}" "wolfssl/wolfssl")
-          echo "ref=$sha" >> "$GITHUB_OUTPUT"
-        env:
-          # Used token to bypass rate limits
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      # Look for a cached version of OpenSSL -- with this compiler version
-      - name: Checking OpenSSL in cache
-        uses: actions/cache@v4
-        id: openssl-cache
+      - name: Cache build dependencies
+        id: deps
+        uses: ./.github/actions/oras-build-deps
         with:
-          path: |
-            openssl-install
-          key: openssl-depends-${{ matrix.CC }}-${{ steps.openssl-ref.outputs.ref }}
-          lookup-only: false
-
-      # Look for a cached version of WolfSSL -- with this compiler version
-      - name: Checking WolfSSL in cache
-        uses: actions/cache@v4
-        id: wolfssl-cache
-        with:
-          path: |
-            wolfssl-install
-          key: wolfssl-depends-${{ matrix.CC }}-${{ steps.wolfssl-ref.outputs.ref }}
-          lookup-only: false
+          variant: ${{ matrix.CC }}-bookworm
+          openssl_ref: ${{ matrix.openssl_ref }}
+          wolfssl_ref: ${{ matrix.wolfssl_ref }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build wolfProvider
         env:
@@ -121,6 +95,15 @@ jobs:
           CXX: ${{ matrix.CXX }}
         run: |
           OPENSSL_TAG=${{ matrix.openssl_ref }} WOLFSSL_TAG=${{ matrix.wolfssl_ref }} ./scripts/build-wolfprovider.sh
+
+      - name: Push build dependencies
+        uses: ./.github/actions/oras-build-deps-push
+        with:
+          registry: ${{ steps.deps.outputs.registry }}
+          openssl_install_tag: ${{ steps.deps.outputs.openssl_install_tag }}
+          wolfssl_install_tag: ${{ steps.deps.outputs.wolfssl_install_tag }}
+          openssl_hit: ${{ steps.deps.outputs.openssl_hit }}
+          wolfssl_hit: ${{ steps.deps.outputs.wolfssl_hit }}
 
       - name: Print errors
         if: ${{ failure() }}

--- a/.github/workflows/nightly-multi-compiler.yml
+++ b/.github/workflows/nightly-multi-compiler.yml
@@ -20,6 +20,9 @@ jobs:
   build_wolfprovider:
     name: Nightly build ${{ matrix.CC }} on ${{ matrix.OS }}, wolfssl ${{ matrix.wolfssl_ref }}, OpenSSL ${{ matrix.openssl_ref }}
     runs-on: ${{ matrix.OS }}
+    permissions:
+      contents: read
+      packages: write
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -110,37 +113,14 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Get OpenSSL commit hash
-        id: openssl-ref
-        run: |
-          sha=$(./scripts/resolve-ref.sh "${{ matrix.openssl_ref }}" "openssl/openssl")
-          echo "ref=$sha" >> "$GITHUB_OUTPUT"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Get WolfSSL commit hash
-        id: wolfssl-ref
-        run: |
-          sha=$(./scripts/resolve-ref.sh "${{ matrix.wolfssl_ref }}" "wolfssl/wolfssl")
-          echo "ref=$sha" >> "$GITHUB_OUTPUT"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Checking OpenSSL in cache
-        uses: actions/cache@v4
-        id: openssl-cache
+      - name: Cache build dependencies
+        id: deps
+        uses: ./.github/actions/oras-build-deps
         with:
-          path: openssl-install
-          key: openssl-depends-${{ matrix.CC }}-${{ steps.openssl-ref.outputs.ref }}
-          lookup-only: false
-
-      - name: Checking WolfSSL in cache
-        uses: actions/cache@v4
-        id: wolfssl-cache
-        with:
-          path: wolfssl-install
-          key: wolfssl-depends-${{ matrix.CC }}-${{ steps.wolfssl-ref.outputs.ref }}
-          lookup-only: false
+          variant: ${{ matrix.CC }}-${{ matrix.OS }}
+          openssl_ref: ${{ matrix.openssl_ref }}
+          wolfssl_ref: ${{ matrix.wolfssl_ref }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build wolfProvider
         env:
@@ -148,6 +128,15 @@ jobs:
           CXX: ${{ matrix.CXX }}
         run: |
           OPENSSL_TAG=${{ matrix.openssl_ref }} WOLFSSL_TAG=${{ matrix.wolfssl_ref }} ./scripts/build-wolfprovider.sh
+
+      - name: Push build dependencies
+        uses: ./.github/actions/oras-build-deps-push
+        with:
+          registry: ${{ steps.deps.outputs.registry }}
+          openssl_install_tag: ${{ steps.deps.outputs.openssl_install_tag }}
+          wolfssl_install_tag: ${{ steps.deps.outputs.wolfssl_install_tag }}
+          openssl_hit: ${{ steps.deps.outputs.openssl_hit }}
+          wolfssl_hit: ${{ steps.deps.outputs.wolfssl_hit }}
 
       - name: Print errors
         if: ${{ failure() }}

--- a/.github/workflows/nightly-osp.yml
+++ b/.github/workflows/nightly-osp.yml
@@ -21,7 +21,7 @@ on:
 
 permissions:
   contents: read
-  packages: read
+  packages: write
   actions: read
 
 concurrency:

--- a/.github/workflows/openssl-version.yml
+++ b/.github/workflows/openssl-version.yml
@@ -18,6 +18,9 @@ jobs:
     needs: discover_versions
     name: OpenSSL Version Test
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      packages: write
     timeout-minutes: 60
     strategy:
       fail-fast: false
@@ -30,11 +33,29 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Cache build dependencies
+        id: deps
+        uses: ./.github/actions/oras-build-deps
+        with:
+          variant: osslver
+          openssl_ref: ${{ matrix.openssl_ref }}
+          wolfssl_ref: ${{ matrix.wolfssl_ref }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build and test wolfProvider
         run: |
           OPENSSL_TAG=${{ matrix.openssl_ref }} \
           WOLFSSL_TAG=${{ matrix.wolfssl_ref }} \
             ./scripts/build-wolfprovider.sh
+
+      - name: Push build dependencies
+        uses: ./.github/actions/oras-build-deps-push
+        with:
+          registry: ${{ steps.deps.outputs.registry }}
+          openssl_install_tag: ${{ steps.deps.outputs.openssl_install_tag }}
+          wolfssl_install_tag: ${{ steps.deps.outputs.wolfssl_install_tag }}
+          openssl_hit: ${{ steps.deps.outputs.openssl_hit }}
+          wolfssl_hit: ${{ steps.deps.outputs.wolfssl_hit }}
 
       - name: Print errors
         if: ${{ failure() }}

--- a/.github/workflows/pr-osp-select.yml
+++ b/.github/workflows/pr-osp-select.yml
@@ -20,7 +20,7 @@ on:
 
 permissions:
   contents: read
-  packages: read
+  packages: write
   actions: read
 
 concurrency:

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -38,6 +38,9 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     name: ASan+UBSan (wolfSSL ${{ matrix.wolfssl_ref }} / ${{ needs.discover_versions.outputs.openssl_latest_ref }})
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      packages: write
     container:
       image: ghcr.io/wolfssl/wolfprovider-test-deps:bookworm
       env:
@@ -59,15 +62,15 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Cache OpenSSL + wolfssl source/install (sanitizers)
-        uses: actions/cache@v4
+      - name: Cache build dependencies
+        id: deps
+        uses: ./.github/actions/oras-build-deps
         with:
-          path: |
-            openssl-source
-            openssl-install
-            wolfssl-source
-            wolfssl-install
-          key: san-${{ runner.os }}-${{ needs.discover_versions.outputs.openssl_latest_ref }}-${{ matrix.wolfssl_ref }}-${{ hashFiles('scripts/utils-openssl.sh', 'scripts/utils-wolfssl.sh', 'scripts/build-wolfprovider.sh', '.github/workflows/sanitizers.yml') }}
+          variant: asan
+          openssl_ref: ${{ needs.discover_versions.outputs.openssl_latest_ref }}
+          wolfssl_ref: ${{ matrix.wolfssl_ref }}
+          extra_key: ${{ hashFiles('.github/workflows/sanitizers.yml') }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build wolfProvider with sanitizers
         env:
@@ -92,6 +95,15 @@ jobs:
           OPENSSL_TAG=${{ needs.discover_versions.outputs.openssl_latest_ref }} \
           WOLFSSL_TAG=${{ matrix.wolfssl_ref }} \
             ./scripts/build-wolfprovider.sh
+
+      - name: Push build dependencies
+        uses: ./.github/actions/oras-build-deps-push
+        with:
+          registry: ${{ steps.deps.outputs.registry }}
+          openssl_install_tag: ${{ steps.deps.outputs.openssl_install_tag }}
+          wolfssl_install_tag: ${{ steps.deps.outputs.wolfssl_install_tag }}
+          openssl_hit: ${{ steps.deps.outputs.openssl_hit }}
+          wolfssl_hit: ${{ steps.deps.outputs.wolfssl_hit }}
 
       - name: Run wolfprov unit tests (make test) under sanitizers
         # bash needed for `source` - container default shell is dash.
@@ -123,6 +135,9 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     name: TSan (wolfSSL ${{ matrix.wolfssl_ref }} / ${{ needs.discover_versions.outputs.openssl_latest_ref }})
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      packages: write
     container:
       image: ghcr.io/wolfssl/wolfprovider-test-deps:bookworm
       env:
@@ -140,15 +155,15 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Cache OpenSSL + wolfssl source/install (tsan)
-        uses: actions/cache@v4
+      - name: Cache build dependencies
+        id: deps
+        uses: ./.github/actions/oras-build-deps
         with:
-          path: |
-            openssl-source
-            openssl-install
-            wolfssl-source
-            wolfssl-install
-          key: tsan-${{ runner.os }}-${{ needs.discover_versions.outputs.openssl_latest_ref }}-${{ matrix.wolfssl_ref }}-${{ hashFiles('scripts/utils-openssl.sh', 'scripts/utils-wolfssl.sh', 'scripts/build-wolfprovider.sh', '.github/workflows/sanitizers.yml') }}
+          variant: tsan
+          openssl_ref: ${{ needs.discover_versions.outputs.openssl_latest_ref }}
+          wolfssl_ref: ${{ matrix.wolfssl_ref }}
+          extra_key: ${{ hashFiles('.github/workflows/sanitizers.yml') }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build wolfProvider with TSan
         env:
@@ -175,6 +190,15 @@ jobs:
           OPENSSL_TAG=${{ needs.discover_versions.outputs.openssl_latest_ref }} \
           WOLFSSL_TAG=${{ matrix.wolfssl_ref }} \
             ./scripts/build-wolfprovider.sh
+
+      - name: Push build dependencies
+        uses: ./.github/actions/oras-build-deps-push
+        with:
+          registry: ${{ steps.deps.outputs.registry }}
+          openssl_install_tag: ${{ steps.deps.outputs.openssl_install_tag }}
+          wolfssl_install_tag: ${{ steps.deps.outputs.wolfssl_install_tag }}
+          openssl_hit: ${{ steps.deps.outputs.openssl_hit }}
+          wolfssl_hit: ${{ steps.deps.outputs.wolfssl_hit }}
 
       - name: Run wolfprov unit tests (make test) under TSan
         shell: bash

--- a/.github/workflows/seed-src.yml
+++ b/.github/workflows/seed-src.yml
@@ -34,6 +34,9 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     name: SEED-SRC Test
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      packages: write
     timeout-minutes: 20
     strategy:
       fail-fast: false
@@ -49,6 +52,16 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Cache build dependencies
+        id: deps
+        uses: ./.github/actions/oras-build-deps
+        with:
+          variant: seed-src
+          openssl_ref: ${{ matrix.openssl_ref }}
+          wolfssl_ref: ${{ matrix.wolfssl_ref }}
+          extra_key: ${{ hashFiles('.github/workflows/seed-src.yml') }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build and test wolfProvider with SEED-SRC
         run: |
              # Force wolfSSL to not use getrandom syscall via ac_cv_func_getrandom=no.
@@ -58,6 +71,15 @@ jobs:
              OPENSSL_TAG=${{ matrix.openssl_ref }} \
              WOLFSSL_TAG=${{ matrix.wolfssl_ref }} \
              ./scripts/build-wolfprovider.sh --enable-seed-src
+
+      - name: Push build dependencies
+        uses: ./.github/actions/oras-build-deps-push
+        with:
+          registry: ${{ steps.deps.outputs.registry }}
+          openssl_install_tag: ${{ steps.deps.outputs.openssl_install_tag }}
+          wolfssl_install_tag: ${{ steps.deps.outputs.wolfssl_install_tag }}
+          openssl_hit: ${{ steps.deps.outputs.openssl_hit }}
+          wolfssl_hit: ${{ steps.deps.outputs.wolfssl_hit }}
 
       - name: Print errors
         if: ${{ failure() }}

--- a/.github/workflows/simple.yml
+++ b/.github/workflows/simple.yml
@@ -34,6 +34,9 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     name: Simple Test
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      packages: write
     timeout-minutes: 20
     strategy:
       fail-fast: false
@@ -56,11 +59,33 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Cache build dependencies
+        id: deps
+        uses: ./.github/actions/oras-build-deps
+        with:
+          variant: simple${{ matrix.debug != '' && '-debug' || '' }}${{ matrix.replace_default != '' && '-rd' || '' }}
+          openssl_ref: ${{ matrix.openssl_ref }}
+          wolfssl_ref: ${{ matrix.wolfssl_ref }}
+          cache_openssl_source: ${{ matrix.replace_default != '' }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build and test wolfProvider
         run: |
              OPENSSL_TAG=${{ matrix.openssl_ref }} \
              WOLFSSL_TAG=${{ matrix.wolfssl_ref }} \
                ./scripts/build-wolfprovider.sh ${{ matrix.debug }} ${{ matrix.replace_default }}
+
+      - name: Push build dependencies
+        uses: ./.github/actions/oras-build-deps-push
+        with:
+          registry: ${{ steps.deps.outputs.registry }}
+          openssl_install_tag: ${{ steps.deps.outputs.openssl_install_tag }}
+          wolfssl_install_tag: ${{ steps.deps.outputs.wolfssl_install_tag }}
+          openssl_source_tag: ${{ steps.deps.outputs.openssl_source_tag }}
+          openssl_hit: ${{ steps.deps.outputs.openssl_hit }}
+          wolfssl_hit: ${{ steps.deps.outputs.wolfssl_hit }}
+          openssl_source_hit: ${{ steps.deps.outputs.openssl_source_hit }}
+          cache_openssl_source: ${{ steps.deps.outputs.cache_openssl_source }}
 
       - name: Print errors
         if: ${{ failure() }}

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -39,6 +39,9 @@ jobs:
     needs: discover_versions
     name: Smoke build (${{ matrix.name }})
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      packages: write
     timeout-minutes: 20
     strategy:
       fail-fast: false
@@ -57,6 +60,15 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Cache build dependencies
+        id: deps
+        uses: ./.github/actions/oras-build-deps
+        with:
+          variant: smoke
+          openssl_ref: ${{ needs.discover_versions.outputs.openssl_latest_ref }}
+          wolfssl_ref: ${{ matrix.wolfssl_ref || needs.discover_versions.outputs.wolfssl_latest_ref }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build and test wolfProvider
         run: |
           # Resolve "stable" matrix row to the discovered latest tag.
@@ -64,6 +76,15 @@ jobs:
           OPENSSL_TAG=${{ needs.discover_versions.outputs.openssl_latest_ref }} \
           WOLFSSL_TAG="$WOLFSSL_TAG" \
             ./scripts/build-wolfprovider.sh
+
+      - name: Push build dependencies
+        uses: ./.github/actions/oras-build-deps-push
+        with:
+          registry: ${{ steps.deps.outputs.registry }}
+          openssl_install_tag: ${{ steps.deps.outputs.openssl_install_tag }}
+          wolfssl_install_tag: ${{ steps.deps.outputs.wolfssl_install_tag }}
+          openssl_hit: ${{ steps.deps.outputs.openssl_hit }}
+          wolfssl_hit: ${{ steps.deps.outputs.wolfssl_hit }}
 
       - name: Print errors
         if: ${{ failure() }}

--- a/.github/workflows/sssd.yml
+++ b/.github/workflows/sssd.yml
@@ -14,6 +14,9 @@ on:
 jobs:
   test_sssd:
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      packages: write
     timeout-minutes: 60
     container:
       image: quay.io/sssd/ci-client-devel:ubuntu-latest
@@ -36,9 +39,27 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Cache build dependencies
+        id: deps
+        uses: ./.github/actions/oras-build-deps
+        with:
+          variant: sssd
+          openssl_ref: ${{ matrix.openssl_ref }}
+          wolfssl_ref: ${{ matrix.wolfssl_ref }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build wolfProvider
         run: |
           OPENSSL_TAG=${{ matrix.openssl_ref }} WOLFSSL_TAG=${{ matrix.wolfssl_ref }} ./scripts/build-wolfprovider.sh
+
+      - name: Push build dependencies
+        uses: ./.github/actions/oras-build-deps-push
+        with:
+          registry: ${{ steps.deps.outputs.registry }}
+          openssl_install_tag: ${{ steps.deps.outputs.openssl_install_tag }}
+          wolfssl_install_tag: ${{ steps.deps.outputs.wolfssl_install_tag }}
+          openssl_hit: ${{ steps.deps.outputs.openssl_hit }}
+          wolfssl_hit: ${{ steps.deps.outputs.wolfssl_hit }}
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -14,6 +14,9 @@ jobs:
   cppcheck:
     name: cppcheck Static Analysis
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      packages: write
     container:
       image: ghcr.io/wolfssl/wolfprovider-test-deps:bookworm
       env:
@@ -25,10 +28,28 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Cache build dependencies
+        id: deps
+        uses: ./.github/actions/oras-build-deps
+        with:
+          variant: static
+          openssl_ref: openssl-3.5.4
+          wolfssl_ref: master
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build dependencies (OpenSSL and wolfSSL)
         run: |
           OPENSSL_TAG=openssl-3.5.4 WOLFSSL_TAG=master ./scripts/build-wolfprovider.sh 2>&1 | tail -100 || true
           # We only need the build to succeed enough to have headers available
+
+      - name: Push build dependencies
+        uses: ./.github/actions/oras-build-deps-push
+        with:
+          registry: ${{ steps.deps.outputs.registry }}
+          openssl_install_tag: ${{ steps.deps.outputs.openssl_install_tag }}
+          wolfssl_install_tag: ${{ steps.deps.outputs.wolfssl_install_tag }}
+          openssl_hit: ${{ steps.deps.outputs.openssl_hit }}
+          wolfssl_hit: ${{ steps.deps.outputs.wolfssl_hit }}
 
       - name: Generate configure script
         run: |
@@ -104,6 +125,9 @@ jobs:
   scan-build:
     name: clang Static Analyzer (scan-build)
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      packages: write
     container:
       image: ghcr.io/wolfssl/wolfprovider-test-deps:bookworm
       env:
@@ -115,9 +139,27 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Cache build dependencies
+        id: deps
+        uses: ./.github/actions/oras-build-deps
+        with:
+          variant: static
+          openssl_ref: openssl-3.5.4
+          wolfssl_ref: master
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build dependencies (OpenSSL and wolfSSL)
         run: |
           OPENSSL_TAG=openssl-3.5.4 WOLFSSL_TAG=master ./scripts/build-wolfprovider.sh 2>&1 | tail -100 || true
+
+      - name: Push build dependencies
+        uses: ./.github/actions/oras-build-deps-push
+        with:
+          registry: ${{ steps.deps.outputs.registry }}
+          openssl_install_tag: ${{ steps.deps.outputs.openssl_install_tag }}
+          wolfssl_install_tag: ${{ steps.deps.outputs.wolfssl_install_tag }}
+          openssl_hit: ${{ steps.deps.outputs.openssl_hit }}
+          wolfssl_hit: ${{ steps.deps.outputs.wolfssl_hit }}
 
       - name: Generate configure script
         run: |
@@ -188,6 +230,9 @@ jobs:
   infer:
     name: Facebook Infer Static Analysis
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      packages: write
     container:
       image: ghcr.io/wolfssl/wolfprovider-test-deps:bookworm
       env:
@@ -211,9 +256,27 @@ jobs:
           mv infer-linux64-v${VERSION} /opt/infer
           ln -sf /opt/infer/bin/infer /usr/local/bin/infer
 
+      - name: Cache build dependencies
+        id: deps
+        uses: ./.github/actions/oras-build-deps
+        with:
+          variant: static
+          openssl_ref: openssl-3.5.4
+          wolfssl_ref: master
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build dependencies (OpenSSL and wolfSSL)
         run: |
           OPENSSL_TAG=openssl-3.5.4 WOLFSSL_TAG=master ./scripts/build-wolfprovider.sh 2>&1 | tail -100 || true
+
+      - name: Push build dependencies
+        uses: ./.github/actions/oras-build-deps-push
+        with:
+          registry: ${{ steps.deps.outputs.registry }}
+          openssl_install_tag: ${{ steps.deps.outputs.openssl_install_tag }}
+          wolfssl_install_tag: ${{ steps.deps.outputs.wolfssl_install_tag }}
+          openssl_hit: ${{ steps.deps.outputs.openssl_hit }}
+          wolfssl_hit: ${{ steps.deps.outputs.wolfssl_hit }}
 
       - name: Generate configure script
         run: |

--- a/.github/workflows/wolfssl-pqc-kat.yml
+++ b/.github/workflows/wolfssl-pqc-kat.yml
@@ -27,13 +27,6 @@ concurrency:
 permissions:
   contents: read
 
-# TODO(revert before merge): the malformed-key vectors in OpenSSL's PQC KAT
-# set only pass with the wolfcrypt FIPS 203/204 decode-validation fix, which
-# currently lives on aidangarske/wolfssl branch pqc-decode-validation. The PQC
-# rows therefore build wolfSSL from that fork/branch (matrix wolfssl-git).
-# Once the fix merges to wolfSSL master, point the PQC rows back at the
-# upstream repo and the dynamic latest-stable / master refs (see discover job).
-
 jobs:
   discover-versions:
     name: Resolve wolfSSL/OpenSSL matrix
@@ -78,18 +71,10 @@ jobs:
           # normal and force-fail anti-test mode (the matrix owns the force-fail
           # axis; the test step hands its raw result to check-workflow-result.sh
           # which inverts the expectation). The pre-PQC row builds only.
-          #
-          # TODO(revert before merge): the PQC rows build the fork branch
-          # pqc-decode-validation. Restore upstream and the latest-stable /
-          # master refs once the wolfcrypt fix is on wolfSSL master.
-          UPSTREAM="https://github.com/wolfSSL/wolfssl.git"
-          FORK="https://github.com/aidangarske/wolfssl.git"
           MATRIX=$(jq -nc \
               --arg latest "$LATEST" \
-              --arg upstream "$UPSTREAM" \
-              --arg fork "$FORK" \
               --argjson latest_pqc "$LATEST_PQC" '
-            def rows($git; $ref; $pqc; $lbl):
+            def rows($ref; $pqc; $lbl):
               if $pqc then
                 [ {"replace":true,"ff":"WOLFPROV_FORCE_FAIL=1",
                    "sfx":" [replace-default] [force-fail]"},
@@ -97,19 +82,18 @@ jobs:
                   {"replace":false,"ff":"WOLFPROV_FORCE_FAIL=1",
                    "sfx":" [non-replace] [force-fail]"},
                   {"replace":false,"ff":"","sfx":" [non-replace]"} ]
-                | map({"name":($lbl+.sfx),"wolfssl-git":$git,
+                | map({"name":($lbl+.sfx),
                        "wolfssl-ref":$ref,"pqc":true,"replace":.replace,
                        "force_fail":.ff})
               else
-                [ {"name":($lbl+" [build-only]"),"wolfssl-git":$git,
+                [ {"name":($lbl+" [build-only]"),
                    "wolfssl-ref":$ref,"pqc":false,"replace":false,
                    "force_fail":""} ]
               end;
             { include:
-                ( rows($upstream; "v5.8.0-stable"; false; "pre-PQC v5.8.0-stable")
-                + rows($fork; "pqc-decode-validation"; $latest_pqc;
-                       ("latest stable " + $latest))
-                + rows($fork; "pqc-decode-validation"; true; "master") )
+                ( rows("v5.8.0-stable"; false; "pre-PQC v5.8.0-stable")
+                + rows($latest; $latest_pqc; ("latest stable " + $latest))
+                + rows("master"; true; "master") )
             }')
           echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
 
@@ -117,6 +101,9 @@ jobs:
     name: ${{ matrix.name }}
     needs: discover-versions
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      packages: write
     timeout-minutes: 45
     strategy:
       fail-fast: false
@@ -126,6 +113,21 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
+
+      # The KAT runs OpenSSL's evp_test, which lives in openssl-source/test and
+      # only exists after a full source build - so the PQC rows cache
+      # openssl-source too (cache_openssl_source), and the action couples
+      # install+source so a hit always restores evp_test alongside the install.
+      - name: Cache build dependencies
+        id: deps
+        uses: ./.github/actions/oras-build-deps
+        with:
+          variant: pqckat${{ matrix.replace == true && '-rd' || '' }}
+          openssl_ref: ${{ needs.discover-versions.outputs.openssl-tag }}
+          wolfssl_ref: ${{ matrix.wolfssl-ref }}
+          extra_key: pqc${{ matrix.pqc }}
+          cache_openssl_source: ${{ matrix.pqc }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build wolfProvider (PQC=${{ matrix.pqc }}, replace=${{ matrix.replace }})
         run: |
@@ -141,10 +143,21 @@ jobs:
           if [ "${{ matrix.pqc }}" = "true" ]; then
             ARGS="$ARGS --enable-openssl-test"
           fi
-          WOLFSSL_GIT=${{ matrix.wolfssl-git }} \
           OPENSSL_TAG=${{ needs.discover-versions.outputs.openssl-tag }} \
           WOLFSSL_TAG=${{ matrix.wolfssl-ref }} \
             ./scripts/build-wolfprovider.sh $ARGS
+
+      - name: Push build dependencies
+        uses: ./.github/actions/oras-build-deps-push
+        with:
+          registry: ${{ steps.deps.outputs.registry }}
+          openssl_install_tag: ${{ steps.deps.outputs.openssl_install_tag }}
+          wolfssl_install_tag: ${{ steps.deps.outputs.wolfssl_install_tag }}
+          openssl_source_tag: ${{ steps.deps.outputs.openssl_source_tag }}
+          openssl_hit: ${{ steps.deps.outputs.openssl_hit }}
+          wolfssl_hit: ${{ steps.deps.outputs.wolfssl_hit }}
+          openssl_source_hit: ${{ steps.deps.outputs.openssl_source_hit }}
+          cache_openssl_source: ${{ steps.deps.outputs.cache_openssl_source }}
 
       # Runs all 2602 OpenSSL ML-KEM/ML-DSA vectors. In normal mode every file
       # must pass and the full count must run; in force-fail mode the run fails

--- a/.github/workflows/wolfssl-versions-pqc.yml
+++ b/.github/workflows/wolfssl-versions-pqc.yml
@@ -98,6 +98,9 @@ jobs:
     name: ${{ matrix.name }}
     needs: discover-versions
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      packages: write
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -111,11 +114,30 @@ jobs:
       # Every row builds against the latest OpenSSL release. PQC needs OpenSSL
       # 3.6+ (and the enable flag enforces that floor); the interop step then
       # compares wolfProvider against that release's native ML-KEM/ML-DSA.
+      - name: Cache build dependencies
+        id: deps
+        uses: ./.github/actions/oras-build-deps
+        with:
+          variant: pqc
+          openssl_ref: ${{ needs.discover-versions.outputs.openssl-tag }}
+          wolfssl_ref: ${{ matrix.wolfssl-ref }}
+          extra_key: ${{ matrix.enable }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build wolfProvider (${{ matrix.enable || 'no PQC flag' }})
         run: |
           OPENSSL_TAG=${{ needs.discover-versions.outputs.openssl-tag }} \
           WOLFSSL_TAG=${{ matrix.wolfssl-ref }} \
             ./scripts/build-wolfprovider.sh ${{ matrix.enable }}
+
+      - name: Push build dependencies
+        uses: ./.github/actions/oras-build-deps-push
+        with:
+          registry: ${{ steps.deps.outputs.registry }}
+          openssl_install_tag: ${{ steps.deps.outputs.openssl_install_tag }}
+          wolfssl_install_tag: ${{ steps.deps.outputs.wolfssl_install_tag }}
+          openssl_hit: ${{ steps.deps.outputs.openssl_hit }}
+          wolfssl_hit: ${{ steps.deps.outputs.wolfssl_hit }}
 
       # Opt-in is per-algorithm: assert exactly the expected PQC test families
       # are present (both / mlkem / mldsa / none). This catches a leaked

--- a/scripts/oras-build-deps.sh
+++ b/scripts/oras-build-deps.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Pull or push a prebuilt OpenSSL/wolfSSL install tree as an OCI artifact.
+# Lets from-source CI builders reuse a dependency built once per commit
+# instead of recompiling it every job.
+#
+# Usage:
+#   oras-build-deps.sh pull <oci-ref> <dir>   # extract artifact into <dir>; exit 0 hit, 3 miss
+#   oras-build-deps.sh push <oci-ref> <dir>   # tar <dir> and push (best-effort; never fails the job)
+
+if [[ $# -lt 3 || $# -gt 4 ]]; then
+    echo "Usage: $0 pull|push <oci-ref> <dir> [verify-src-dir]" >&2
+    exit 1
+fi
+
+CMD="$1"
+REF="$2"
+DIR="$3"
+VERIFY_SRC="${4:-}"
+ARTIFACT="deps.tar.gz"
+
+# No oras on PATH (best-effort install failed): fast-path instead of burning
+# retry backoff on 'command not found'. pull -> miss, push -> no-op.
+if ! command -v oras >/dev/null 2>&1; then
+    case "$CMD" in
+        pull) echo "miss (oras not installed): $REF"; exit 3 ;;
+        push) echo "push skipped (oras not installed): $REF"; exit 0 ;;
+    esac
+fi
+
+oras_retry() {
+    local attempt
+    for attempt in 1 2 3; do
+        if "$@"; then
+            return 0
+        fi
+        [[ "$attempt" -lt 3 ]] && sleep $((attempt * 15))
+    done
+    return 1
+}
+
+case "$CMD" in
+    pull)
+        # A missing tag is a normal cache miss, not an error.
+        if ! err=$(oras manifest fetch "$REF" 2>&1 >/dev/null); then
+            case "$err" in
+                *"not found"*|*"failed to resolve"*|*"unauthorized"*|*"denied"*|*"UNAUTHORIZED"*|*"forbidden"*|*"401"*|*"403"*)
+                    echo "miss: $REF"
+                    exit 3
+                    ;;
+            esac
+        fi
+        # Stage in the same directory as $DIR so the final swap is an atomic
+        # rename, not a cross-filesystem copy (container /tmp vs the workspace
+        # bind-mount) that could leave a half-populated install dir on failure.
+        parent=$(dirname "$DIR")
+        tmp=$(mktemp -d "${parent}/.oras-deps.XXXXXX")
+        trap 'rm -rf "$tmp"' EXIT
+        if ! oras_retry oras pull "$REF" -o "$tmp"; then
+            echo "miss (pull failed): $REF"
+            exit 3
+        fi
+        if [[ ! -f "$tmp/$ARTIFACT" ]]; then
+            echo "miss (no artifact in $REF)"
+            exit 3
+        fi
+        # Extract into the temp dir first, then swap into place. A failed or
+        # partial extract must never leave a half-populated install dir - the
+        # build scripts treat a present dir as a cache hit and skip rebuild.
+        if ! tar xzf "$tmp/$ARTIFACT" -C "$tmp"; then
+            echo "miss (extract failed): $REF"
+            exit 3
+        fi
+        base=$(basename "$DIR")
+        if [[ ! -d "$tmp/$base" ]]; then
+            echo "miss (artifact missing $base): $REF"
+            exit 3
+        fi
+        rm -rf "$DIR"
+        mv "$tmp/$base" "$DIR"
+        echo "hit: $REF"
+        ;;
+    push)
+        # Best-effort: a push failure must never fail the job, so guard every
+        # fallible step and always exit 0.
+        if [[ ! -d "$DIR" ]]; then
+            echo "nothing to push: $DIR absent"
+            exit 0
+        fi
+        # Guard against a moving ref (master) advancing between the resolve step
+        # and the clone: the tag embeds the resolved SHA, so refuse to push if
+        # the built source is a different commit (would poison the durable tag).
+        if [[ -n "$VERIFY_SRC" && -d "$VERIFY_SRC/.git" ]]; then
+            expected=$(printf '%s' "$REF" | grep -oE '[0-9a-f]{40}' | head -1 || true)
+            built=$(git -C "$VERIFY_SRC" rev-parse HEAD 2>/dev/null || true)
+            if [[ -n "$expected" && -n "$built" && "$expected" != "$built" ]]; then
+                echo "push skipped: $VERIFY_SRC at $built != tag $expected (moving ref advanced)"
+                exit 0
+            fi
+        fi
+        if ! tmp=$(mktemp -d); then
+            echo "push skipped: mktemp failed"
+            exit 0
+        fi
+        trap 'rm -rf "$tmp"' EXIT
+        if ! tar czf "$tmp/$ARTIFACT" -C "$(dirname "$DIR")" "$(basename "$DIR")"; then
+            echo "push skipped: tar failed"
+            exit 0
+        fi
+        # oras rejects absolute file paths on push, and an absolute path stored
+        # in the manifest would break the pull side too; push by relative name
+        # from inside the temp dir.
+        if ( cd "$tmp" && oras_retry oras push "$REF" "$ARTIFACT" ); then
+            echo "pushed: $REF"
+        else
+            echo "push failed (non-fatal): $REF"
+        fi
+        ;;
+    *)
+        echo "unknown command: $CMD" >&2
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
## Description

Adds an ORAS-backed dependency cache for the from-source CI builders. OpenSSL/wolfSSL
are built once per resolved commit SHA and pushed to `ghcr.io/wolfssl/wolfprovider/build-deps`,
then pulled by every from-source job — the same registry pattern the repo already uses for
the `debs:` packages. Addresses the PR #412 review: durable, cross-run, cross-workflow reuse
instead of relying only on the evictable GitHub Actions cache.

The build scripts already skip configure+make when `openssl-install`/`wolfssl-install` exist
(`utils-openssl.sh`, `utils-wolfssl.sh`), so a pulled artifact is a drop-in — no build-script
changes needed.

### How the layers work (per job)

1. Resolve openssl/wolfssl ref → commit SHA (`resolve-ref.sh`), compute tags keyed by
   `variant + SHA + build-script-hash`.
2. `oras pull` the install dirs. Hit → build skips.
3. On a miss, fall back to `actions/cache` (PR #412's key).
4. Build only what is still absent.
5. On an ORAS miss where the dir now exists, `oras push` it so the next job/run hits warm
   (self-healing; canonical repo + write token only).

Master refs are keyed by resolved HEAD SHA, so master is rebuilt only when upstream master
actually advances — not every run.

### New

- `scripts/oras-build-deps.sh` — pull/push helper.
- `.github/actions/oras-build-deps` — pull + GH-cache fallback.
- `.github/actions/oras-build-deps-push` — self-healing push.

### Wired (14 from-source workflows)

cmdline, simple, smoke-test, seed-src, fips-ready, multi-compiler, nightly-multi-compiler,
sanitizers (isolated asan/tsan variants), openssl-version, wolfssl-versions-pqc,
wolfssl-pqc-kat, libtss2, sssd, static-analysis.

`wolfssl-pqc-kat.yml` is also reverted from the temporary fork branch back to upstream refs.

### Deployment note

First canonical run creates `ghcr.io/wolfssl/wolfprovider/build-deps` (private). An org admin
must flip it to **Public** so fork PRs can pull anonymously (same as the `debs:` package). Until
then forks fall back to build — no broken state.
