### PR TITLE
fix: guard wp_kdf_free refCnt with mutex

### DIFF
--- a/src/wp_kdf_kmgmt.c
+++ b/src/wp_kdf_kmgmt.c
@@ -126,10 +126,11 @@ void wp_kdf_free(wp_Kdf* kdf)
         int rc;
 
         rc = wc_LockMutex(&kdf->mutex);
-        cnt = --kdf->refCnt;
-        if (rc == 0) {
-            wc_UnLockMutex(&kdf->mutex);
+        if (rc != 0) {
+            return;
         }
+        cnt = --kdf->refCnt;
+        wc_UnLockMutex(&kdf->mutex);
     #else
         cnt = --kdf->refCnt;
     #endif


### PR DESCRIPTION
## Bug

In `wp_kdf_free` (src/wp_kdf_kmgmt.c), the reference-count decrement runs outside the mutex guard in the multi-threaded (`#ifndef WP_SINGLE_THREADED`) path:

```c
rc = wc_LockMutex(&kdf->mutex);
cnt = --kdf->refCnt;        // runs unconditionally, even when the lock was NOT acquired
if (rc == 0) {
    wc_UnLockMutex(&kdf->mutex);
}
```

When `wc_LockMutex` fails, `--kdf->refCnt` is a non-atomic read-modify-write on shared state with no lock held. Two threads can race and both observe `cnt == 0`, leading to a double `OPENSSL_free(kdf)`.

## Fix

Return early when the lock cannot be acquired, and hold the mutex across the decrement — mirroring the already-correct `wp_mac_free` in src/wp_mac_kmgmt.c:

```c
rc = wc_LockMutex(&kdf->mutex);
if (rc != 0) {
    return;
}
cnt = --kdf->refCnt;
wc_UnLockMutex(&kdf->mutex);
```

The single-threaded `#else` branch is unchanged.

## Verification

Compiled the changed translation unit against a wolfSSL install + system OpenSSL headers (`gcc -c src/wp_kdf_kmgmt.c ...`) — EXIT=0, `wp_kdf_free` emitted as a defined text symbol. `WP_SINGLE_THREADED` is not defined by default, so the fixed branch is the live one.

Reported by static analysis (Fenrir finding 840).

`[fenrir-sweep:held]`
