### PR TITLE
Gate secp192r1/P-192 TLS-GROUP advertisement on curve availability

### DIFF
--- a/src/wp_tls_capa.c
+++ b/src/wp_tls_capa.c
@@ -135,8 +135,11 @@ static const wp_tls_group_consts wp_group_const_list[35] = {
 
 /** List of parameters for TLS groups. */
 static const OSSL_PARAM wp_param_group_list[][11] = {
+#if defined(WP_HAVE_EC_P192) && !defined(HAVE_FIPS) && \
+    !defined(HAVE_FIPS_VERSION)
     WP_TLS_GROUP_ENTRY_EC(    "secp192r1"      , "prime192v1"     , 0 ),
     WP_TLS_GROUP_ENTRY_EC(    "P-192"          , "prime192v1"     , 0 ),
+#endif
     WP_TLS_GROUP_ENTRY_EC(    "secp224r1"      , "secp224r1"      , 1 ),
     WP_TLS_GROUP_ENTRY_EC(    "P-224"          , "secp224r1"      , 1 ),
     WP_TLS_GROUP_ENTRY_EC(    "secp256r1"      , "prime256v1"     , 2 ),

--- a/test/test_ecc.c
+++ b/test/test_ecc.c
@@ -2845,4 +2845,92 @@ int test_ec_fromdata_oversize(void *data)
 }
 #endif /* WP_HAVE_EC_P256 */
 
+/* Collected while walking the advertised TLS-GROUP capability list. */
+typedef struct wp_group_scan {
+    int total;           /* Number of groups advertised. */
+    int foundP192;       /* "P-192" was advertised. */
+    int foundSecp192r1;  /* "secp192r1" was advertised. */
+    int foundP256;       /* "P-256" was advertised. */
+} wp_group_scan;
+
+/* Record whether the weak P-192 group is advertised. P-256 is always in the
+ * table and anchors the name matching, so an absent P-192 is not confused
+ * with a broken name lookup. */
+static int wp_group_name_cb(const OSSL_PARAM params[], void *arg)
+{
+    wp_group_scan *scan = (wp_group_scan*)arg;
+    const OSSL_PARAM *p;
+    const char *name = NULL;
+
+    p = OSSL_PARAM_locate_const(params, OSSL_CAPABILITY_TLS_GROUP_NAME);
+    if ((p != NULL) && OSSL_PARAM_get_utf8_string_ptr(p, &name) &&
+            (name != NULL)) {
+        scan->total++;
+        if (strcmp(name, "P-192") == 0) {
+            scan->foundP192 = 1;
+        }
+        else if (strcmp(name, "secp192r1") == 0) {
+            scan->foundSecp192r1 = 1;
+        }
+        else if (strcmp(name, "P-256") == 0) {
+            scan->foundP256 = 1;
+        }
+    }
+
+    return 1;
+}
+
+/* P-192 gives only 80 bits of security and is not FIPS approved. Advertise it
+ * as a TLS group only in non-FIPS builds where the curve is compiled in and
+ * usable (WP_HAVE_EC_P192). */
+int test_ec_tls_group_p192(void *data)
+{
+    int err = 0;
+    wp_group_scan scan;
+
+    (void)data;
+
+    memset(&scan, 0, sizeof(scan));
+
+    if (wpProv == NULL) {
+        PRINT_ERR_MSG("wolfProvider not loaded");
+        err = 1;
+    }
+
+    if (err == 0) {
+        if (OSSL_PROVIDER_get_capabilities(wpProv, "TLS-GROUP",
+                wp_group_name_cb, &scan) != 1) {
+            PRINT_ERR_MSG("get_capabilities(TLS-GROUP) failed");
+            err = 1;
+        }
+    }
+
+    if (err == 0 && scan.total == 0) {
+        PRINT_ERR_MSG("No TLS groups advertised");
+        err = 1;
+    }
+
+    /* Anchor: proves name matching works, so an absent P-192 below is a real
+     * absence rather than a broken lookup. */
+    if (err == 0 && scan.foundP256 == 0) {
+        PRINT_ERR_MSG("P-256 should always be advertised");
+        err = 1;
+    }
+
+#if defined(WP_HAVE_EC_P192) && !defined(HAVE_FIPS) && \
+    !defined(HAVE_FIPS_VERSION)
+    if (err == 0 && (scan.foundP192 == 0 || scan.foundSecp192r1 == 0)) {
+        PRINT_ERR_MSG("P-192 should be advertised when the curve is usable");
+        err = 1;
+    }
+#else
+    if (err == 0 && (scan.foundP192 != 0 || scan.foundSecp192r1 != 0)) {
+        PRINT_ERR_MSG("P-192 must not be advertised (80-bit / non-FIPS only)");
+        err = 1;
+    }
+#endif
+
+    return err;
+}
+
 #endif /* WP_HAVE_ECC */

--- a/test/unit.c
+++ b/test/unit.c
@@ -29,6 +29,7 @@
 
 OSSL_LIB_CTX* wpLibCtx = NULL;
 OSSL_LIB_CTX* osslLibCtx = NULL;
+OSSL_PROVIDER* wpProv = NULL;
 int noKeyLimits = 0;
 
 #ifdef WOLFPROV_DEBUG
@@ -469,6 +470,10 @@ TEST_CASE test_case[] = {
     TEST_DECL(test_ec_load_cert, NULL),
 #endif /* WP_HAVE_ECDSA */
 
+#ifdef WP_HAVE_ECC
+    TEST_DECL(test_ec_tls_group_p192, NULL),
+#endif /* WP_HAVE_ECC */
+
 #ifdef WP_HAVE_PBE
     #if !defined(HAVE_FIPS) || defined(WP_ALLOW_NON_FIPS)
         TEST_DECL(test_pbe, NULL),
@@ -768,7 +773,6 @@ int main(int argc, char* argv[])
 {
     int err = 0;
     OSSL_PROVIDER* osslProv = NULL;
-    OSSL_PROVIDER* wpProv = NULL;
     int staticTest = 0;
     const char *name = wolfprovider_id;
     const char *dir = ".libs";

--- a/test/unit.h
+++ b/test/unit.h
@@ -94,6 +94,7 @@ int test_ct_masks(void *data);
 
 extern OSSL_LIB_CTX* wpLibCtx;
 extern OSSL_LIB_CTX* osslLibCtx;
+extern OSSL_PROVIDER* wpProv;
 extern int noKeyLimits;
 
 
@@ -461,6 +462,7 @@ int test_ec_decode(void* data);
 int test_ec_import(void* data);
 int test_ec_auto_derive_pubkey(void* data);
 int test_ec_null_init(void* data);
+int test_ec_tls_group_p192(void* data);
 #ifdef WP_HAVE_EC_P256
 int test_ec_print_public(void* data);
 int test_ec_fromdata_oversize(void* data);


### PR DESCRIPTION
# Gate secp192r1/P-192 TLS-GROUP advertisement on curve availability

Fixes finding f_6497.

## Problem

When libssl queries wolfProvider for `TLS-GROUP` capabilities,
`wp_tls_group_capability()` walked `wp_param_group_list[]` and
unconditionally advertised `secp192r1` and `P-192`. That entry declares
only 80 bits of security, which is below the 112-bit modern/NIST minimum
and below the P-224 floor used by wolfCrypt FIPS.

Two consequences followed:

1. **FIPS builds.** P-192 is not a FIPS approved curve, and wolfCrypt FIPS
   blocks P-192 private key operations (`WP_FIPS_CHECK_P192`). The provider
   advertised it anyway, so libssl could select a group the underlying
   wolfCrypt cannot perform, failing at key generation rather than at
   negotiation. The brainpool curves in the same table were already gated
   with `#ifndef HAVE_FIPS`, so the intent to FIPS-gate non-approved curves
   was established; P-192 was simply missed.
2. **Curve not compiled in.** Nothing tied the entry to whether `secp192r1`
   was actually built into wolfCrypt, so the provider could advertise a
   curve it cannot satisfy.

A peer configured to accept the advertised set could therefore negotiate an
80-bit ECDHE group with no error surfaced to the application.

## Fix

Wrap the two P-192 entries in the curve's own availability macro, plus an
explicit FIPS exclusion:

```c
static const OSSL_PARAM wp_param_group_list[][11] = {
#if defined(WP_HAVE_EC_P192) && !defined(HAVE_FIPS)
    WP_TLS_GROUP_ENTRY_EC(    "secp192r1"      , "prime192v1"     , 0 ),
    WP_TLS_GROUP_ENTRY_EC(    "P-192"          , "prime192v1"     , 0 ),
#endif
    WP_TLS_GROUP_ENTRY_EC(    "secp224r1"      , "secp224r1"      , 1 ),
```

`WP_HAVE_EC_P192` already exists in `include/wolfprovider/settings.h` and is
defined as `(HAVE_ECC192 || HAVE_ALL_CURVES) && ECC_MIN_KEY_SZ <= 192`. It
covers the "curve compiled in and usable" half, including hardened builds
that raise the minimum ECC key size.

Both terms are needed. `ECC_MIN_KEY_SZ` defaults to 224 in a plain non-FIPS
build, so `WP_HAVE_EC_P192` is already off by default there. However,
wolfSSL defaults `ECC_MIN_KEY_SZ` to **192** under `FIPS_VERSION_GE(2,0)`,
so a FIPS build that does not separately override it would leave
`WP_HAVE_EC_P192` defined. The explicit `!defined(HAVE_FIPS)` term
guarantees P-192 is never advertised in a FIPS build regardless of the
configured minimum key size, and matches the existing brainpool gating
convention in the same file.

## Scope

This change is intentionally limited to P-192, the subject of the finding.
The `P-224`, `P-256`, `P-384`, and `P-521` entries remain unconditional even
though each has a corresponding `WP_HAVE_EC_Pxxx` macro. Those curves all
meet the 112-bit floor and are FIPS approved. Gating them on their
availability macros is a pre-existing inconsistency and is left as a
separate follow-up rather than widening this fix.

## Testing

New regression test `test_ec_tls_group_p192` in `test/test_ecc.c` (registered
in `test/unit.c` and `test/unit.h`). It calls
`OSSL_PROVIDER_get_capabilities(prov, "TLS-GROUP", ...)`, walks the advertised
group list, and asserts that P-192 presence matches the guard, so it stays
correct in both FIPS and non-FIPS builds.

Verified at runtime against the actual built provider across three
configurations:

| Configuration | secp192r1 / P-192 advertised |
| --- | --- |
| Guarded, `WP_HAVE_EC_P192` on, non-FIPS | Yes (correct, curve is usable) |
| Guarded, `WP_HAVE_EC_P192` forced off | No (P-224 and above unaffected) |
| Guarded, `HAVE_FIPS` forced on | No (P-224 and above unaffected) |
| Unguarded, `WP_HAVE_EC_P192` off (pre-fix) | Yes (reproduces the bug) |

The last row is the negative control: it confirms the test fails without the
fix rather than passing vacuously.