### PR TITLE
Constrain file store decoders to the caller's provider boundary

### DIFF
--- a/src/wp_file_store.c
+++ b/src/wp_file_store.c
@@ -32,6 +32,8 @@
 #include <wolfprovider/settings.h>
 #include <wolfprovider/alg_funcs.h>
 
+#include <wolfssl/wolfcrypt/types.h>
+
 /* TODO: support directory access. */
 
 /**
@@ -354,6 +356,55 @@ static const wp_DecoderInfo wp_decoders[] = {
 #define WP_DECODERS_SIZE  (sizeof(wp_decoders) / sizeof(*wp_decoders))
 
 /**
+ * Combine a decoder's structure query with the caller's property query.
+ *
+ * @param [in]  base    Structure property query. May be NULL.
+ * @param [in]  caller  Caller's property query. May be NULL.
+ * @param [out] query   Combined property query string, or NULL when neither
+ *                      input constrains the fetch.
+ * @return  1 on success.
+ * @return  0 on allocation failure.
+ */
+static int wp_file_decoder_prop_query(const char* base, const char* caller,
+    char** query)
+{
+    int ok = 1;
+    size_t len;
+
+    /* Treat an empty query string the same as an absent (NULL) one. */
+    if ((base != NULL) && (*base == '\0')) {
+        base = NULL;
+    }
+    if ((caller != NULL) && (*caller == '\0')) {
+        caller = NULL;
+    }
+
+    *query = NULL;
+    if (base == NULL) {
+        if (caller != NULL) {
+            *query = OPENSSL_strdup(caller);
+            ok = (*query != NULL);
+        }
+    }
+    else if (caller == NULL) {
+        *query = OPENSSL_strdup(base);
+        ok = (*query != NULL);
+    }
+    else {
+        len = XSTRLEN(base) + XSTRLEN(caller) + 2;
+        *query = OPENSSL_malloc(len);
+        if (*query == NULL) {
+            ok = 0;
+        }
+        else {
+            XSNPRINTF(*query, len, "%s,%s", base, caller);
+        }
+    }
+
+    return ok;
+}
+
+/**
  * Set the decoders into the decoder context.
  *
  * @param [in]      ctx     File system context object.
@@ -366,19 +417,28 @@ static int wp_file_set_decoder(wp_FileCtx* ctx, OSSL_DECODER_CTX* decCtx)
     int ok = 1;
     size_t i;
     OSSL_DECODER* decoder;
+    char* query = NULL;
 
     WOLFPROV_ENTER(WP_LOG_COMP_PROVIDER, "wp_file_set_decoder");
 
     for (i = 0; ok && (i < WP_DECODERS_SIZE); i++) {
-        decoder = OSSL_DECODER_fetch(ctx->provCtx->libCtx, wp_decoders[i].name,
-            wp_decoders[i].propQuery);
-        if (decoder == NULL) {
+        if (!wp_file_decoder_prop_query(wp_decoders[i].propQuery,
+                ctx->propQuery, &query)) {
             ok = 0;
         }
-        if (ok && !OSSL_DECODER_CTX_add_decoder(decCtx, decoder)) {
-            ok = 0;
+        if (ok) {
+            decoder = OSSL_DECODER_fetch(ctx->provCtx->libCtx,
+                wp_decoders[i].name, query);
+            if (decoder == NULL) {
+                ok = 0;
+            }
+            if (ok && !OSSL_DECODER_CTX_add_decoder(decCtx, decoder)) {
+                ok = 0;
+            }
+            OSSL_DECODER_free(decoder);
         }
-        OSSL_DECODER_free(decoder);
+        OPENSSL_free(query);
+        query = NULL;
     }
 
     WOLFPROV_LEAVE(WP_LOG_COMP_PROVIDER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);

--- a/test/test_rsa.c
+++ b/test/test_rsa.c
@@ -1580,6 +1580,79 @@ int test_rsa_load_cert(void* data)
     return err;
 }
 
+/**
+ * Load the RSA private key from the file store with a caller property query.
+ *
+ * @param [in] props  Property query passed as OSSL_STORE_PARAM_PROPERTIES.
+ * @return  1 when a key was loaded, 0 otherwise.
+ */
+static int test_rsa_store_load_props(const char* props)
+{
+    int loaded = 0;
+    OSSL_PARAM params[2];
+    OSSL_STORE_CTX* ctx = NULL;
+    OSSL_STORE_INFO* info = NULL;
+    EVP_PKEY* pkey = NULL;
+
+    params[0] = OSSL_PARAM_construct_utf8_string(OSSL_STORE_PARAM_PROPERTIES,
+        (char *)props, 0);
+    params[1] = OSSL_PARAM_construct_end();
+
+    ctx = OSSL_STORE_open_ex(CERTS_DIR "/server-key.pem", wpLibCtx, NULL, NULL,
+        NULL, params, NULL, NULL);
+    if (ctx != NULL) {
+        info = OSSL_STORE_load(ctx);
+    }
+    if (info != NULL) {
+        pkey = OSSL_STORE_INFO_get1_PKEY(info);
+        loaded = pkey != NULL;
+    }
+
+    EVP_PKEY_free(pkey);
+    OSSL_STORE_INFO_free(info);
+    OSSL_STORE_close(ctx);
+    return loaded;
+}
+
+int test_rsa_load_key_prop_query(void* data)
+{
+    int err = 0;
+
+    (void)data;
+
+    PRINT_MSG("Load RSA private key within the wolfProvider boundary");
+    if (!test_rsa_store_load_props("provider=wolfprov")) {
+        PRINT_ERR_MSG("Store load with provider=wolfprov failed");
+        err = 1;
+    }
+
+    if (err == 0) {
+        PRINT_MSG("Load RSA private key with an empty property query");
+        if (!test_rsa_store_load_props("")) {
+            PRINT_ERR_MSG("Store load with an empty property query failed");
+            err = 1;
+        }
+    }
+
+    if (err == 0) {
+        PRINT_MSG("Load RSA private key with an optional provider clause");
+        if (!test_rsa_store_load_props("?provider=wp_no_such_provider")) {
+            PRINT_ERR_MSG("Store load with an optional clause failed");
+            err = 1;
+        }
+    }
+
+    if (err == 0) {
+        PRINT_MSG("Load RSA private key with an unavailable provider");
+        if (test_rsa_store_load_props("provider=wp_no_such_provider")) {
+            PRINT_ERR_MSG("Store load ignored the caller's property query");
+            err = 1;
+        }
+    }
+
+    return err;
+}
+
 int test_rsa_fromdata(void* data)
 {
     (void)data;

--- a/test/unit.c
+++ b/test/unit.c
@@ -343,6 +343,7 @@ TEST_CASE test_case[] = {
     TEST_DECL(test_rsa_pss_restrictions, NULL),
     TEST_DECL(test_rsa_load_key, NULL),
     TEST_DECL(test_rsa_load_cert, NULL),
+    TEST_DECL(test_rsa_load_key_prop_query, NULL),
     TEST_DECL(test_rsa_fromdata, NULL),
     TEST_DECL(test_rsa_fromdata_oversize, NULL),
     TEST_DECL(test_rsa_decode_pkcs8, NULL),

--- a/test/unit.h
+++ b/test/unit.h
@@ -305,6 +305,7 @@ int test_rsa_pss_restrictions(void *data);
 
 int test_rsa_load_key(void* data);
 int test_rsa_load_cert(void* data);
+int test_rsa_load_key_prop_query(void* data);
 int test_rsa_fromdata(void* data);
 int test_rsa_fromdata_oversize(void* data);
 int test_rsa_decode_pkcs8(void* data);


### PR DESCRIPTION
# Constrain file store decoders to the caller's provider boundary

## Summary

The wolfProvider file store fetched its terminal decoders using only the
structure property and ignored the caller's property query, so a store load
routed to wolfProvider could add and use a decoder from another provider. This
PR propagates the caller's property query into those explicit fetches so a
`provider=wolfprov` boundary is honored consistently. Fixes finding f_5534.

## Problem

`wp_file_set_decoder()` fetched each decoder like this:

```c
decoder = OSSL_DECODER_fetch(ctx->provCtx->libCtx, wp_decoders[i].name,
    wp_decoders[i].propQuery);   /* e.g. "structure=PrivateKeyInfo" */
```

The caller-supplied `ctx->propQuery` (where an application expresses a
`provider=wolfprov` compliance boundary via `OSSL_STORE_PARAM_PROPERTIES`) was
applied only to `OSSL_DECODER_CTX_add_extra`, not to these explicit fetches.
As a result the store's own terminal decoders were fetched without any provider
constraint and could resolve to another provider's implementation.

## Fix

Add a file-local helper that combines each decoder's structure query with the
caller's property query, and use it for every explicit fetch:

```c
static int wp_file_decoder_prop_query(const char* base, const char* caller,
    char** query);   /* 1 = ok, 0 = alloc failure; *query freed by caller */
```

- No caller query (`NULL`) → behavior unchanged (`"structure=..."`).
- `provider=wolfprov` → combined query (`"structure=...,provider=wolfprov"`),
  so the boundary applies to the explicit fetches as well as to
  `OSSL_DECODER_CTX_add_extra`.

## Behavior / compatibility

- Default behavior (no property query) is unchanged.
- When the caller sets `provider=wolfprov`, the boundary is now enforced on all
  of the store's decoder fetches. A load that previously resolved silently
  through another provider will now stay within wolfProvider — or fail if
  wolfProvider cannot satisfy it, which is the intended boundary semantics.

## Testing

- Builds clean under the project's strict warning set
  (`-Werror -Wextra -Wshadow -Wshorten-64-to-32 ...`).
- Full unit suite passes (`OPENSSL_CONF=provider.conf`), including the
  store-load paths: `test_rsa_load_key`, `test_rsa_load_cert`,
  `test_ec_load_key`, `test_ec_load_cert`.