### PR TITLE
Enforce DH minimum prime size on the parameters-only generation path

### DIFF
--- a/include/wolfprovider/internal.h
+++ b/include/wolfprovider/internal.h
@@ -65,6 +65,13 @@
 /** Maximum supported digest name size. */
 #define WP_MAX_PROPS_SIZE       80
 
+/** Minimum accepted DH prime size in bits for parameter/key generation. */
+#ifdef HAVE_FIPS
+#define WP_DH_MIN_BITS          2048
+#else
+#define WP_DH_MIN_BITS          1024
+#endif
+
 /* DER key encoding/decoding formats. */
 /** SubjectPublicKeyInfo encoding format. */
 #define WP_ENC_FORMAT_SPKI              1

--- a/src/wp_dh_kmgmt.c
+++ b/src/wp_dh_kmgmt.c
@@ -51,13 +51,6 @@ static const int wp_dh_decode_nids[] = {
 /** Maximum size of the group name string. */
 #define WP_MAX_DH_GROUP_NAME_SZ     10
 
-/* Min accepted bitlen for keygen */
-#ifdef HAVE_FIPS
-#define WP_DH_MIN_BITS 2048
-#else
-#define WP_DH_MIN_BITS 1024
-#endif
-
 /**
  * DH key.
  */
@@ -1574,17 +1567,18 @@ static wp_DhGenCtx* wp_dh_gen_init(WOLFPROV_CTX* provCtx,
             WOLFPROV_MSG_DEBUG_RETCODE(WP_LOG_LEVEL_DEBUG, "wc_InitRng", rc);
             ok = 0;
         }
-        if (ok) {
-            if (!wp_dh_gen_set_params(ctx, params)) {
-                wc_FreeRng(&ctx->rng);
-                ok = 0;
-            }
-        }
+        /* Defaults first so init-time parameters override them. */
         if (ok) {
             ctx->provCtx   = provCtx;
             ctx->selection = selection;
             ctx->bits      = 2048;
             ctx->generator = 2;
+        }
+        if (ok) {
+            if (!wp_dh_gen_set_params(ctx, params)) {
+                wc_FreeRng(&ctx->rng);
+                ok = 0;
+            }
         }
 
         if (!ok) {
@@ -1644,13 +1638,25 @@ static int wp_dh_gen_set_template(wp_DhGenCtx* ctx, const wp_Dh* dh)
 static int wp_dh_gen_set_params(wp_DhGenCtx* ctx, const OSSL_PARAM params[])
 {
     int ok = 1;
+    int bits;
     const OSSL_PARAM* p;
 
     WOLFPROV_ENTER(WP_LOG_COMP_DH, "wp_dh_gen_set_params");
 
     p = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_FFC_PBITS);
-    if ((p != NULL) && (!OSSL_PARAM_get_int(p, &ctx->bits))) {
-        ok = 0;
+    if (p != NULL) {
+        if (!OSSL_PARAM_get_int(p, &bits)) {
+            ok = 0;
+        }
+        /* Reject a prime size below the provider minimum. */
+        if (ok && (bits < WP_DH_MIN_BITS)) {
+            ERR_raise(ERR_LIB_PROV, PROV_R_KEY_SIZE_TOO_SMALL);
+            ok = 0;
+        }
+        /* Only store the value once it has passed the size check. */
+        if (ok) {
+            ctx->bits = bits;
+        }
     }
     if (ok) {
         p = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_DH_PRIV_LEN);
@@ -1928,12 +1934,13 @@ static wp_Dh* wp_dh_gen(wp_DhGenCtx *ctx, OSSL_CALLBACK *cb, void *cbArg)
         else if (!wp_dh_gen_copy_parameters(ctx, dh)) {
             ok = 0;
         }
+        /* Validate parameters meet minimum requirements in every path. */
+        if (ok && (!wp_dh_params_validate(dh))) {
+            ok = 0;
+        }
         /* Generate key pair if requested. */
         if (ok && ((ctx->selection & OSSL_KEYMGMT_SELECT_KEYPAIR) != 0)) {
-            if (!wp_dh_params_validate(dh)) {
-                ok = 0;
-            }
-            if (ok && (!wp_dh_gen_keypair(ctx, dh))) {
+            if (!wp_dh_gen_keypair(ctx, dh)) {
                 ok = 0;
             }
         }

--- a/test/test_dh.c
+++ b/test/test_dh.c
@@ -21,6 +21,7 @@
 #include "unit.h"
 #include <openssl/core_names.h>
 #include <openssl/decoder.h>
+#include <wolfprovider/internal.h>
 
 #ifdef WP_HAVE_DH
 
@@ -1543,6 +1544,100 @@ int test_dh_import_group_no_nul(void *data)
     EVP_PKEY_free(pkey);
     EVP_PKEY_CTX_free(ctx);
     OPENSSL_free(name);
+    return err;
+}
+
+/* Enforce the minimum prime size: a below-minimum request must not produce
+ * parameters, while a request at the minimum must still succeed. Sizes come
+ * from the provider's own WP_DH_MIN_BITS so the two cannot diverge. */
+#define TEST_DH_MIN_BITS  WP_DH_MIN_BITS
+#define TEST_DH_WEAK_BITS (WP_DH_MIN_BITS / 2)
+int test_dh_pgen_min_bits(void *data)
+{
+    int err = 0;
+    int rc;
+    EVP_PKEY_CTX *ctx = NULL;
+    EVP_PKEY *keyParams = NULL;
+    EVP_PKEY *weakParams = NULL;
+    BIGNUM *prime = NULL;
+
+    (void)data;
+
+    PRINT_MSG("Testing DH parameter generation minimum prime size enforcement");
+
+    /* Below-minimum size must be rejected at set-params time. */
+    ctx = EVP_PKEY_CTX_new_from_name(wpLibCtx, "DH", NULL);
+    if (ctx == NULL) {
+        err = 1;
+    }
+    if (err == 0) {
+        err = EVP_PKEY_paramgen_init(ctx) != 1;
+    }
+    if (err == 0) {
+        rc = EVP_PKEY_CTX_set_dh_paramgen_prime_len(ctx, TEST_DH_WEAK_BITS);
+        if (rc == 1) {
+            PRINT_MSG("set_dh_paramgen_prime_len accepted a below-minimum size");
+            err = 1;
+        }
+    }
+    EVP_PKEY_CTX_free(ctx);
+    ctx = NULL;
+
+    /* A caller that ignores the set-params failure must never end up with
+     * below-minimum parameters: generation either fails, or the prime it
+     * produced is at least the minimum size. */
+    if (err == 0) {
+        ctx = EVP_PKEY_CTX_new_from_name(wpLibCtx, "DH", NULL);
+        err = ctx == NULL;
+    }
+    if (err == 0) {
+        err = EVP_PKEY_paramgen_init(ctx) != 1;
+    }
+    if (err == 0) {
+        (void)EVP_PKEY_CTX_set_dh_paramgen_prime_len(ctx, TEST_DH_WEAK_BITS);
+        if (EVP_PKEY_paramgen(ctx, &weakParams) == 1) {
+            err = EVP_PKEY_get_bn_param(weakParams, OSSL_PKEY_PARAM_FFC_P,
+                                        &prime) != 1;
+            if ((err == 0) && (BN_num_bits(prime) < TEST_DH_MIN_BITS)) {
+                PRINT_MSG("paramgen produced a prime below the minimum size");
+                err = 1;
+            }
+        }
+    }
+    EVP_PKEY_CTX_free(ctx);
+    ctx = NULL;
+
+    /* Size at the minimum must still succeed. */
+    if (err == 0) {
+        ctx = EVP_PKEY_CTX_new_from_name(wpLibCtx, "DH", NULL);
+        err = ctx == NULL;
+    }
+    if (err == 0) {
+        err = EVP_PKEY_paramgen_init(ctx) != 1;
+    }
+    if (err == 0) {
+        err = EVP_PKEY_CTX_set_dh_paramgen_prime_len(ctx, TEST_DH_MIN_BITS)
+              != 1;
+    }
+    if (err == 0) {
+        err = EVP_PKEY_paramgen(ctx, &keyParams) != 1;
+        if (err != 0) {
+            PRINT_MSG("DH paramgen failed at the minimum prime size");
+        }
+    }
+    if (err == 0) {
+        err = EVP_PKEY_get_bn_param(keyParams, OSSL_PKEY_PARAM_FFC_P,
+                                    &prime) != 1;
+        if ((err == 0) && (BN_num_bits(prime) < TEST_DH_MIN_BITS)) {
+            PRINT_MSG("paramgen produced a prime below the minimum size");
+            err = 1;
+        }
+    }
+
+    BN_free(prime);
+    EVP_PKEY_free(weakParams);
+    EVP_PKEY_free(keyParams);
+    EVP_PKEY_CTX_free(ctx);
     return err;
 }
 

--- a/test/unit.c
+++ b/test/unit.c
@@ -338,6 +338,7 @@ TEST_CASE test_case[] = {
     TEST_DECL(test_dh_fromdata_oversize, NULL),
     TEST_DECL(test_dh_param_check_explicit, NULL),
     TEST_DECL(test_dh_import_group_no_nul, NULL),
+    TEST_DECL(test_dh_pgen_min_bits, NULL),
 #ifndef WOLFPROV_QUICKTEST
     TEST_DECL(test_dh_get_params, NULL),
 #endif

--- a/test/unit.h
+++ b/test/unit.h
@@ -361,6 +361,7 @@ int test_dh_x963_kdf(void *data);
 int test_dh_fromdata_oversize(void *data);
 int test_dh_param_check_explicit(void *data);
 int test_dh_import_group_no_nul(void *data);
+int test_dh_pgen_min_bits(void *data);
 #endif /* WP_HAVE_DH */
 
 #ifdef WP_HAVE_ECC


### PR DESCRIPTION
## Summary

DH parameter generation could produce keys weaker than the provider's own declared minimum on the **parameters-only** path.

`wp_dh_params_validate` — which enforces `WP_DH_MIN_BITS` — was only invoked when `OSSL_KEYMGMT_SELECT_KEYPAIR` was set. A caller requesting only `OSSL_KEYMGMT_SELECT_DOMAIN_PARAMETERS` (parameter-only generation) could therefore have the provider generate DH parameters below the minimum with no check, and `wp_dh_gen_set_params` read `OSSL_PKEY_PARAM_FFC_PBITS` into `ctx->bits` with no range check.

This is most impactful in **FIPS** builds: `WP_DH_MIN_BITS` is 2048, but wolfCrypt's own `wc_DhGenerateParams` floor is 1024, so sub-2048 parameters could be generated unchecked. In non-FIPS builds wolfCrypt's floor (1024) already equals `WP_DH_MIN_BITS`, so there the change is defense-in-depth.

## Changes

- **`wp_dh_gen`**: run `wp_dh_params_validate` after parameters are generated or copied, in **every** selection path, before key pair generation (previously only under the keypair branch).
- **`wp_dh_gen_set_params`**: reject an `FFC_PBITS` request below `WP_DH_MIN_BITS` at set-params time (fail-fast for callers that check the return).
- **`test_dh_pgen_min_bits`** (new): asserts a below-minimum prime length is rejected and a request at exactly the minimum still succeeds. Gated on `HAVE_FIPS` to mirror `WP_DH_MIN_BITS` (1024 non-FIPS / 2048 FIPS).

## Testing

- Full DH unit suite passes (tests 77–86), including the new `test_dh_pgen_min_bits`.
- Negative control: disabling the size guard makes the new test fail at the set-params assertion, confirming it is non-vacuous.

## Notes

- `WP_DH_MIN_BITS` is left at 1024 for non-FIPS to avoid breaking interop with legitimate 1024-bit DH consumers. Raising it to 2048 (per NIST SP 800-131A / Logjam) is a separate policy decision and not included here.
- The relocated `wp_dh_params_validate` is the actual enforcer; OpenSSL buffers `prime_len` and the set-params guard is a secondary fail-fast.
