### PR TITLE
fix: constant-time Ed sig order check

### DIFF
--- a/src/wp_ecx_sig.c
+++ b/src/wp_ecx_sig.c
@@ -453,14 +453,18 @@ static int wp_ed25519_digest_verify(wp_EcxSigCtx *ctx, unsigned char *sig,
     }
     if (ok) {
         int i;
+        byte gt = 0;  /* s > order found at a more-significant byte */
+        byte lt = 0;  /* s < order found at a more-significant byte */
+        /* Constant-time full-width magnitude compare, big-endian scan with no
+         * early break: reject iff s > order (accept when equal or less). */
         for (i = ED25519_KEY_SIZE - 1; i >= 0; i--) {
-            if (sig[ED25519_KEY_SIZE + i] > wp_ed25519_order[i]) {
-                ok = 0;
-            }
-            if (sig[ED25519_KEY_SIZE + i] != wp_ed25519_order[i]) {
-                break;
-            }
+            byte s = sig[ED25519_KEY_SIZE + i];
+            byte o = wp_ed25519_order[i];
+            byte eq = (byte)~(gt | lt);           /* still tied above */
+            gt |= (byte)(eq & wp_ct_int_mask_lt(o, s));  /* o < s => s > order */
+            lt |= (byte)(eq & wp_ct_int_mask_lt(s, o));  /* s < order          */
         }
+        ok &= (int)(1u & ~(unsigned int)gt);
     }
     if (ok) {
         int res;
@@ -666,14 +670,18 @@ static int wp_ed448_digest_verify(wp_EcxSigCtx *ctx, unsigned char *sig,
     }
     if (ok) {
         int i;
+        byte gt = 0;  /* s > order found at a more-significant byte */
+        byte lt = 0;  /* s < order found at a more-significant byte */
+        /* Constant-time full-width magnitude compare, big-endian scan with no
+         * early break: reject iff s > order (accept when equal or less). */
         for (i = ED448_KEY_SIZE - 1; i >= 0; i--) {
-            if (sig[ED448_KEY_SIZE + i] > wp_ed448_order[i]) {
-                ok = 0;
-            }
-            if (sig[ED448_KEY_SIZE + i] != wp_ed448_order[i]) {
-                break;
-            }
+            byte s = sig[ED448_KEY_SIZE + i];
+            byte o = wp_ed448_order[i];
+            byte eq = (byte)~(gt | lt);           /* still tied above */
+            gt |= (byte)(eq & wp_ct_int_mask_lt(o, s));  /* o < s => s > order */
+            lt |= (byte)(eq & wp_ct_int_mask_lt(s, o));  /* s < order          */
         }
+        ok &= (int)(1u & ~(unsigned int)gt);
     }
     if (ok) {
         int res;


### PR DESCRIPTION
Bug: `wp_ed25519_digest_verify` and `wp_ed448_digest_verify` (src/wp_ecx_sig.c) validate that the signature scalar `s` is below the curve order with a byte-by-byte compare that `break`s on the first differing byte. Iteration count — and therefore execution time — depends on the position of the highest differing `s` byte, leaking information about `s` in a variable-time path.

Fix: replace the branchy loop in both functions with a branchless full-width magnitude compare built on the in-tree `wp_ct_int_mask_lt` helper (include/wolfprovider/internal.h, src/wp_internal.c). The scan runs a fixed number of iterations (32 for Ed25519, 57 for Ed448) with no early exit. Exact semantics preserved: reject iff `s > curve_order` (accept when equal or less).

Impact: Ed signatures are normally public, so this matters chiefly for blind / threshold signing constructions where `s` (or a component) is secret. Severity low.

Build-verified: compiled the translation unit with `gcc -c -O2 -Wall` against a wolfSSL `--enable-all` install + system OpenSSL headers (EXIT_CC=0). Disassembly of both functions confirms the loop terminator is now a fixed pointer-vs-end compare (data-independent iteration count) and the prior data-dependent early-break `jne` is gone; the two `wp_ct_int_mask_lt` calls are branchless.

Reported by static analysis (Fenrir finding 841).

`[fenrir-sweep:held]`
