### PR TITLE
Fix EncryptedPrivateKeyInfo encode + decode (PBES2) across all key types

### DIFF
--- a/include/wolfprovider/internal.h
+++ b/include/wolfprovider/internal.h
@@ -243,9 +243,14 @@ int wp_hash_copy(wc_HashAlg* src, wc_HashAlg* dst, enum wc_HashType hashType);
 int wp_cipher_from_params(const OSSL_PARAM params[], int* cipher,
     const char** cipherName);
 
-int wp_encrypt_key(WOLFPROV_CTX* provCtx, const char* cipherName,
-    unsigned char* keyData, size_t* keyLen, word32 pkcs8Len,
-    OSSL_PASSPHRASE_CALLBACK *pwCb, void *pwCbArg, byte** cipherInfo);
+int wp_encrypt_key_pkcs8_size(WOLFPROV_CTX* provCtx, int cipher,
+    word32 plainLen, size_t* outLen);
+int wp_encrypt_key_pkcs8(WOLFPROV_CTX* provCtx, int cipher,
+    const unsigned char* plain, word32 plainLen,
+    unsigned char* out, size_t* outLen,
+    OSSL_PASSPHRASE_CALLBACK* pwCb, void* pwCbArg);
+int wp_decrypt_key_pkcs8(unsigned char* data, word32* len,
+    OSSL_PASSPHRASE_CALLBACK* pwCb, void* pwCbArg);
 
 int wp_read_der_bio(WOLFPROV_CTX* provCtx, OSSL_CORE_BIO *coreBio, unsigned char** data, word32* len);
 int wp_read_pem_bio(WOLFPROV_CTX *provctx, OSSL_CORE_BIO *coreBio,

--- a/src/wp_dh_kmgmt.c
+++ b/src/wp_dh_kmgmt.c
@@ -2352,6 +2352,43 @@ static int wp_dh_dec_send_params(wp_Dh* dh, OSSL_CALLBACK *dataCb,
     return ok;
 }
 
+#ifdef WOLFSSL_ENCRYPTED_KEYS
+/**
+ * Decode an encrypted PKCS#8 DER DH private key into the DH key object.
+ *
+ * @param [in, out] dh       DH key object.
+ * @param [in]      data     DER encoding (decrypted in place).
+ * @param [in]      len      Length, in bytes, of DER encoding.
+ * @param [in]      pwCb     Password callback.
+ * @param [in]      pwCbArg  Argument to pass to password callback.
+ * @return  1 on success.
+ * @return  0 on failure.
+ */
+static int wp_dh_decode_enc_pki(wp_Dh* dh, unsigned char* data, word32 len,
+    OSSL_PASSPHRASE_CALLBACK* pwCb, void* pwCbArg)
+{
+    int ok = 1;
+
+    WOLFPROV_ENTER_SILENT(WP_LOG_COMP_DH, WOLFPROV_FUNC_NAME);
+
+    if (!wolfssl_prov_is_running()) {
+        ok = 0;
+    }
+    /* Decrypt the PBES2 EncryptedPrivateKeyInfo in place. */
+    if (ok && (!wp_decrypt_key_pkcs8(data, &len, pwCb, pwCbArg))) {
+        ok = 0;
+    }
+    if (ok) {
+        /* Decode the recovered plaintext private key. */
+        ok = wp_dh_decode_pki(dh, data, len);
+    }
+
+    WOLFPROV_LEAVE_SILENT(WP_LOG_COMP_DH, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__),
+        ok);
+    return ok;
+}
+#endif
+
 /**
  * Decode the data in the core BIO.
  *
@@ -2432,8 +2469,13 @@ static int wp_dh_decode(wp_DhEncDecCtx* ctx, OSSL_CORE_BIO *cBio,
     }
     else if (ok && (ctx->format == WP_ENC_FORMAT_PKI)) {
         if (!wp_dh_decode_pki(dh, data, len)) {
-            ok = 0;
-            decoded = 0;
+#ifdef WOLFSSL_ENCRYPTED_KEYS
+            if (!wp_dh_decode_enc_pki(dh, data, len, pwCb, pwCbArg))
+#endif
+            {
+                ok = 0;
+                decoded = 0;
+            }
         }
     }
 
@@ -2670,7 +2712,8 @@ static int wp_dh_encode_pki(const wp_Dh *dh, unsigned char* keyData,
  * @return  1 on success.
  * @return  0 on failure.
  */
-static int wp_dh_encode_epki_size(const wp_Dh *dh, size_t* keyLen)
+static int wp_dh_encode_epki_size(const wp_DhEncDecCtx* ctx, const wp_Dh *dh,
+    size_t* keyLen)
 {
     int ok = 1;
     int ret;
@@ -2678,12 +2721,14 @@ static int wp_dh_encode_epki_size(const wp_Dh *dh, size_t* keyLen)
 
     WOLFPROV_ENTER(WP_LOG_COMP_DH, "wp_dh_encode_epki_size");
 
+    /* Get the plaintext PKCS #8 length. */
     ret = wc_DhPrivKeyToDer((DhKey*)&dh->key, NULL, &len);
     if (ret != LENGTH_ONLY_E) {
         ok = 0;
     }
     if (ok) {
-        *keyLen = ((len + 15) / 16) * 16;
+        /* Get the size of the PBES2 EncryptedPrivateKeyInfo encoding. */
+        ok = wp_encrypt_key_pkcs8_size(ctx->provCtx, ctx->cipher, len, keyLen);
     }
 
     WOLFPROV_LEAVE(WP_LOG_COMP_DH, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
@@ -2691,7 +2736,7 @@ static int wp_dh_encode_epki_size(const wp_Dh *dh, size_t* keyLen)
 }
 
 /**
- * Encode the DH key in an Encrypted PKCS#8 format.
+ * Encode the DH key in a PBES2 EncryptedPrivateKeyInfo format.
  *
  * @param [in]      ctx         DH encoder/decoder context object.
  * @param [in]      dh          DH key object.
@@ -2700,28 +2745,48 @@ static int wp_dh_encode_epki_size(const wp_Dh *dh, size_t* keyLen)
  *                              On out, length of encoding in bytes.
  * @param [in]      pwCb        Password callback.
  * @param [in]      pwCbArg     Argument to pass to password callback.
- * @param [out]     cipherInfo  Information about encryption.
  * @return  1 on success.
  * @return  0 on failure.
  */
 static int wp_dh_encode_epki(const wp_DhEncDecCtx* ctx, const wp_Dh *dh,
     unsigned char* keyData, size_t* keyLen, OSSL_PASSPHRASE_CALLBACK *pwCb,
-    void *pwCbArg, byte** cipherInfo)
+    void *pwCbArg)
 {
     int ok = 1;
     int rc;
-    word32 pkcs8Len = (word32)*keyLen;
+    word32 pkcs8Len = 0;
+    byte* encodedKey = NULL;
 
     WOLFPROV_ENTER(WP_LOG_COMP_DH, "wp_dh_encode_epki");
 
-    /* Encode key. */
-    rc = wc_DhPrivKeyToDer((DhKey*)&dh->key, keyData, &pkcs8Len);
-    if (rc <= 0) {
+    /* Determine the plaintext PKCS #8 length. */
+    rc = wc_DhPrivKeyToDer((DhKey*)&dh->key, NULL, &pkcs8Len);
+    if (rc != LENGTH_ONLY_E) {
         ok = 0;
     }
-    if (ok && (!wp_encrypt_key(ctx->provCtx, ctx->cipherName, keyData, keyLen,
-            pkcs8Len, pwCb, pwCbArg, cipherInfo))) {
-        ok = 0;
+    if (ok) {
+        /* Allocate the plaintext buffer - must differ from the output. */
+        encodedKey = OPENSSL_malloc(pkcs8Len);
+        if (encodedKey == NULL) {
+            ok = 0;
+        }
+    }
+    if (ok) {
+        /* Encode the plaintext PKCS #8 key. */
+        rc = wc_DhPrivKeyToDer((DhKey*)&dh->key, encodedKey, &pkcs8Len);
+        if (rc <= 0) {
+            ok = 0;
+        }
+    }
+    if (ok) {
+        /* Encrypt as a PBES2 EncryptedPrivateKeyInfo. */
+        ok = wp_encrypt_key_pkcs8(ctx->provCtx, ctx->cipher, encodedKey,
+            pkcs8Len, keyData, keyLen, pwCb, pwCbArg);
+    }
+
+    /* encodedKey holds the plaintext PKCS#8 private key before encryption. */
+    if (encodedKey != NULL) {
+        OPENSSL_clear_free(encodedKey, pkcs8Len);
     }
 
     WOLFPROV_LEAVE(WP_LOG_COMP_DH, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
@@ -2766,7 +2831,6 @@ static int wp_dh_encode(wp_DhEncDecCtx* ctx, OSSL_CORE_BIO *cBio,
     size_t pemLen = 0;
     int pemType = DH_PRIVATEKEY_TYPE;
     int private = 0;
-    byte* cipherInfo = NULL;
 
     if (out == NULL) {
         ok = 0;
@@ -2797,7 +2861,7 @@ static int wp_dh_encode(wp_DhEncDecCtx* ctx, OSSL_CORE_BIO *cBio,
 #ifdef WOLFSSL_ENCRYPTED_KEYS
     else if (ok && (ctx->format == WP_ENC_FORMAT_EPKI)) {
         private = 1;
-        if (!wp_dh_encode_epki_size(key, &derLen)) {
+        if (!wp_dh_encode_epki_size(ctx, key, &derLen)) {
             ok = 0;
         }
     }
@@ -2832,8 +2896,8 @@ static int wp_dh_encode(wp_DhEncDecCtx* ctx, OSSL_CORE_BIO *cBio,
 #ifdef WOLFSSL_ENCRYPTED_KEYS
     else if (ok && (ctx->format == WP_ENC_FORMAT_EPKI)) {
         private = 1;
-        if (!wp_dh_encode_epki(ctx, key, derData, &derLen, pwCb, pwCbArg,
-                (ctx->encoding == WP_FORMAT_PEM) ? &cipherInfo : NULL)) {
+        pemType = PKCS8_ENC_PRIVATEKEY_TYPE;
+        if (!wp_dh_encode_epki(ctx, key, derData, &derLen, pwCb, pwCbArg)) {
             ok = 0;
         }
     }
@@ -2843,7 +2907,7 @@ static int wp_dh_encode(wp_DhEncDecCtx* ctx, OSSL_CORE_BIO *cBio,
         keyLen = derLen;
     }
     else if (ok && (ctx->encoding == WP_FORMAT_PEM)) {
-        rc = wc_DerToPemEx(derData, (word32)derLen, NULL, 0, cipherInfo,
+        rc = wc_DerToPemEx(derData, (word32)derLen, NULL, 0, NULL,
             pemType);
         if (rc <= 0) {
             ok = 0;
@@ -2857,7 +2921,7 @@ static int wp_dh_encode(wp_DhEncDecCtx* ctx, OSSL_CORE_BIO *cBio,
         }
         if (ok) {
             rc = wc_DerToPemEx(derData, (word32)derLen, pemData, (word32)pemLen,
-                cipherInfo, pemType);
+                NULL, pemType);
             if (rc <= 0) {
                 ok = 0;
             }
@@ -2882,7 +2946,6 @@ static int wp_dh_encode(wp_DhEncDecCtx* ctx, OSSL_CORE_BIO *cBio,
         OPENSSL_free(derData);
         OPENSSL_free(pemData);
     }
-    OPENSSL_free(cipherInfo);
 
     BIO_free(out);
 #else

--- a/src/wp_ecc_kmgmt.c
+++ b/src/wp_ecc_kmgmt.c
@@ -2337,6 +2337,43 @@ static int wp_ecc_dec_send_params(wp_Ecc* ecc, OSSL_CALLBACK *dataCb,
     return ok;
 }
 
+#ifdef WOLFSSL_ENCRYPTED_KEYS
+/**
+ * Decode an encrypted PKCS#8 DER ECC private key into the ECC key object.
+ *
+ * @param [in, out] ecc      ECC key object.
+ * @param [in]      data     DER encoding (decrypted in place).
+ * @param [in]      len      Length, in bytes, of DER encoding.
+ * @param [in]      pwCb     Password callback.
+ * @param [in]      pwCbArg  Argument to pass to password callback.
+ * @return  1 on success.
+ * @return  0 on failure.
+ */
+static int wp_ecc_decode_enc_pki(wp_Ecc* ecc, unsigned char* data, word32 len,
+    OSSL_PASSPHRASE_CALLBACK* pwCb, void* pwCbArg)
+{
+    int ok = 1;
+
+    WOLFPROV_ENTER_SILENT(WP_LOG_COMP_ECC, WOLFPROV_FUNC_NAME);
+
+    if (!wolfssl_prov_is_running()) {
+        ok = 0;
+    }
+    /* Decrypt the PBES2 EncryptedPrivateKeyInfo in place. */
+    if (ok && (!wp_decrypt_key_pkcs8(data, &len, pwCb, pwCbArg))) {
+        ok = 0;
+    }
+    if (ok) {
+        /* Decode the recovered plaintext private key. */
+        ok = wp_ecc_decode_pki(ecc, data, len);
+    }
+
+    WOLFPROV_LEAVE_SILENT(WP_LOG_COMP_ECC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__),
+        ok);
+    return ok;
+}
+#endif
+
 /**
  * Decode the data in the core BIO.
  *
@@ -2414,8 +2451,13 @@ static int wp_ecc_decode(wp_EccEncDecCtx* ctx, OSSL_CORE_BIO *cBio,
     }
     else if (ok && (ctx->format == WP_ENC_FORMAT_PKI)) {
         if (!wp_ecc_decode_pki(ecc, data, len)) {
-            ok = 0;
-            decoded = 0;
+#ifdef WOLFSSL_ENCRYPTED_KEYS
+            if (!wp_ecc_decode_enc_pki(ecc, data, len, pwCb, pwCbArg))
+#endif
+            {
+                ok = 0;
+                decoded = 0;
+            }
         }
     }
 
@@ -2762,7 +2804,8 @@ static int wp_ecc_encode_pki(const wp_Ecc *ecc, unsigned char* keyData,
  * @return  1 on success.
  * @return  0 on failure.
  */
-static int wp_ecc_encode_epki_size(const wp_Ecc *ecc, size_t* keyLen)
+static int wp_ecc_encode_epki_size(const wp_EccEncDecCtx* ctx,
+    const wp_Ecc *ecc, size_t* keyLen)
 {
     int ok = 1;
     int rc;
@@ -2770,6 +2813,7 @@ static int wp_ecc_encode_epki_size(const wp_Ecc *ecc, size_t* keyLen)
 
     WOLFPROV_ENTER(WP_LOG_COMP_ECC, "wp_ecc_encode_epki_size");
 
+    /* Get the plaintext PKCS #8 length. */
     PRIVATE_KEY_UNLOCK();
     rc = wc_EccKeyToPKCS8((ecc_key*)&ecc->key, NULL, &len);
     PRIVATE_KEY_LOCK();
@@ -2777,7 +2821,8 @@ static int wp_ecc_encode_epki_size(const wp_Ecc *ecc, size_t* keyLen)
         ok = 0;
     }
     if (ok) {
-        *keyLen = ((len + 15) / 16) * 16;
+        /* Get the size of the PBES2 EncryptedPrivateKeyInfo encoding. */
+        ok = wp_encrypt_key_pkcs8_size(ctx->provCtx, ctx->cipher, len, keyLen);
     }
 
     WOLFPROV_LEAVE(WP_LOG_COMP_ECC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
@@ -2785,7 +2830,7 @@ static int wp_ecc_encode_epki_size(const wp_Ecc *ecc, size_t* keyLen)
 }
 
 /**
- * Encode the ECC key in an Encrypted PKCS#8 format.
+ * Encode the ECC key in a PBES2 EncryptedPrivateKeyInfo format.
  *
  * @param [in]      ctx         ECC encoder/decoder context object.
  * @param [in]      ecc         ECC key object.
@@ -2794,30 +2839,52 @@ static int wp_ecc_encode_epki_size(const wp_Ecc *ecc, size_t* keyLen)
  *                              On out, length of encoding in bytes.
  * @param [in]      pwCb        Password callback.
  * @param [in]      pwCbArg     Argument to pass to password callback.
- * @param [out]     cipherInfo  Information about encryption.
  * @return  1 on success.
  * @return  0 on failure.
  */
 static int wp_ecc_encode_epki(const wp_EccEncDecCtx* ctx, const wp_Ecc *ecc,
     unsigned char* keyData, size_t* keyLen, OSSL_PASSPHRASE_CALLBACK *pwCb,
-    void *pwCbArg, byte** cipherInfo)
+    void *pwCbArg)
 {
     int ok = 1;
     int rc;
-    word32 len = (word32)*keyLen;
+    word32 len = 0;
+    byte* encodedKey = NULL;
 
     WOLFPROV_ENTER(WP_LOG_COMP_ECC, "wp_ecc_encode_epki");
 
-    /* Encode key. */
+    /* Determine the plaintext PKCS #8 length. */
     PRIVATE_KEY_UNLOCK();
-    rc = wc_EccKeyToPKCS8((ecc_key*)&ecc->key, keyData, &len);
+    rc = wc_EccKeyToPKCS8((ecc_key*)&ecc->key, NULL, &len);
     PRIVATE_KEY_LOCK();
-    if (rc <= 0) {
+    if (rc != LENGTH_ONLY_E) {
         ok = 0;
     }
-    if (ok && (!wp_encrypt_key(ctx->provCtx, ctx->cipherName, keyData, keyLen,
-            len, pwCb, pwCbArg, cipherInfo))) {
-        ok = 0;
+    if (ok) {
+        /* Allocate the plaintext buffer - must differ from the output. */
+        encodedKey = OPENSSL_malloc(len);
+        if (encodedKey == NULL) {
+            ok = 0;
+        }
+    }
+    if (ok) {
+        /* Encode the plaintext PKCS #8 key. */
+        PRIVATE_KEY_UNLOCK();
+        rc = wc_EccKeyToPKCS8((ecc_key*)&ecc->key, encodedKey, &len);
+        PRIVATE_KEY_LOCK();
+        if (rc <= 0) {
+            ok = 0;
+        }
+    }
+    if (ok) {
+        /* Encrypt as a PBES2 EncryptedPrivateKeyInfo. */
+        ok = wp_encrypt_key_pkcs8(ctx->provCtx, ctx->cipher, encodedKey, len,
+            keyData, keyLen, pwCb, pwCbArg);
+    }
+
+    /* encodedKey holds the plaintext PKCS#8 private key before encryption. */
+    if (encodedKey != NULL) {
+        OPENSSL_clear_free(encodedKey, len);
     }
 
     WOLFPROV_LEAVE(WP_LOG_COMP_ECC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
@@ -2853,7 +2920,6 @@ static int wp_ecc_encode(wp_EccEncDecCtx* ctx, OSSL_CORE_BIO *cBio,
     size_t pemLen = 0;
     int pemType = PKCS8_PRIVATEKEY_TYPE;
     int private = 0;
-    byte* cipherInfo = NULL;
 
     WOLFPROV_ENTER(WP_LOG_COMP_ECC, "wp_ecc_encode");
 
@@ -2898,7 +2964,7 @@ static int wp_ecc_encode(wp_EccEncDecCtx* ctx, OSSL_CORE_BIO *cBio,
 #ifdef WOLFSSL_ENCRYPTED_KEYS
     else if (ok && (ctx->format == WP_ENC_FORMAT_EPKI)) {
         private = 1;
-        if (!wp_ecc_encode_epki_size(key, &derLen)) {
+        if (!wp_ecc_encode_epki_size(ctx, key, &derLen)) {
             ok = 0;
         }
     }
@@ -2949,8 +3015,8 @@ static int wp_ecc_encode(wp_EccEncDecCtx* ctx, OSSL_CORE_BIO *cBio,
 #ifdef WOLFSSL_ENCRYPTED_KEYS
     else if (ok && (ctx->format == WP_ENC_FORMAT_EPKI)) {
         private = 1;
-        if (!wp_ecc_encode_epki(ctx, key, derData, &derLen, pwCb, pwCbArg,
-                (ctx->encoding == WP_FORMAT_PEM) ? &cipherInfo : NULL)) {
+        pemType = PKCS8_ENC_PRIVATEKEY_TYPE;
+        if (!wp_ecc_encode_epki(ctx, key, derData, &derLen, pwCb, pwCbArg)) {
             ok = 0;
         }
     }
@@ -2960,7 +3026,7 @@ static int wp_ecc_encode(wp_EccEncDecCtx* ctx, OSSL_CORE_BIO *cBio,
         keyLen = derLen;
     }
     else if (ok && (ctx->encoding == WP_FORMAT_PEM)) {
-        rc = wc_DerToPemEx(derData, (word32)derLen, NULL, 0, cipherInfo,
+        rc = wc_DerToPemEx(derData, (word32)derLen, NULL, 0, NULL,
             pemType);
         if (rc <= 0) {
             ok = 0;
@@ -2974,7 +3040,7 @@ static int wp_ecc_encode(wp_EccEncDecCtx* ctx, OSSL_CORE_BIO *cBio,
         }
         if (ok) {
             rc = wc_DerToPemEx(derData, (word32)derLen, pemData, (word32)pemLen,
-                cipherInfo, pemType);
+                NULL, pemType);
             if (rc <= 0) {
                 ok = 0;
             }
@@ -3008,7 +3074,6 @@ static int wp_ecc_encode(wp_EccEncDecCtx* ctx, OSSL_CORE_BIO *cBio,
         OPENSSL_free(derData);
         OPENSSL_free(pemData);
     }
-    OPENSSL_free(cipherInfo);
     BIO_free(out);
     WOLFPROV_LEAVE(WP_LOG_COMP_ECC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;

--- a/src/wp_ecx_kmgmt.c
+++ b/src/wp_ecx_kmgmt.c
@@ -2031,6 +2031,46 @@ static int wp_ecx_dec_send_params(wp_Ecx* ecx, const char* dataType,
     return ok;
 }
 
+#ifdef WOLFSSL_ENCRYPTED_KEYS
+/**
+ * Decode an encrypted PKCS#8 DER ECX private key into the ECX key object.
+ *
+ * @param [in]      ctx      ECX encoder/decoder context object.
+ * @param [in, out] ecx      ECX key object.
+ * @param [in]      data     DER encoding (decrypted in place).
+ * @param [in]      len      Length, in bytes, of DER encoding.
+ * @param [in]      pwCb     Password callback.
+ * @param [in]      pwCbArg  Argument to pass to password callback.
+ * @return  1 on success.
+ * @return  0 on failure.
+ */
+static int wp_ecx_decode_enc_pki(wp_EcxEncDecCtx* ctx, wp_Ecx* ecx,
+    unsigned char* data, word32 len, OSSL_PASSPHRASE_CALLBACK* pwCb,
+    void* pwCbArg)
+{
+    int ok = 1;
+    word32 idx = 0;
+
+    WOLFPROV_ENTER_SILENT(WP_LOG_COMP_KE, WOLFPROV_FUNC_NAME);
+
+    if (!wolfssl_prov_is_running()) {
+        ok = 0;
+    }
+    /* Decrypt the PBES2 EncryptedPrivateKeyInfo in place. */
+    if (ok && (!wp_decrypt_key_pkcs8(data, &len, pwCb, pwCbArg))) {
+        ok = 0;
+    }
+    /* Decode the recovered plaintext private key. */
+    if (ok && (ctx->decode(data, &idx, (void*)&ecx->key, len) != 0)) {
+        ok = 0;
+    }
+
+    WOLFPROV_LEAVE_SILENT(WP_LOG_COMP_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__),
+        ok);
+    return ok;
+}
+#endif
+
 /**
  * Decode the data in the core BIO.
  *
@@ -2112,9 +2152,16 @@ static int wp_ecx_decode(wp_EcxEncDecCtx* ctx, OSSL_CORE_BIO* cBio,
     if (ok) {
         rc = ctx->decode(data, &idx, (void*)&ecx->key, len);
         if (rc != 0) {
-            WOLFPROV_MSG_DEBUG_RETCODE(WP_LOG_LEVEL_DEBUG, "decode", rc);
-            ok = 0;
-            decoded = 0;
+#ifdef WOLFSSL_ENCRYPTED_KEYS
+            /* May be an encrypted PKCS#8 key - decrypt and retry. */
+            if ((ctx->format != WP_ENC_FORMAT_PKI) ||
+                    (!wp_ecx_decode_enc_pki(ctx, ecx, data, len, pwCb, pwCbArg)))
+#endif
+            {
+                WOLFPROV_MSG_DEBUG_RETCODE(WP_LOG_LEVEL_DEBUG, "decode", rc);
+                ok = 0;
+                decoded = 0;
+            }
         }
     }
     if (ok && (ctx->format == WP_ENC_FORMAT_SPKI)) {
@@ -2171,13 +2218,16 @@ static int wp_ecx_encode(wp_EcxEncDecCtx* ctx, OSSL_CORE_BIO *cBio,
     size_t keyLen = 0;
     unsigned char derData[160];
     size_t derLen = 0;
+    unsigned char* encData = NULL;
+    size_t encLen = 0;
+    unsigned char* srcData;
+    size_t srcLen;
     unsigned char* pemData = NULL;
     size_t pemLen = 0;
     int pemType = (ctx->format == WP_ENC_FORMAT_SPKI) ? PUBLICKEY_TYPE :
                                                         PKCS8_PRIVATEKEY_TYPE;
     int private = (ctx->format == WP_ENC_FORMAT_PKI) ||
                   (ctx->format == WP_ENC_FORMAT_EPKI);
-    byte* cipherInfo = NULL;
 
     (void)params;
     (void)selection;
@@ -2195,19 +2245,40 @@ static int wp_ecx_encode(wp_EcxEncDecCtx* ctx, OSSL_CORE_BIO *cBio,
             derLen = rc;
         }
     }
+
+    /* By default the plaintext DER is the source for the output encoding. */
+    srcData = derData;
+    srcLen = derLen;
     if (ok && (ctx->format == WP_ENC_FORMAT_EPKI)) {
-        if (!wp_encrypt_key(ctx->provCtx, ctx->cipherName, derData, &derLen, rc,
-            pwCb, pwCbArg, &cipherInfo)) {
+        pemType = PKCS8_ENC_PRIVATEKEY_TYPE;
+        /* The PBES2 output is larger than the plaintext and must use a
+         * separate buffer, so size it and encrypt into fresh memory. */
+        if (!wp_encrypt_key_pkcs8_size(ctx->provCtx, ctx->cipher,
+                (word32)derLen, &encLen)) {
             ok = 0;
+        }
+        if (ok) {
+            encData = OPENSSL_malloc(encLen);
+            if (encData == NULL) {
+                ok = 0;
+            }
+        }
+        if (ok && (!wp_encrypt_key_pkcs8(ctx->provCtx, ctx->cipher, derData,
+                (word32)derLen, encData, &encLen, pwCb, pwCbArg))) {
+            ok = 0;
+        }
+        if (ok) {
+            srcData = encData;
+            srcLen = encLen;
         }
     }
 
     if (ok && (ctx->encoding == WP_FORMAT_DER)) {
-        keyData = derData;
-        keyLen = derLen;
+        keyData = srcData;
+        keyLen = srcLen;
     }
     else if (ok && (ctx->encoding == WP_FORMAT_PEM)) {
-        rc = wc_DerToPemEx(derData, (word32)derLen, NULL, 0, cipherInfo, pemType);
+        rc = wc_DerToPemEx(srcData, (word32)srcLen, NULL, 0, NULL, pemType);
         if (rc <= 0) {
             ok = 0;
         }
@@ -2219,8 +2290,8 @@ static int wp_ecx_encode(wp_EcxEncDecCtx* ctx, OSSL_CORE_BIO *cBio,
             }
         }
         if (ok) {
-            rc = wc_DerToPemEx(derData, (word32)derLen, pemData, (word32)pemLen, cipherInfo,
-                pemType);
+            rc = wc_DerToPemEx(srcData, (word32)srcLen, pemData, (word32)pemLen,
+                NULL, pemType);
             if (rc <= 0) {
                 ok = 0;
             }
@@ -2237,14 +2308,15 @@ static int wp_ecx_encode(wp_EcxEncDecCtx* ctx, OSSL_CORE_BIO *cBio,
         }
     }
 
+    /* derData holds the plaintext private key material. */
     if (private) {
-        OPENSSL_cleanse(derData, derLen);
+        OPENSSL_cleanse(derData, sizeof(derData));
         OPENSSL_clear_free(pemData, pemLen);
     }
     else {
         OPENSSL_free(pemData);
     }
-    OPENSSL_free(cipherInfo);
+    OPENSSL_clear_free(encData, encLen);
     BIO_free(out);
     WOLFPROV_LEAVE(WP_LOG_COMP_KE, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;

--- a/src/wp_internal.c
+++ b/src/wp_internal.c
@@ -32,6 +32,7 @@
 
 #include <wolfssl/wolfcrypt/rsa.h>
 #include <wolfssl/wolfcrypt/pwdbased.h>
+#include <wolfssl/wolfcrypt/asn_public.h>
 #ifdef HAVE_FIPS
 #include <wolfssl/wolfcrypt/fips_test.h>
 #endif
@@ -948,265 +949,303 @@ int wp_cipher_from_params(const OSSL_PARAM params[], int* cipher,
     return ok;
 }
 
-#ifndef WOLFSSL_ENCRYPTED_KEYS
-#ifdef WP_HAVE_MD5
-/*
- * wolfProvider version of EncryptedInfo.
- */
-typedef struct wp_EncryptedInfo {
-    /* Cipher identifier. */
-    int    cipherType;
-    /* Length of IV. */
-    word32 ivSz;
-    /* Length of key. */
-    word32 keySz;
-    /* Name of cipher alglorithm. */
-    char   name[NAME_SZ];
-    /* IV for encryption. */
-    byte   iv[IV_SZ];
-} wp_EncryptedInfo;
+/* Salt length used for PBES2 EncryptedPrivateKeyInfo encoding. The same value
+ * is used for the size query and the encrypt call so the reported and actual
+ * output sizes agree. */
+#define WP_EPKI_SALT_LEN    16
 
-#if !defined(NO_AES) && defined(HAVE_AES_CBC) && defined(WOLFSSL_AES_128)
-    static wcchar kEncTypeAesCbc128 = "AES-128-CBC";
-#endif
-#if !defined(NO_AES) && defined(HAVE_AES_CBC) && defined(WOLFSSL_AES_192)
-    static wcchar kEncTypeAesCbc192 = "AES-192-CBC";
-#endif
-#if !defined(NO_AES) && defined(HAVE_AES_CBC) && defined(WOLFSSL_AES_256)
-    static wcchar kEncTypeAesCbc256 = "AES-256-CBC";
-#endif
-
-static int wp_EncryptedInfoGet(wp_EncryptedInfo* info, const char* cipherInfo)
-{
-    int ret = 0;
-
-    if (info == NULL || cipherInfo == NULL)
-        return BAD_FUNC_ARG;
-
-    /* determine cipher information */
-#if !defined(NO_AES) && defined(HAVE_AES_CBC) && defined(WOLFSSL_AES_128)
-    if (XSTRCMP(cipherInfo, kEncTypeAesCbc128) == 0) {
-        info->cipherType = WC_CIPHER_AES_CBC;
-        info->keySz = AES_128_KEY_SIZE;
-        if (info->ivSz == 0) info->ivSz  = AES_IV_SIZE;
-    }
-    else
-#endif
-#if !defined(NO_AES) && defined(HAVE_AES_CBC) && defined(WOLFSSL_AES_192)
-    if (XSTRCMP(cipherInfo, kEncTypeAesCbc192) == 0) {
-        info->cipherType = WC_CIPHER_AES_CBC;
-        info->keySz = AES_192_KEY_SIZE;
-        if (info->ivSz == 0) info->ivSz  = AES_IV_SIZE;
-    }
-    else
-#endif
-#if !defined(NO_AES) && defined(HAVE_AES_CBC) && defined(WOLFSSL_AES_256)
-    if (XSTRCMP(cipherInfo, kEncTypeAesCbc256) == 0) {
-        info->cipherType = WC_CIPHER_AES_CBC;
-        info->keySz = AES_256_KEY_SIZE;
-        if (info->ivSz == 0) info->ivSz  = AES_IV_SIZE;
-    }
-    else
-#endif
-    {
-        ret = NOT_COMPILED_IN;
-    }
-    return ret;
-}
-
-#define PKCS5_SALT_SZ   8
-
-static int wp_BufferKeyEncrypt(wp_EncryptedInfo* info, byte* der, word32 derSz,
-    const byte* password, int passwordSz, int hashType)
-{
-    int ret = NOT_COMPILED_IN;
-#ifdef WOLFSSL_SMALL_STACK
-    byte* key      = NULL;
-#else
-    byte  key[WC_MAX_SYM_KEY_SIZE];
-#endif
-
-    (void)derSz;
-    (void)passwordSz;
-    (void)hashType;
-
-    if (der == NULL || password == NULL || info == NULL || info->keySz == 0 ||
-            info->ivSz < PKCS5_SALT_SZ) {
-        return BAD_FUNC_ARG;
-    }
-
-#ifdef WOLFSSL_SMALL_STACK
-    key = (byte*)XMALLOC(WC_MAX_SYM_KEY_SIZE, NULL, DYNAMIC_TYPE_SYMMETRIC_KEY);
-    if (key == NULL) {
-        return MEMORY_E;
-    }
-#endif /* WOLFSSL_SMALL_STACK */
-
-    (void)XMEMSET(key, 0, WC_MAX_SYM_KEY_SIZE);
-
-#ifndef NO_PWDBASED
-    if ((ret = wc_PBKDF1(key, password, passwordSz, info->iv, PKCS5_SALT_SZ, 1,
-                                        info->keySz, hashType)) != 0) {
-        ForceZero(key, WC_MAX_SYM_KEY_SIZE);
-#ifdef WOLFSSL_SMALL_STACK
-        XFREE(key, NULL, DYNAMIC_TYPE_SYMMETRIC_KEY);
-#endif
-        return ret;
-    }
-#endif
-
-#ifndef NO_DES3
-    if (info->cipherType == WC_CIPHER_DES)
-        ret = wc_Des_CbcEncryptWithKey(der, der, derSz, key, info->iv);
-    if (info->cipherType == WC_CIPHER_DES3)
-        ret = wc_Des3_CbcEncryptWithKey(der, der, derSz, key, info->iv);
-#endif /* NO_DES3 */
-#if !defined(NO_AES) && defined(HAVE_AES_CBC)
-    if (info->cipherType == WC_CIPHER_AES_CBC)
-        ret = wc_AesCbcEncryptWithKey(der, der, derSz, key, info->keySz,
-            info->iv);
-#endif /* !NO_AES && HAVE_AES_CBC */
-
-    ForceZero(key, WC_MAX_SYM_KEY_SIZE);
-#ifdef WOLFSSL_SMALL_STACK
-    XFREE(key, NULL, DYNAMIC_TYPE_SYMMETRIC_KEY);
-#endif
-
-    return ret;
-}
-#endif /* WP_HAVE_MD5 */
-#endif /* WOLFSSL_ENCRYPTED_KEYS */
+/* Maximum passphrase length read from the password callback. */
+#define WP_EPKI_PASSWORD_MAX    1024
 
 /**
- * Encrypt the PKCS #8 key.
+ * Get the size of the PBES2 EncryptedPrivateKeyInfo encoding of a PKCS #8 key.
  *
- * Calls password callback and generates a random IV.
+ * The encrypted structure is larger than the plaintext (it carries the PBES2
+ * AlgorithmIdentifier), and the exact size depends on the cipher, so the size
+ * is obtained from wolfSSL rather than computed.
  *
- * @param [in]      provCtx     Provider context.
- * @param [in]      cipherName  Name of cipher to encrypt with.
- * @param [in, out] keyData     On in, PKCS #8 encoded key.
- *                              On out, encrypted PKCS #8 encoded key.
- * @param [in, out] keyLen      On in, length of buffer in bytes.
- *                              On out, length of encrypted key in bytes.
- * @param [in]      pkcs8Len    Length of PKCS #8 key in bytes.
- * @param [in]      pwCb        Password callback.
- * @param [in]      pwCbArg     Argument to pass to password callback.
- * @param [out]     cipherInfo  Information about encryption.
+ * @param [in]  provCtx   Provider context (supplies the RNG).
+ * @param [in]  cipher    wolfCrypt cipher identifier to encrypt with.
+ * @param [in]  plainLen  Length of the plaintext PKCS #8 key in bytes.
+ * @param [out] outLen    Length of the encrypted encoding in bytes.
  * @return  1 on success.
  * @return  0 on failure.
  */
-int wp_encrypt_key(WOLFPROV_CTX* provCtx, const char* cipherName,
-    unsigned char* keyData, size_t* keyLen, word32 pkcs8Len,
-    OSSL_PASSPHRASE_CALLBACK *pwCb, void *pwCbArg, byte** cipherInfo)
+int wp_encrypt_key_pkcs8_size(WOLFPROV_CTX* provCtx, int cipher,
+    word32 plainLen, size_t* outLen)
 {
-#ifdef WP_HAVE_MD5
+#if defined(HAVE_PKCS8) && !defined(NO_PWDBASED)
     int ok = 1;
-    int rc;
-    word32 len = (word32)*keyLen;
-#ifdef WOLFSSL_ENCRYPTED_KEYS
-    EncryptedInfo info[1];
-#else
-    wp_EncryptedInfo info[1];
-#endif
-    word32 cipherInfoSz;
-    char password[1024];
-    size_t passwordSz = sizeof(password);
+    int rc = 0;
+    word32 outSz = 0;
+    byte fakeData[1] = { 0 };
+    byte fakeSalt[WP_EPKI_SALT_LEN] = { 0 };
 
-    WOLFPROV_ENTER(WP_LOG_COMP_PROVIDER, "wp_encrypt_key");
+    WOLFPROV_ENTER(WP_LOG_COMP_PROVIDER, "wp_encrypt_key_pkcs8_size");
 
-    /* Get password. */
-    if (!pwCb(password, passwordSz, &passwordSz, NULL, pwCbArg)) {
-        ok = 0;
-    }
-    if (ok && (passwordSz > sizeof(password))) {
+    /* A cipher must be selected to produce an encrypted key. */
+    if (cipher == 0) {
         ok = 0;
     }
     if (ok) {
-        XMEMSET(info, 0, sizeof(info));
-        XSTRNCPY(info->name, cipherName, NAME_SZ-1);
-        info->name[NAME_SZ-1] = '\0';
-
-    #ifdef WOLFSSL_ENCRYPTED_KEYS
-        rc = wc_EncryptedInfoGet(info, info->name);
+        /* Passing a NULL output buffer returns the required length. The _ex
+         * form (wolfSSL 5.8.2+) selects the HMAC-SHA256 PBKDF2 PRF; older
+         * wolfSSL uses the SHA-1 PRF. */
+    #if LIBWOLFSSL_VERSION_HEX >= 0x05008002
+        rc = wc_EncryptPKCS8Key_ex(fakeData, plainLen, NULL, &outSz, "", 0,
+            WP_PKCS5, WP_PBES2, cipher, fakeSalt, sizeof(fakeSalt),
+            WP_PKCS12_ITERATIONS_DEFAULT, HMAC_SHA256_OID,
+            wp_provctx_get_rng(provCtx), NULL);
     #else
-        rc = wp_EncryptedInfoGet(info, info->name);
+        rc = wc_EncryptPKCS8Key(fakeData, plainLen, NULL, &outSz, "", 0,
+            WP_PKCS5, WP_PBES2, cipher, fakeSalt, sizeof(fakeSalt),
+            WP_PKCS12_ITERATIONS_DEFAULT, wp_provctx_get_rng(provCtx), NULL);
     #endif
-        if (rc != 0) {
-            WOLFPROV_MSG_DEBUG_RETCODE(WP_LOG_LEVEL_DEBUG, "EncryptedInfoGet", rc);
+        if (rc != LENGTH_ONLY_E) {
             ok = 0;
         }
-    }
-    if (ok) {
-        /* Calculate random IV. */
-        WC_RNG* rng = wp_provctx_get_rng(provCtx);
-
-    #ifndef WP_SINGLE_THREADED
-        wp_provctx_lock_rng(provCtx);
-    #endif
-        rc = wc_RNG_GenerateBlock(rng, info->iv, info->ivSz);
-    #ifndef WP_SINGLE_THREADED
-        wp_provctx_unlock_rng(provCtx);
-    #endif
-        if (rc < 0) {
-            WOLFPROV_MSG_DEBUG_RETCODE(WP_LOG_LEVEL_DEBUG, "wc_RNG_GenerateBlock", rc);
-            ok = 0;
+        else {
+            *outLen = (size_t)outSz;
         }
-    }
-    if (ok) {
-        /* Pad with zeros. */
-        XMEMSET(keyData + pkcs8Len, 0, len - pkcs8Len);
-
-        /* Encrypt key and padding. */
-    #ifdef WOLFSSL_ENCRYPTED_KEYS
-        rc = wc_BufferKeyEncrypt(info, keyData, len, (byte*)password,
-            (int)passwordSz, WC_MD5);
-    #else
-        rc = wp_BufferKeyEncrypt(info, keyData, len, (byte*)password,
-            (int)passwordSz, WC_MD5);
-    #endif
-        if (rc != 0) {
-            WOLFPROV_MSG_DEBUG_RETCODE(WP_LOG_LEVEL_DEBUG, "BufferKeyEncrypt", rc);
-            ok = 0;
-        }
-    }
-    if (ok && (cipherInfo != NULL)) {
-        /* cipher name | ',' | hex encoded IV */
-        cipherInfoSz = (word32)(XSTRLEN(info->name) + 2 + info->ivSz * 2);
-        *cipherInfo = (byte*)OPENSSL_malloc(cipherInfoSz);
-        if (*cipherInfo == NULL) {
-            ok = 0;
-        }
-    }
-    if (ok && (cipherInfo != NULL)) {
-        word32 idx = (word32)XSTRLEN(info->name);
-        XSTRNCPY((char*)*cipherInfo, info->name, cipherInfoSz);
-        cipherInfoSz -= idx;
-        XSTRNCAT((char*)*cipherInfo, ",", cipherInfoSz);
-        cipherInfoSz--;
-        rc = Base16_Encode(info->iv, info->ivSz, *cipherInfo + idx,
-            &cipherInfoSz);
-        if (rc != 0) {
-            WOLFPROV_MSG_DEBUG_RETCODE(WP_LOG_LEVEL_DEBUG, "Base16_Encode", rc);
-            ok = 0;
-        }
-    }
-    if (ok) {
-        *keyLen = len;
     }
 
-    OPENSSL_cleanse(password, sizeof(password));
-
-    WOLFPROV_LEAVE(WP_LOG_COMP_PROVIDER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    WOLFPROV_LEAVE(WP_LOG_COMP_PROVIDER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__),
+        ok);
     return ok;
 #else
     (void)provCtx;
-    (void)cipherName;
-    (void)keyData;
-    (void)keyLen;
-    (void)pkcs8Len;
+    (void)cipher;
+    (void)plainLen;
+    (void)outLen;
+    return 0;
+#endif
+}
+
+/**
+ * Encrypt a plaintext PKCS #8 key into a PBES2 EncryptedPrivateKeyInfo.
+ *
+ * Derives the key with PBKDF2 and encrypts with the requested cipher, producing
+ * a standards-compliant EncryptedPrivateKeyInfo structure. The plaintext and
+ * output buffers must be different (wolfSSL requirement).
+ *
+ * @param [in]      provCtx   Provider context (supplies the RNG).
+ * @param [in]      cipher    wolfCrypt cipher identifier to encrypt with.
+ * @param [in]      plain     Plaintext PKCS #8 key.
+ * @param [in]      plainLen  Length of the plaintext key in bytes.
+ * @param [out]     out       Buffer to hold the encrypted encoding.
+ * @param [in, out] outLen    On in, size of buffer; on out, length written.
+ * @param [in]      pwCb      Password callback.
+ * @param [in]      pwCbArg   Argument to pass to the password callback.
+ * @return  1 on success.
+ * @return  0 on failure.
+ */
+int wp_encrypt_key_pkcs8(WOLFPROV_CTX* provCtx, int cipher,
+    const unsigned char* plain, word32 plainLen,
+    unsigned char* out, size_t* outLen,
+    OSSL_PASSPHRASE_CALLBACK* pwCb, void* pwCbArg)
+{
+#if defined(HAVE_PKCS8) && !defined(NO_PWDBASED)
+    int ok = 1;
+    int rc = 0;
+    word32 outSz = (word32)*outLen;
+    byte salt[WP_EPKI_SALT_LEN];
+#ifdef WOLFSSL_SMALL_STACK
+    char* password = NULL;
+#else
+    char password[WP_EPKI_PASSWORD_MAX];
+#endif
+    size_t passwordSz = WP_EPKI_PASSWORD_MAX;
+    WC_RNG* rng = wp_provctx_get_rng(provCtx);
+
+    WOLFPROV_ENTER(WP_LOG_COMP_PROVIDER, "wp_encrypt_key_pkcs8");
+
+#ifdef WOLFSSL_SMALL_STACK
+    password = (char*)XMALLOC(WP_EPKI_PASSWORD_MAX, NULL,
+        DYNAMIC_TYPE_TMP_BUFFER);
+    if (password == NULL) {
+        ok = 0;
+    }
+#endif
+
+    /* A cipher must be selected and the in/out buffers must differ. */
+    if (ok && ((cipher == 0) || (plain == NULL) || (out == NULL) ||
+            (plain == out))) {
+        ok = 0;
+    }
+    /* Get the password from the callback. */
+    if (ok && (!pwCb(password, passwordSz, &passwordSz, NULL, pwCbArg))) {
+        ok = 0;
+    }
+    /* Callback reports the length written - reject one past the buffer. */
+    if (ok && (passwordSz > WP_EPKI_PASSWORD_MAX)) {
+        ok = 0;
+    }
+    if (ok) {
+    #ifndef WP_SINGLE_THREADED
+        wp_provctx_lock_rng(provCtx);
+    #endif
+        /* Generate the PBKDF2 salt. */
+        rc = wc_RNG_GenerateBlock(rng, salt, sizeof(salt));
+        if (rc == 0) {
+            /* Encrypt into the separate output buffer as PBES2. The _ex form
+             * (wolfSSL 5.8.2+) selects the HMAC-SHA256 PBKDF2 PRF; older
+             * wolfSSL uses the SHA-1 PRF. */
+        #if LIBWOLFSSL_VERSION_HEX >= 0x05008002
+            rc = wc_EncryptPKCS8Key_ex((byte*)plain, plainLen, out, &outSz,
+                password, (int)passwordSz, WP_PKCS5, WP_PBES2, cipher,
+                salt, sizeof(salt), WP_PKCS12_ITERATIONS_DEFAULT,
+                HMAC_SHA256_OID, rng, NULL);
+        #else
+            rc = wc_EncryptPKCS8Key((byte*)plain, plainLen, out, &outSz,
+                password, (int)passwordSz, WP_PKCS5, WP_PBES2, cipher,
+                salt, sizeof(salt), WP_PKCS12_ITERATIONS_DEFAULT, rng, NULL);
+        #endif
+        }
+    #ifndef WP_SINGLE_THREADED
+        wp_provctx_unlock_rng(provCtx);
+    #endif
+        if (rc <= 0) {
+            WOLFPROV_MSG_DEBUG_RETCODE(WP_LOG_LEVEL_DEBUG, "wc_EncryptPKCS8Key",
+                rc);
+            ok = 0;
+        }
+        else {
+            *outLen = (size_t)outSz;
+        }
+    }
+
+    /* Password is sensitive - force zeroization. */
+#ifdef WOLFSSL_SMALL_STACK
+    if (password != NULL) {
+        OPENSSL_cleanse(password, WP_EPKI_PASSWORD_MAX);
+        XFREE(password, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    }
+#else
+    OPENSSL_cleanse(password, sizeof(password));
+#endif
+
+    WOLFPROV_LEAVE(WP_LOG_COMP_PROVIDER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__),
+        ok);
+    return ok;
+#else
+    (void)provCtx;
+    (void)cipher;
+    (void)plain;
+    (void)plainLen;
+    (void)out;
+    (void)outLen;
     (void)pwCb;
     (void)pwCbArg;
-    (void)cipherInfo;
+    return 0;
+#endif
+}
+
+#if defined(HAVE_PKCS8) && !defined(NO_PWDBASED)
+/* DER encoding of the PBKDF2 OID (1.2.840.113549.1.5.12). */
+static const unsigned char wp_pbkdf2_oid[] = {
+    42, 134, 72, 134, 247, 13, 1, 5, 12
+};
+
+/*
+ * Detect whether a DER blob is a PBES2-encrypted PKCS#8 key by looking for the
+ * PBKDF2 OID near the start of the encryptionAlgorithm field. Avoids prompting
+ * for a passphrase on data that is not an encrypted key.
+ */
+static int wp_is_pbkdf2_encrypted(const unsigned char* data, word32 len)
+{
+    int found = 0;
+    word32 i;
+
+    for (i = 0; (i < 40) && (i + sizeof(wp_pbkdf2_oid) <= len); i++) {
+        if (XMEMCMP(data + i, wp_pbkdf2_oid, sizeof(wp_pbkdf2_oid)) == 0) {
+            found = 1;
+            break;
+        }
+    }
+
+    return found;
+}
+#endif
+
+/**
+ * Decrypt a PBES2 EncryptedPrivateKeyInfo to plaintext PKCS#8 in place, getting
+ * the passphrase from the callback. Returns 0 without prompting when the data
+ * is not a PBES2-encrypted key.
+ *
+ * @param [in, out] data     On in, encrypted key; on out, plaintext PKCS#8.
+ * @param [in, out] len      On in, encrypted length; on out, plaintext length.
+ * @param [in]      pwCb     Password callback.
+ * @param [in]      pwCbArg  Argument to pass to the password callback.
+ * @return  1 on success.
+ * @return  0 on failure or when the data is not an encrypted PKCS#8 key.
+ */
+int wp_decrypt_key_pkcs8(unsigned char* data, word32* len,
+    OSSL_PASSPHRASE_CALLBACK* pwCb, void* pwCbArg)
+{
+#if defined(HAVE_PKCS8) && !defined(NO_PWDBASED)
+    int ok = 1;
+    int rc;
+#ifdef WOLFSSL_SMALL_STACK
+    char* password = NULL;
+#else
+    char password[WP_EPKI_PASSWORD_MAX];
+#endif
+    size_t passwordSz = WP_EPKI_PASSWORD_MAX;
+
+    WOLFPROV_ENTER(WP_LOG_COMP_PROVIDER, "wp_decrypt_key_pkcs8");
+
+    /* Only handle data that looks like a PBES2-encrypted PKCS#8 key. */
+    if ((data == NULL) || (!wp_is_pbkdf2_encrypted(data, *len))) {
+        ok = 0;
+    }
+#ifdef WOLFSSL_SMALL_STACK
+    if (ok) {
+        password = (char*)XMALLOC(WP_EPKI_PASSWORD_MAX, NULL,
+            DYNAMIC_TYPE_TMP_BUFFER);
+        if (password == NULL) {
+            ok = 0;
+        }
+    }
+#endif
+    /* Get the password from the callback. */
+    if (ok && (!pwCb(password, passwordSz, &passwordSz, NULL, pwCbArg))) {
+        ok = 0;
+    }
+    /* Callback reports the length written - reject one past the buffer. */
+    if (ok && (passwordSz > WP_EPKI_PASSWORD_MAX)) {
+        ok = 0;
+    }
+    if (ok) {
+        /* Decrypt the key in place. */
+        rc = wc_DecryptPKCS8Key(data, *len, password, (int)passwordSz);
+        if (rc <= 0) {
+            WOLFPROV_MSG_DEBUG_RETCODE(WP_LOG_LEVEL_DEBUG, "wc_DecryptPKCS8Key",
+                rc);
+            ok = 0;
+        }
+        else {
+            *len = (word32)rc;
+        }
+    }
+
+    /* Password is sensitive - force zeroization. */
+#ifdef WOLFSSL_SMALL_STACK
+    if (password != NULL) {
+        OPENSSL_cleanse(password, WP_EPKI_PASSWORD_MAX);
+        XFREE(password, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    }
+#else
+    OPENSSL_cleanse(password, sizeof(password));
+#endif
+
+    WOLFPROV_LEAVE(WP_LOG_COMP_PROVIDER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__),
+        ok);
+    return ok;
+#else
+    (void)data;
+    (void)len;
+    (void)pwCb;
+    (void)pwCbArg;
     return 0;
 #endif
 }

--- a/src/wp_mldsa_kmgmt.c
+++ b/src/wp_mldsa_kmgmt.c
@@ -1356,6 +1356,46 @@ static int wp_mldsa_dec_send_params(wp_MlDsa* mldsa, const char* dataType,
     return ok;
 }
 
+#ifdef WOLFSSL_ENCRYPTED_KEYS
+/**
+ * Decode an encrypted PKCS#8 DER ML-DSA private key into the ML-DSA key object.
+ *
+ * @param [in]      ctx      ML-DSA encoder/decoder context object.
+ * @param [in, out] mldsa    ML-DSA key object.
+ * @param [in]      data     DER encoding (decrypted in place).
+ * @param [in]      len      Length, in bytes, of DER encoding.
+ * @param [in]      pwCb     Password callback.
+ * @param [in]      pwCbArg  Argument to pass to password callback.
+ * @return  1 on success.
+ * @return  0 on failure.
+ */
+static int wp_mldsa_decode_enc_pki(wp_MlDsaEncDecCtx* ctx, wp_MlDsa* mldsa,
+    unsigned char* data, word32 len, OSSL_PASSPHRASE_CALLBACK* pwCb,
+    void* pwCbArg)
+{
+    int ok = 1;
+    word32 idx = 0;
+
+    WOLFPROV_ENTER_SILENT(WP_LOG_COMP_PQC, WOLFPROV_FUNC_NAME);
+
+    if (!wolfssl_prov_is_running()) {
+        ok = 0;
+    }
+    /* Decrypt the PBES2 EncryptedPrivateKeyInfo in place. */
+    if (ok && (!wp_decrypt_key_pkcs8(data, &len, pwCb, pwCbArg))) {
+        ok = 0;
+    }
+    /* Decode the recovered plaintext private key. */
+    if (ok && (ctx->decode(data, &idx, (void*)&mldsa->key, len) != 0)) {
+        ok = 0;
+    }
+
+    WOLFPROV_LEAVE_SILENT(WP_LOG_COMP_PQC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__),
+        ok);
+    return ok;
+}
+#endif
+
 /**
  * Decode the data in the core BIO.
  *
@@ -1407,9 +1447,17 @@ static int wp_mldsa_decode(wp_MlDsaEncDecCtx* ctx, OSSL_CORE_BIO* cBio,
     if (ok) {
         rc = ctx->decode(data, &idx, (void*)&mldsa->key, len);
         if (rc != 0) {
-            WOLFPROV_MSG_DEBUG_RETCODE(WP_LOG_LEVEL_DEBUG, "decode", rc);
-            ok = 0;
-            decoded = 0;
+#ifdef WOLFSSL_ENCRYPTED_KEYS
+            /* May be an encrypted PKCS#8 key - decrypt and retry. */
+            if ((ctx->format != WP_ENC_FORMAT_PKI) ||
+                    (!wp_mldsa_decode_enc_pki(ctx, mldsa, data, len, pwCb,
+                        pwCbArg)))
+#endif
+            {
+                WOLFPROV_MSG_DEBUG_RETCODE(WP_LOG_LEVEL_DEBUG, "decode", rc);
+                ok = 0;
+                decoded = 0;
+            }
         }
     }
     if (ok && (ctx->format == WP_ENC_FORMAT_SPKI)) {
@@ -1468,13 +1516,16 @@ static int wp_mldsa_encode(wp_MlDsaEncDecCtx* ctx, OSSL_CORE_BIO* cBio,
     unsigned char* derData = NULL;
     word32 derAllocLen = 0;
     size_t derLen = 0;
+    unsigned char* encData = NULL;
+    size_t encLen = 0;
+    unsigned char* srcData;
+    size_t srcLen;
     unsigned char* pemData = NULL;
     size_t pemLen = 0;
     int pemType = (ctx->format == WP_ENC_FORMAT_SPKI) ? PUBLICKEY_TYPE :
                                                         PKCS8_PRIVATEKEY_TYPE;
     int private = (ctx->format == WP_ENC_FORMAT_PKI) ||
                   (ctx->format == WP_ENC_FORMAT_EPKI);
-    byte* cipherInfo = NULL;
 
     WOLFPROV_ENTER(WP_LOG_COMP_PQC, "wp_mldsa_encode");
 
@@ -1494,15 +1545,9 @@ static int wp_mldsa_encode(wp_MlDsaEncDecCtx* ctx, OSSL_CORE_BIO* cBio,
             ok = 0;
         }
         else {
-            derAllocLen = (word32)rc;
-            /* EPKI encrypts in place: round up to the AES block size so the
-             * buffer has room for the padded ciphertext. */
-            if (ctx->format == WP_ENC_FORMAT_EPKI) {
-                derAllocLen = ((derAllocLen + 15) / 16) * 16;
-            }
-            else {
-                derAllocLen += WP_MLDSA_DER_SLACK;
-            }
+            /* Buffer holds the plaintext PKCS #8 encoding; EPKI encrypts into
+             * a separate buffer allocated later. */
+            derAllocLen = (word32)rc + WP_MLDSA_DER_SLACK;
         }
     }
     if (ok) {
@@ -1520,23 +1565,39 @@ static int wp_mldsa_encode(wp_MlDsaEncDecCtx* ctx, OSSL_CORE_BIO* cBio,
             derLen = (size_t)rc;
         }
     }
+    /* By default the plaintext DER is the source for the output encoding. */
+    srcData = derData;
+    srcLen = derLen;
     if (ok && (ctx->format == WP_ENC_FORMAT_EPKI)) {
-        size_t encLen = derAllocLen;
-        if (!wp_encrypt_key(ctx->provCtx, ctx->cipherName, derData, &encLen,
-                (word32)derLen, pwCb, pwCbArg, &cipherInfo)) {
+        pemType = PKCS8_ENC_PRIVATEKEY_TYPE;
+        /* The PBES2 output is larger than the plaintext and must use a
+         * separate buffer, so size it and encrypt into fresh memory. */
+        if (!wp_encrypt_key_pkcs8_size(ctx->provCtx, ctx->cipher,
+                (word32)derLen, &encLen)) {
             ok = 0;
         }
-        else {
-            derLen = encLen;
+        if (ok) {
+            encData = (unsigned char*)OPENSSL_malloc(encLen);
+            if (encData == NULL) {
+                ok = 0;
+            }
+        }
+        if (ok && (!wp_encrypt_key_pkcs8(ctx->provCtx, ctx->cipher, derData,
+                (word32)derLen, encData, &encLen, pwCb, pwCbArg))) {
+            ok = 0;
+        }
+        if (ok) {
+            srcData = encData;
+            srcLen = encLen;
         }
     }
 
     if (ok && (ctx->encoding == WP_FORMAT_DER)) {
-        keyData = derData;
-        keyLen = derLen;
+        keyData = srcData;
+        keyLen = srcLen;
     }
     else if (ok && (ctx->encoding == WP_FORMAT_PEM)) {
-        rc = wc_DerToPemEx(derData, (word32)derLen, NULL, 0, cipherInfo,
+        rc = wc_DerToPemEx(srcData, (word32)srcLen, NULL, 0, NULL,
             pemType);
         if (rc <= 0) {
             ok = 0;
@@ -1549,8 +1610,8 @@ static int wp_mldsa_encode(wp_MlDsaEncDecCtx* ctx, OSSL_CORE_BIO* cBio,
             }
         }
         if (ok) {
-            rc = wc_DerToPemEx(derData, (word32)derLen, pemData, (word32)pemLen,
-                cipherInfo, pemType);
+            rc = wc_DerToPemEx(srcData, (word32)srcLen, pemData, (word32)pemLen,
+                NULL, pemType);
             if (rc <= 0) {
                 ok = 0;
             }
@@ -1577,7 +1638,7 @@ static int wp_mldsa_encode(wp_MlDsaEncDecCtx* ctx, OSSL_CORE_BIO* cBio,
         OPENSSL_free(derData);
         OPENSSL_free(pemData);
     }
-    OPENSSL_free(cipherInfo);
+    OPENSSL_clear_free(encData, encLen);
     BIO_free(out);
     WOLFPROV_LEAVE(WP_LOG_COMP_PQC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;

--- a/src/wp_rsa_kmgmt.c
+++ b/src/wp_rsa_kmgmt.c
@@ -2707,41 +2707,6 @@ static int wp_rsa_decode_pki(wp_Rsa* rsa, unsigned char* data, word32 len)
 
 #ifdef WOLFSSL_ENCRYPTED_KEYS
 
-/** PBKDF2 OPID. */
-unsigned char pbkdf2_oid[] = {
-    42, 134, 72, 134, 247, 13, 1, 5, 12
-};
-/** Size of PBKDF2 OID. */
-#define PBKDF2_OID_SZ    sizeof(pbkdf2_oid)
-
-/**
- * Find the PBKDF2 OID in the key and set type.
- *
- * @param [in]      data  DER encoding.
- * @param [in]      len   Length, in bytes, of DER encoding.
- * @return  1 on success.
- * @return  0 on failure.
- */
-static int wp_rsa_find_pbkdf2_oid(unsigned char* data, word32 len)
-{
-    int ok = 0;
-    word32 i;
-
-    WOLFPROV_ENTER_SILENT(WP_LOG_COMP_RSA, WOLFPROV_FUNC_NAME);
-
-    for (i = 0; i < 40 && i + PBKDF2_OID_SZ < len; i++) {
-        /* Find the base OID. */
-        if (XMEMCMP(data + i, pbkdf2_oid, PBKDF2_OID_SZ) == 0) {
-            ok = 1;
-            break;
-        }
-    }
-
-    WOLFPROV_LEAVE_SILENT(WP_LOG_COMP_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__),
-        ok);
-    return ok;
-}
-
 /**
  * Decode the encrypted DER encoded RSA private key into the RSA key object.
  *
@@ -2757,43 +2722,20 @@ static int wp_rsa_decode_enc_pki(wp_Rsa* rsa, unsigned char* data, word32 len,
      OSSL_PASSPHRASE_CALLBACK* pwCb, void* pwCbArg)
 {
     int ok = 1;
-    char password[1024];
-    size_t passwordSz = sizeof(password);
 
     WOLFPROV_ENTER_SILENT(WP_LOG_COMP_RSA, WOLFPROV_FUNC_NAME);
 
     if (!wolfssl_prov_is_running()) {
         ok = 0;
     }
-
-    /* Look for the PBKDF2 OID to know we have an encrypted key. */
-    if (ok && !wp_rsa_find_pbkdf2_oid(data, len)) {
-        ok = 0;
-    }
-    /* Get password for decryption. */
-    if (ok && !pwCb(password, passwordSz, &passwordSz, NULL, pwCbArg)) {
-        ok = 0;
-    }
-    if (ok && (passwordSz > sizeof(password))) {
+    /* Decrypt the PBES2 EncryptedPrivateKeyInfo in place. */
+    if (ok && (!wp_decrypt_key_pkcs8(data, &len, pwCb, pwCbArg))) {
         ok = 0;
     }
     if (ok) {
-        /* Decrypt to encoded private key. */
-        int ret = wc_DecryptPKCS8Key(data, len, password, (int)passwordSz);
-        if (ret <= 0) {
-            ok = 0;
-        }
-        else {
-            /* Get length of encoded private key. */
-            len = (word32)ret;
-        }
-    }
-    if (ok) {
-        /* Decode private key. */
+        /* Decode the recovered plaintext private key. */
         ok = wp_rsa_decode_pki(rsa, data, len);
     }
-
-    OPENSSL_cleanse(password, sizeof(password));
 
     WOLFPROV_LEAVE_SILENT(WP_LOG_COMP_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__),
         ok);
@@ -3501,26 +3443,15 @@ static int wp_rsa_encode_enc_pki_size(const wp_RsaEncDecCtx* ctx,
 {
     int ok;
     size_t len;
-    word32 outSz;
-    byte fakeData[1];
-    byte fakeSalt[16];
 
     WOLFPROV_ENTER(WP_LOG_COMP_RSA, "wp_rsa_encode_enc_pki_size");
 
-    /* Get encode private key length. */
+    /* Get the plaintext PKCS #8 encoding length. */
     ok = wp_rsa_encode_pki_size(rsa, &len, RSA_ALGO_ID(ctx));
     if (ok) {
-        /* Get encrypted encode private key. */
-        if (wc_EncryptPKCS8Key(fakeData, (word32)len, NULL, &outSz, "", 0,
-                WP_PKCS5, WP_PBES2, ctx->cipher, fakeSalt, sizeof(fakeSalt),
-                WP_PKCS12_ITERATIONS_DEFAULT, wp_provctx_get_rng(ctx->provCtx),
-                NULL) != LENGTH_ONLY_E) {
-            ok = 0;
-        }
-        else {
-            /* Return the length calculated. */
-            *keyLen = (size_t)outSz;
-        }
+        /* Get the size of the PBES2 EncryptedPrivateKeyInfo encoding. */
+        ok = wp_encrypt_key_pkcs8_size(ctx->provCtx, ctx->cipher, (word32)len,
+            keyLen);
     }
 
     WOLFPROV_LEAVE(WP_LOG_COMP_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
@@ -3528,7 +3459,7 @@ static int wp_rsa_encode_enc_pki_size(const wp_RsaEncDecCtx* ctx,
 }
 
 /**
- * Encode the RSA key in a Encrypted Private Key format.
+ * Encode the RSA key in a PBES2 EncryptedPrivateKeyInfo format.
  *
  * @param [in]      ctx      RSA encoder/decoder context object.
  * @param [in]      rsa      RSA key object.
@@ -3546,51 +3477,27 @@ static int wp_rsa_encode_enc_pki(const wp_RsaEncDecCtx* ctx, const wp_Rsa* rsa,
 {
     int ok = 1;
     size_t len;
-    word32 outSz = (word32)*keyLen;
-    byte salt[WP_MAX_SALT_SIZE];
-    int saltLen = 16;
-    char password[1024];
-    size_t passwordSz = sizeof(password);
     byte* encodedKey = NULL;
 
     WOLFPROV_ENTER(WP_LOG_COMP_RSA, "wp_rsa_encode_enc_pki");
 
-    /* TODO: support salt length of 8 for DES3. */
-
-    /* Encode key. */
+    /* Determine the plaintext PKCS #8 length. */
     ok = wp_rsa_encode_pki_size(rsa, &len, RSA_ALGO_ID(ctx));
     if (ok) {
-        /* Allocate buffer for encrypted key to be placed into. */
+        /* Allocate the plaintext buffer - must differ from the output. */
         encodedKey = XMALLOC(len, NULL, DYNAMIC_TYPE_RSA_BUFFER);
         if (encodedKey == NULL) {
             ok = 0;
         }
     }
     if (ok) {
-        /* Encode key. */
+        /* Encode the plaintext PKCS #8 key. */
         ok = wp_rsa_encode_pki(rsa, encodedKey, &len, RSA_ALGO_ID(ctx));
     }
-    /* Generate salt. */
-    if (ok && (wc_RNG_GenerateBlock(wp_provctx_get_rng(ctx->provCtx), salt,
-            saltLen) != 0)) {
-        ok = 0;
-    }
-    /* Get password. */
-    if (ok && !pwCb(password, passwordSz, &passwordSz, NULL, pwCbArg)) {
-        ok = 0;
-    }
     if (ok) {
-        /* Encrypt encoded key - in and out buffers must be different. */
-        if (wc_EncryptPKCS8Key(encodedKey, (word32)len, keyData, &outSz,
-                password, (word32)passwordSz, WP_PKCS5, WP_PBES2, ctx->cipher,
-                salt, saltLen, WP_PKCS12_ITERATIONS_DEFAULT,
-                wp_provctx_get_rng(ctx->provCtx), NULL) <= 0) {
-            ok = 0;
-        }
-        else {
-            /* Return actual size of encrypted encoded private key. */
-            *keyLen = (size_t)outSz;
-        }
+        /* Encrypt as a PBES2 EncryptedPrivateKeyInfo. */
+        ok = wp_encrypt_key_pkcs8(ctx->provCtx, ctx->cipher, encodedKey,
+            (word32)len, keyData, keyLen, pwCb, pwCbArg);
     }
 
     /* encodedKey holds the plaintext PKCS#8 private key before encryption. */
@@ -3598,67 +3505,6 @@ static int wp_rsa_encode_enc_pki(const wp_RsaEncDecCtx* ctx, const wp_Rsa* rsa,
         OPENSSL_cleanse(encodedKey, len);
     }
     XFREE(encodedKey, NULL, DYNAMIC_TYPE_RSA_BUFFER);
-
-    OPENSSL_cleanse(password, sizeof(password));
-
-    WOLFPROV_LEAVE(WP_LOG_COMP_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
-    return ok;
-}
-
-/**
- * Get the Encrypted PKCS#8 encoding size for the key.
- *
- * @param [in]  rsa     RSA key object.
- * @param [out] keyLen  Length of encoding in bytes.
- * @return  1 on success.
- * @return  0 on failure.
- */
-static int wp_rsa_encode_epki_size(const wp_RsaEncDecCtx* ctx,
-    const wp_Rsa* rsa, size_t* keyLen)
-{
-    int ok;
-    size_t len;
-
-    WOLFPROV_ENTER(WP_LOG_COMP_RSA, "wp_rsa_encode_epki_size");
-
-    ok = wp_rsa_encode_pki_size(rsa, &len, RSA_ALGO_ID(ctx));
-    if (ok) {
-        *keyLen = ((len + 15) / 16) * 16;
-    }
-
-    WOLFPROV_LEAVE(WP_LOG_COMP_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
-    return ok;
-}
-
-/**
- * Encode the RSA key in an Encrypted PKCS#8 format.
- *
- * @param [in]      ctx         RSA encoder/decoder context object.
- * @param [in]      rsa         RSA key object.
- * @param [out]     keyData     Buffer to hold encoded data.
- * @param [in, out] keyLen      On in, length of buffer in bytes.
- *                              On out, length of encoding in bytes.
- * @param [in]      pwCb        Password callback.
- * @param [in]      pwCbArg     Argument to pass to password callback.
- * @param [out]     cipherInfo  Information about encryption.
- * @return  1 on success.
- * @return  0 on failure.
- */
-static int wp_rsa_encode_epki(const wp_RsaEncDecCtx* ctx, const wp_Rsa* rsa,
-    unsigned char* keyData, size_t* keyLen, OSSL_PASSPHRASE_CALLBACK* pwCb,
-    void* pwCbArg, byte** cipherInfo)
-{
-    int ok = 1;
-    size_t len = *keyLen;
-
-    WOLFPROV_ENTER(WP_LOG_COMP_RSA, "wp_rsa_encode_epki");
-
-    /* Encode key. */
-    ok = wp_rsa_encode_pki(rsa, keyData, &len, RSA_ALGO_ID(ctx));
-    if (ok && (!wp_encrypt_key(ctx->provCtx, ctx->cipherName, keyData, keyLen,
-            (word32)len, pwCb, pwCbArg, cipherInfo))) {
-        ok = 0;
-    }
 
     WOLFPROV_LEAVE(WP_LOG_COMP_RSA, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
@@ -3699,7 +3545,6 @@ static int wp_rsa_encode(wp_RsaEncDecCtx* ctx, OSSL_CORE_BIO* cBio,
     size_t pemLen = 0;
     int pemType = PKCS8_PRIVATEKEY_TYPE;
     int private = 0;
-    byte* cipherInfo = NULL;
 
     (void)params;
     (void)selection;
@@ -3728,7 +3573,7 @@ static int wp_rsa_encode(wp_RsaEncDecCtx* ctx, OSSL_CORE_BIO* cBio,
     }
 #ifdef WOLFSSL_ENCRYPTED_KEYS
     else if (ok && (ctx->format == WP_ENC_FORMAT_EPKI)) {
-        if (!wp_rsa_encode_epki_size(ctx, key, &derLen)) {
+        if (!wp_rsa_encode_enc_pki_size(ctx, key, &derLen)) {
             ok = 0;
         }
     }
@@ -3776,8 +3621,8 @@ static int wp_rsa_encode(wp_RsaEncDecCtx* ctx, OSSL_CORE_BIO* cBio,
 #ifdef WOLFSSL_ENCRYPTED_KEYS
     else if (ok && (ctx->format == WP_ENC_FORMAT_EPKI)) {
         private = 1;
-        if (!wp_rsa_encode_epki(ctx, key, derData, &derLen, pwCb, pwCbArg,
-                (ctx->encoding == WP_FORMAT_PEM) ? &cipherInfo : NULL)) {
+        pemType = PKCS8_ENC_PRIVATEKEY_TYPE;
+        if (!wp_rsa_encode_enc_pki(ctx, key, derData, &derLen, pwCb, pwCbArg)) {
             ok = 0;
         }
     }
@@ -3802,7 +3647,7 @@ static int wp_rsa_encode(wp_RsaEncDecCtx* ctx, OSSL_CORE_BIO* cBio,
         keyLen = derLen;
     }
     else if (ok && (ctx->encoding == WP_FORMAT_PEM)) {
-        rc = wc_DerToPemEx(derData, (word32)derLen, NULL, 0, cipherInfo,
+        rc = wc_DerToPemEx(derData, (word32)derLen, NULL, 0, NULL,
             pemType);
         if (rc <= 0) {
             ok = 0;

--- a/test/test_dh.c
+++ b/test/test_dh.c
@@ -360,6 +360,47 @@ int test_dh_pkey(void *data)
     return err;
 }
 
+#if defined(WOLFSSL_DH_EXTRA) && defined(WP_HAVE_EPKI_TEST)
+int test_dh_encode_epki(void *data)
+{
+    int err = 0;
+    const unsigned char* p = dh_der;
+    EVP_PKEY* pkey = NULL;
+
+    (void)data;
+
+    /* Load a DH key into a wolfProvider-backed EVP_PKEY. */
+    pkey = d2i_PrivateKey_ex(EVP_PKEY_DH, NULL, &p, sizeof(dh_der), wpLibCtx,
+        NULL);
+    err = (pkey == NULL);
+
+    if (err == 0) {
+        PRINT_MSG("EncryptedPrivateKeyInfo DER: wolfProvider -> OpenSSL");
+        err = test_epki_encode_decode(pkey, "DER", "provider=libwolfprov",
+            osslLibCtx);
+    }
+    if (err == 0) {
+        PRINT_MSG("EncryptedPrivateKeyInfo DER: wolfProvider -> wolfProvider");
+        err = test_epki_encode_decode(pkey, "DER", "provider=libwolfprov",
+            wpLibCtx);
+    }
+    if (err == 0) {
+        PRINT_MSG("EncryptedPrivateKeyInfo PEM: wolfProvider -> OpenSSL");
+        err = test_epki_encode_decode(pkey, "PEM", "provider=libwolfprov",
+            osslLibCtx);
+    }
+    if (err == 0) {
+        PRINT_MSG("EncryptedPrivateKeyInfo PEM: wolfProvider -> wolfProvider");
+        err = test_epki_encode_decode(pkey, "PEM", "provider=libwolfprov",
+            wpLibCtx);
+    }
+
+    EVP_PKEY_free(pkey);
+
+    return err;
+}
+#endif /* WOLFSSL_DH_EXTRA && WP_HAVE_EPKI_TEST */
+
 int test_dh_invalid_kdf_strings(void *data)
 {
     int err = 0;

--- a/test/test_ecc.c
+++ b/test/test_ecc.c
@@ -860,6 +860,67 @@ static int test_ecdh(const unsigned char *privKey, size_t len,
 }
 
 #ifdef WP_HAVE_EC_P256
+#ifdef WP_HAVE_EPKI_TEST
+int test_ecc_encode_epki(void *data)
+{
+    int err = 0;
+    const unsigned char* p = ecc_key_der_256;
+    const unsigned char* op = ecc_key_der_256;
+    EVP_PKEY* pkey = NULL;
+    EVP_PKEY* osslKey = NULL;
+
+    (void)data;
+
+    /* Load a P-256 key into a wolfProvider-backed EVP_PKEY. */
+    pkey = d2i_PrivateKey_ex(EVP_PKEY_EC, NULL, &p, sizeof(ecc_key_der_256),
+        wpLibCtx, NULL);
+    err = (pkey == NULL);
+
+    if (err == 0) {
+        PRINT_MSG("EncryptedPrivateKeyInfo DER: wolfProvider -> OpenSSL");
+        err = test_epki_encode_decode(pkey, "DER", "provider=libwolfprov",
+            osslLibCtx);
+    }
+    if (err == 0) {
+        PRINT_MSG("EncryptedPrivateKeyInfo DER: wolfProvider -> wolfProvider");
+        err = test_epki_encode_decode(pkey, "DER", "provider=libwolfprov",
+            wpLibCtx);
+    }
+    if (err == 0) {
+        PRINT_MSG("EncryptedPrivateKeyInfo PEM: wolfProvider -> OpenSSL");
+        err = test_epki_encode_decode(pkey, "PEM", "provider=libwolfprov",
+            osslLibCtx);
+    }
+    if (err == 0) {
+        PRINT_MSG("EncryptedPrivateKeyInfo PEM: wolfProvider -> wolfProvider");
+        err = test_epki_encode_decode(pkey, "PEM", "provider=libwolfprov",
+            wpLibCtx);
+    }
+
+    /* Decode an OpenSSL-produced blob (foreign PBES2 params). */
+    if (err == 0) {
+        osslKey = d2i_PrivateKey_ex(EVP_PKEY_EC, NULL, &op,
+            sizeof(ecc_key_der_256), osslLibCtx, NULL);
+        err = (osslKey == NULL);
+    }
+    if (err == 0) {
+        PRINT_MSG("EncryptedPrivateKeyInfo DER: OpenSSL -> wolfProvider");
+        err = test_epki_encode_decode(osslKey, "DER", "provider=default",
+            wpLibCtx);
+    }
+    if (err == 0) {
+        PRINT_MSG("EncryptedPrivateKeyInfo PEM: OpenSSL -> wolfProvider");
+        err = test_epki_encode_decode(osslKey, "PEM", "provider=default",
+            wpLibCtx);
+    }
+
+    EVP_PKEY_free(osslKey);
+    EVP_PKEY_free(pkey);
+
+    return err;
+}
+#endif /* WP_HAVE_EPKI_TEST */
+
 int test_ecdh_invalid_kdf_strings(void *data)
 {
     int err = 0;

--- a/test/test_ecx.c
+++ b/test/test_ecx.c
@@ -135,6 +135,40 @@ static int sign_verify(unsigned char* sig, size_t sigLen,
     return err;
 }
 
+#if defined(WP_HAVE_ED25519) && defined(WP_HAVE_EPKI_TEST)
+int test_ecx_encode_epki(void *data)
+{
+    int err = 0;
+    const unsigned char* p = ed25519_key_der;
+    EVP_PKEY* pkey = NULL;
+
+    (void)data;
+
+    /* Load an Ed25519 key into a wolfProvider-backed EVP_PKEY. */
+    pkey = d2i_PrivateKey_ex(EVP_PKEY_ED25519, NULL, &p, sizeof(ed25519_key_der),
+        wpLibCtx, NULL);
+    err = (pkey == NULL);
+
+    /* wolfProvider self round-trip (DER and PEM). ECX plaintext PKCS#8 is
+     * block-aligned, so wolfProvider -> OpenSSL interop additionally depends on
+     * a wolfSSL PKCS#7 padding fix and is not asserted here. */
+    if (err == 0) {
+        PRINT_MSG("EncryptedPrivateKeyInfo DER: wolfProvider -> wolfProvider");
+        err = test_epki_encode_decode(pkey, "DER", "provider=libwolfprov",
+            wpLibCtx);
+    }
+    if (err == 0) {
+        PRINT_MSG("EncryptedPrivateKeyInfo PEM: wolfProvider -> wolfProvider");
+        err = test_epki_encode_decode(pkey, "PEM", "provider=libwolfprov",
+            wpLibCtx);
+    }
+
+    EVP_PKEY_free(pkey);
+
+    return err;
+}
+#endif /* WP_HAVE_ED25519 && WP_HAVE_EPKI_TEST */
+
 int test_ecx_sign_verify(void *data)
 {
     int err = 0;

--- a/test/test_mldsa.c
+++ b/test/test_mldsa.c
@@ -1220,4 +1220,36 @@ int test_mldsa_pubonly_sign_fails(void* data)
     return err;
 }
 
+#ifdef WP_HAVE_EPKI_TEST
+int test_mldsa_encode_epki(void* data)
+{
+    int err = 0;
+    EVP_PKEY* pkey = NULL;
+
+    (void)data;
+
+    /* Generate an ML-DSA-44 key via wolfProvider. */
+    err = mldsa_keygen("ML-DSA-44", &pkey);
+
+    /* wolfProvider self round-trip (DER and PEM): the encoder output is decoded
+     * back by wolfProvider and must match. Stock-OpenSSL interop for ML-DSA
+     * encrypted keys depends on separate ML-DSA/PQC work and is not asserted
+     * here. */
+    if (err == 0) {
+        PRINT_MSG("EncryptedPrivateKeyInfo DER: wolfProvider -> wolfProvider");
+        err = test_epki_encode_decode(pkey, "DER", "provider=libwolfprov",
+            wpLibCtx);
+    }
+    if (err == 0) {
+        PRINT_MSG("EncryptedPrivateKeyInfo PEM: wolfProvider -> wolfProvider");
+        err = test_epki_encode_decode(pkey, "PEM", "provider=libwolfprov",
+            wpLibCtx);
+    }
+
+    EVP_PKEY_free(pkey);
+
+    return err;
+}
+#endif /* WP_HAVE_EPKI_TEST */
+
 #endif /* WP_HAVE_MLDSA */

--- a/test/test_pkey.c
+++ b/test/test_pkey.c
@@ -19,6 +19,9 @@
  */
 
 #include "unit.h"
+#include <openssl/encoder.h>
+#include <openssl/decoder.h>
+#include <openssl/err.h>
 
 int test_digest_sign(EVP_PKEY *pkey, OSSL_LIB_CTX* libCtx, unsigned char *data,
     size_t len, const char *md, const EVP_MD *mgf1Md, unsigned char *sig,
@@ -291,6 +294,97 @@ int test_pkey_dec(EVP_PKEY *pkey, OSSL_LIB_CTX* libCtx, unsigned char *msg,
     if (buf != NULL) {
         OPENSSL_free(buf);
     }
+
+    return err;
+}
+
+/* Encode as EncryptedPrivateKeyInfo with encProp, decode with decLibCtx and
+ * check it matches; a wrong passphrase must fail. Drives both directions. */
+int test_epki_encode_decode(EVP_PKEY* pkey, const char* fmt,
+    const char* encProp, OSSL_LIB_CTX* decLibCtx)
+{
+    int err = 0;
+    EVP_PKEY* pkey2 = NULL;
+    EVP_PKEY* badKey = NULL;
+    OSSL_ENCODER_CTX* ectx = NULL;
+    OSSL_DECODER_CTX* dctx = NULL;
+    OSSL_DECODER_CTX* bctx = NULL;
+    unsigned char* data = NULL;
+    size_t dataLen = 0;
+    size_t encLen = 0;
+    const unsigned char* pp;
+    const char* pass = "wolfprov-test-pass";
+    const char* badPass = "wrong-passphrase";
+    size_t passLen = strlen(pass);
+
+    /* Encode as EncryptedPrivateKeyInfo with the requested provider. */
+    ectx = OSSL_ENCODER_CTX_new_for_pkey(pkey, EVP_PKEY_KEYPAIR, fmt,
+        "EncryptedPrivateKeyInfo", encProp);
+    err = (ectx == NULL);
+    if (err == 0) {
+        err = OSSL_ENCODER_CTX_set_cipher(ectx, "AES-256-CBC", NULL) != 1;
+    }
+    if (err == 0) {
+        err = OSSL_ENCODER_CTX_set_passphrase(ectx, (const unsigned char*)pass,
+            passLen) != 1;
+    }
+    if (err == 0) {
+        err = OSSL_ENCODER_to_data(ectx, &data, &dataLen) != 1;
+    }
+    if (err == 0) {
+        /* Save the encoded length; OSSL_DECODER_from_data consumes it. */
+        encLen = dataLen;
+    }
+
+    /* Decode with the requested library context and the correct passphrase. */
+    if (err == 0) {
+        pp = data;
+        dctx = OSSL_DECODER_CTX_new_for_pkey(&pkey2, fmt, NULL,
+            EVP_PKEY_get0_type_name(pkey), EVP_PKEY_KEYPAIR, decLibCtx, NULL);
+        err = (dctx == NULL);
+    }
+    if (err == 0) {
+        err = OSSL_DECODER_CTX_set_passphrase(dctx, (const unsigned char*)pass,
+            passLen) != 1;
+    }
+    if (err == 0) {
+        err = OSSL_DECODER_from_data(dctx, &pp, &dataLen) != 1;
+    }
+    if (err == 0) {
+        err = (pkey2 == NULL);
+    }
+    if (err == 0) {
+        err = EVP_PKEY_eq(pkey, pkey2) != 1;
+    }
+
+    /* Negative case: a wrong passphrase must not yield a key. */
+    if (err == 0) {
+        pp = data;
+        dataLen = encLen;
+        bctx = OSSL_DECODER_CTX_new_for_pkey(&badKey, fmt, NULL,
+            EVP_PKEY_get0_type_name(pkey), EVP_PKEY_KEYPAIR, decLibCtx, NULL);
+        err = (bctx == NULL);
+    }
+    if (err == 0) {
+        err = OSSL_DECODER_CTX_set_passphrase(bctx,
+            (const unsigned char*)badPass, strlen(badPass)) != 1;
+    }
+    if (err == 0) {
+        /* Decode is expected to fail; success with a recovered key is wrong. */
+        if ((OSSL_DECODER_from_data(bctx, &pp, &dataLen) == 1) &&
+                (badKey != NULL)) {
+            err = 1;
+        }
+        /* The failed decrypt leaves an expected error on the queue. */
+        ERR_clear_error();
+    }
+
+    OSSL_DECODER_CTX_free(bctx);
+    OSSL_DECODER_CTX_free(dctx);
+    OSSL_ENCODER_CTX_free(ectx);
+    OPENSSL_free(data);
+    EVP_PKEY_free(badKey);
+    EVP_PKEY_free(pkey2);
 
     return err;
 }

--- a/test/test_rsa.c
+++ b/test/test_rsa.c
@@ -2370,6 +2370,70 @@ int test_rsa_encode_pkcs8(void* data)
     return err;
 }
 
+#ifdef WP_HAVE_EPKI_TEST
+int test_rsa_encode_epki(void* data)
+{
+    int err = 0;
+    const unsigned char* p = rsa_key_der_2048_pkcs8;
+    PKCS8_PRIV_KEY_INFO* p8 = NULL;
+    EVP_PKEY* pkey = NULL;
+    EVP_PKEY* osslKey = NULL;
+
+    (void)data;
+
+    /* Load the key into a wolfProvider-backed EVP_PKEY. */
+    p8 = d2i_PKCS8_PRIV_KEY_INFO(NULL, &p, sizeof(rsa_key_der_2048_pkcs8));
+    err = (p8 == NULL);
+    if (err == 0) {
+        pkey = EVP_PKCS82PKEY_ex(p8, wpLibCtx, NULL);
+        err = (pkey == NULL);
+    }
+
+    if (err == 0) {
+        PRINT_MSG("EncryptedPrivateKeyInfo DER: wolfProvider -> OpenSSL");
+        err = test_epki_encode_decode(pkey, "DER", "provider=libwolfprov",
+            osslLibCtx);
+    }
+    if (err == 0) {
+        PRINT_MSG("EncryptedPrivateKeyInfo DER: wolfProvider -> wolfProvider");
+        err = test_epki_encode_decode(pkey, "DER", "provider=libwolfprov",
+            wpLibCtx);
+    }
+    if (err == 0) {
+        PRINT_MSG("EncryptedPrivateKeyInfo PEM: wolfProvider -> OpenSSL");
+        err = test_epki_encode_decode(pkey, "PEM", "provider=libwolfprov",
+            osslLibCtx);
+    }
+    if (err == 0) {
+        PRINT_MSG("EncryptedPrivateKeyInfo PEM: wolfProvider -> wolfProvider");
+        err = test_epki_encode_decode(pkey, "PEM", "provider=libwolfprov",
+            wpLibCtx);
+    }
+
+    /* Decode an OpenSSL-produced blob (foreign PBES2 params). */
+    if (err == 0) {
+        osslKey = EVP_PKCS82PKEY_ex(p8, osslLibCtx, NULL);
+        err = (osslKey == NULL);
+    }
+    if (err == 0) {
+        PRINT_MSG("EncryptedPrivateKeyInfo DER: OpenSSL -> wolfProvider");
+        err = test_epki_encode_decode(osslKey, "DER", "provider=default",
+            wpLibCtx);
+    }
+    if (err == 0) {
+        PRINT_MSG("EncryptedPrivateKeyInfo PEM: OpenSSL -> wolfProvider");
+        err = test_epki_encode_decode(osslKey, "PEM", "provider=default",
+            wpLibCtx);
+    }
+
+    EVP_PKEY_free(osslKey);
+    EVP_PKEY_free(pkey);
+    PKCS8_PRIV_KEY_INFO_free(p8);
+
+    return err;
+}
+#endif /* WP_HAVE_EPKI_TEST */
+
 static int test_rsa_null_sign_init_ex(OSSL_LIB_CTX *libCtx)
 {
     int err = 0;

--- a/test/unit.c
+++ b/test/unit.c
@@ -328,6 +328,9 @@ TEST_CASE test_case[] = {
     TEST_DECL(test_dh_pgen_pkey, NULL),
     TEST_DECL(test_dh_pkey, NULL),
     TEST_DECL(test_dh_invalid_kdf_strings, NULL),
+#if defined(WOLFSSL_DH_EXTRA) && defined(WP_HAVE_EPKI_TEST)
+    TEST_DECL(test_dh_encode_epki, NULL),
+#endif
     TEST_DECL(test_dh_decode, NULL),
     TEST_DECL(test_dh_krb5_keygen, NULL),
     TEST_DECL(test_dh_pad, NULL),
@@ -366,6 +369,9 @@ TEST_CASE test_case[] = {
     TEST_DECL(test_rsa_fromdata_oversize, NULL),
     TEST_DECL(test_rsa_decode_pkcs8, NULL),
     TEST_DECL(test_rsa_encode_pkcs8, NULL),
+#ifdef WP_HAVE_EPKI_TEST
+    TEST_DECL(test_rsa_encode_epki, NULL),
+#endif
     TEST_DECL(test_rsa_null_init, NULL),
     TEST_DECL(test_rsa_param_prefix_match, NULL),
     TEST_DECL(test_rsa_kem_prefix_match, NULL),
@@ -404,6 +410,9 @@ TEST_CASE test_case[] = {
     #endif
 #endif
 #ifdef WP_HAVE_EC_P256
+    #ifdef WP_HAVE_EPKI_TEST
+        TEST_DECL(test_ecc_encode_epki, NULL),
+    #endif
     #ifdef WP_HAVE_ECKEYGEN
         TEST_DECL(test_eckeygen_p256, NULL),
     #endif
@@ -507,6 +516,9 @@ TEST_CASE test_case[] = {
 #endif
 
 #if defined(WP_HAVE_ED25519) || defined(WP_HAVE_ED448)
+#if defined(WP_HAVE_ED25519) && defined(WP_HAVE_EPKI_TEST)
+    TEST_DECL(test_ecx_encode_epki, NULL),
+#endif
     TEST_DECL(test_ecx_sign_verify, NULL),
     TEST_DECL(test_ecx_sign_verify_raw_priv, NULL),
     TEST_DECL(test_ecx_sign_verify_raw_pub, NULL),
@@ -554,6 +566,9 @@ TEST_CASE test_case[] = {
 #endif
 
 #ifdef WP_HAVE_MLDSA
+    #ifdef WP_HAVE_EPKI_TEST
+    TEST_DECL(test_mldsa_encode_epki, NULL),
+    #endif
     TEST_DECL(test_mldsa_keygen, NULL),
     TEST_DECL(test_mldsa_import_export_roundtrip, NULL),
     TEST_DECL(test_mldsa_sign_verify, NULL),

--- a/test/unit.h
+++ b/test/unit.h
@@ -50,6 +50,13 @@
     #define AES_BLOCK_SIZE 16
 #endif
 
+/* Encrypted PKCS#8 (EncryptedPrivateKeyInfo) round-trip tests require
+ * encrypted-key, PKCS#8 and PBKDF support in the linked wolfSSL. */
+#if defined(WOLFSSL_ENCRYPTED_KEYS) && defined(HAVE_PKCS8) && \
+    !defined(NO_PWDBASED)
+    #define WP_HAVE_EPKI_TEST
+#endif
+
 #ifdef TEST_MULTITHREADED
 #define PRINT_MSG(str)
 #define PRINT_ERR_MSG(str)
@@ -316,6 +323,8 @@ int test_pkey_enc_rsa(EVP_PKEY *pkey, unsigned char *msg, size_t msgLen,
 int test_pkey_dec_rsa(EVP_PKEY *pkey, unsigned char *msg, size_t msgLen,
                   unsigned char *ciphertext, size_t cipherLen, int padMode,
                   const EVP_MD *rsaMd, const EVP_MD *rsaMgf1Md);
+int test_epki_encode_decode(EVP_PKEY* pkey, const char* fmt,
+                  const char* encProp, OSSL_LIB_CTX* decLibCtx);
 int test_rsa_sign_sha1(void *data);
 int test_rsa_sign_verify_pkcs1(void *data);
 int test_rsa_sign_verify_recover_pkcs1(void *data);
@@ -338,6 +347,9 @@ int test_rsa_fromdata(void* data);
 int test_rsa_fromdata_oversize(void* data);
 int test_rsa_decode_pkcs8(void* data);
 int test_rsa_encode_pkcs8(void* data);
+#ifdef WP_HAVE_EPKI_TEST
+int test_rsa_encode_epki(void* data);
+#endif
 int test_rsa_null_init(void* data);
 int test_rsa_param_prefix_match(void* data);
 int test_rsa_kem_prefix_match(void* data);
@@ -350,6 +362,9 @@ int test_rsa_key_integrity(void* data);
 int test_dh_pgen_pkey(void *data);
 int test_dh_pkey(void *data);
 int test_dh_invalid_kdf_strings(void *data);
+#if defined(WOLFSSL_DH_EXTRA) && defined(WP_HAVE_EPKI_TEST)
+int test_dh_encode_epki(void *data);
+#endif
 int test_dh_decode(void *data);
 int test_dh_get_params(void *data);
 int test_dh_krb5_keygen(void *data);
@@ -442,6 +457,9 @@ int test_ecdh_p224(void *data);
 #endif /* WP_HAVE_EC_P224 */
 #ifdef WP_HAVE_EC_P256
 int test_ecdh_invalid_kdf_strings(void *data);
+#ifdef WP_HAVE_EPKI_TEST
+int test_ecc_encode_epki(void *data);
+#endif
 int test_ecdh_p256(void *data);
 #if defined(HAVE_X963_KDF) && defined(WP_HAVE_SHA256)
 int test_ecdh_x963_kdf(void *data);
@@ -514,6 +532,9 @@ int test_pbkdf2(void *data);
 #endif /* WP_HAVE_PBE */
 
 #if defined(WP_HAVE_ED25519) || defined(WP_HAVE_ED448)
+#if defined(WP_HAVE_ED25519) && defined(WP_HAVE_EPKI_TEST)
+int test_ecx_encode_epki(void *data);
+#endif
 int test_ecx_sign_verify(void *data);
 int test_ecx_sign_verify_raw_priv(void *data);
 int test_ecx_sign_verify_raw_pub(void *data);
@@ -563,6 +584,9 @@ int test_mlx_encap_decap(void *data);
 #endif
 
 #ifdef WP_HAVE_MLDSA
+#ifdef WP_HAVE_EPKI_TEST
+int test_mldsa_encode_epki(void *data);
+#endif
 int test_mldsa_keygen(void *data);
 int test_mldsa_import_export_roundtrip(void *data);
 int test_mldsa_sign_verify(void *data);


### PR DESCRIPTION
# Fix EncryptedPrivateKeyInfo encode + decode (PBES2) across all key types

## Summary

wolfProvider's `EncryptedPrivateKeyInfo` (encrypted PKCS#8) support was
both **weak** and **incomplete**:

1. **Encoder (finding f_4081):** the EPKI encoders derived the key with
   **MD5 / PBKDF1 / 1 iteration**, encrypted the DER in place, and emitted it
   under the *unencrypted* `-----BEGIN PRIVATE KEY-----` label. The output was
   not a valid `EncryptedPrivateKeyInfo` and could not be decoded by OpenSSL or
   by wolfProvider itself.
2. **Decoder:** only RSA could decode a raw-DER encrypted PKCS#8; EC/DH/ECX/ML-DSA
   decoders did not handle encrypted input, so those keys failed to load in DER
   form (PEM happened to work via a different path).

This PR replaces the encode path with standards-compliant **PBES2
(PBKDF2 + AES-CBC)** and makes the decode path handle encrypted PKCS#8 for every
key type, routed through shared helpers.

## Changes

### Encoder (finding f_4081)
- New shared `wp_encrypt_key_pkcs8()` / `_size()` in `wp_internal.c` wrapping
  `wc_EncryptPKCS8Key` (PBKDF2 + AES-CBC, `WP_PKCS12_ITERATIONS_DEFAULT`).
- All EPKI encoders (RSA, EC, DH, ECX, ML-DSA) route through it; RSA's existing
  `PrivateKeyInfo`+cipher path unified onto the same helper.
- Fixed PEM label to `PKCS8_ENC_PRIVATEKEY_TYPE` (`ENCRYPTED PRIVATE KEY`) and
  fixed output sizing to use the real `LENGTH_ONLY_E` query (block-rounding
  under-sized the structure).
- Removed the weak `wp_encrypt_key` / `wp_BufferKeyEncrypt` / `wp_EncryptedInfoGet`
  helpers and their MD5 dependency.

### Decoder
- New shared `wp_decrypt_key_pkcs8()` in `wp_internal.c` (detect PBES2 via the
  PBKDF2 OID, get passphrase, `wc_DecryptPKCS8Key` in place).
- RSA `wp_rsa_decode_enc_pki` refactored onto it (removed the RSA-local
  `pbkdf2_oid` table / `wp_rsa_find_pbkdf2_oid`).
- Added `wp_*_decode_enc_pki` fallbacks to EC/DH/ECX/ML-DSA: on plaintext-decode
  failure, decrypt then re-decode. No change to `wp_dec_epki2pki.c`.

### Common
- Both helpers guarded on `HAVE_PKCS8 && !NO_PWDBASED` and **fail closed** rather
  than emit weak/plaintext output. This matches the pre-existing decode-side
  requirement (`wc_DecryptPKCS8Key`, also `HAVE_PKCS8`).
- Passphrase buffers use the `WOLFSSL_SMALL_STACK` pattern and `wc_ForceZero`.

## Tests

New encrypted-PKCS#8 round-trip tests via a shared `test_epki_encode_decode`
helper, gated on `WP_HAVE_EPKI_TEST` (`WOLFSSL_ENCRYPTED_KEYS && HAVE_PKCS8 &&
!NO_PWDBASED`).

| Key type | DER wp→OpenSSL | PEM wp→OpenSSL | DER wp→wp | PEM wp→wp |
|----------|:--:|:--:|:--:|:--:|
| RSA      | ✅ | ✅ | ✅ | ✅ |
| EC (P-256) | ✅ | ✅ | ✅ | ✅ |
| DH       | ✅ | ✅ | ✅ | ✅ |
| ECX (Ed25519) | ⏸ | ⏸ | ✅ | ✅ |
| ML-DSA-44 | — | — | ✅ | ✅ |

`wp→OpenSSL` = stock OpenSSL decrypts wolfProvider's output (interop guarantee).
`wp→wp` = wolfProvider round-trips its own output.

## Verification

- **Non-PQC** build + `make test`: green (RSA/EC/DH/ECX; ML-DSA guarded out).
- **PQC** build (OpenSSL 3.6 + wolfSSL ML-DSA) + `make test`: green (all 5 EPKI
  tests).
- **ASan + UBSan**: clean across all modified sources.

## Known limitations / follow-ups (out of scope)

- **ECX interop (⏸):** X25519/Ed25519 plaintext PKCS#8 is block-aligned;
  `wc_EncryptPKCS8Key_ex` omits the PKCS#7 padding block for block-aligned input
  (`asn.c`), which OpenSSL rejects. Fix belongs in wolfSSL; ECX `wp→OpenSSL`
  interop is not asserted until it lands.
  On going: https://github.com/wolfSSL/wolfssl/pull/10836
- **ML-DSA interop (—):** stock OpenSSL does not decode wolfProvider's ML-DSA
  EPKI — a separate ML-DSA/PQC-decode matter, independent of this change.
- Iteration count stays at `WP_PKCS12_ITERATIONS_DEFAULT` (2048) for parity with
  OpenSSL's default output; raising it is a separate decision.