### PR TITLE
Security hardening, input validation, memory-safety, and key zeroization fixes

### DIFF
--- a/src/wp_aes_aead.c
+++ b/src/wp_aes_aead.c
@@ -1789,6 +1789,7 @@ static int wp_aesccm_init(wp_AeadCtx* ctx, const unsigned char *key,
     }
     if (ok) {
         ctx->enc = enc;
+        ctx->tlsAadLen = UNINITIALISED_SIZET;
         ok = wp_aead_set_ctx_params(ctx, params);
     }
 
@@ -1914,6 +1915,7 @@ static int wp_aesccm_tls_cipher(wp_AeadCtx* ctx, unsigned char* out,
     }
 
     *outLen = olen;
+    ctx->tlsAadLen = UNINITIALISED_SIZET;
     WOLFPROV_LEAVE(WP_LOG_COMP_AES, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;
 }

--- a/src/wp_aes_block.c
+++ b/src/wp_aes_block.c
@@ -589,7 +589,6 @@ static int wp_aes_block_tls_dec_record(wp_AesBlockCtx *ctx,
             gd = d - 1;
         }
         ivRecLen -= gd & ((size_t)padV + 1);
-        *outLen = ivRecLen;
         /* No MAC to extract */
         ctx->tlsmac = NULL;
         ctx->tlsmacAlloced = 0;
@@ -597,8 +596,13 @@ static int wp_aes_block_tls_dec_record(wp_AesBlockCtx *ctx,
          * already verified by the record layer, so there is no padding
          * oracle concern).  Matches OpenSSL ssl3_cbc_copy_mac returning
          * 0 when good==0 and mac_size==0. */
-        if (gd == 0)
+        if (gd == 0) {
             ok = 0;
+            *outLen = 0;
+        }
+        else {
+            *outLen = ivRecLen;
+        }
     }
     else if (ok) {
         /* 64-byte aligned buffer for cache-line-aware MAC rotation */

--- a/src/wp_aes_block.c
+++ b/src/wp_aes_block.c
@@ -747,6 +747,7 @@ static int wp_aes_block_update(wp_AesBlockCtx *ctx, unsigned char *out,
     int ok = 1;
     size_t oLen = 0;
     size_t nextBlocks;
+    unsigned char *outStart = out;
 
     WOLFPROV_ENTER(WP_LOG_COMP_AES, "wp_aes_block_update");
 
@@ -812,7 +813,7 @@ static int wp_aes_block_update(wp_AesBlockCtx *ctx, unsigned char *out,
         *outLen = oLen;
     }
     if (ok && (ctx->tls_version > 0) && (!ctx->enc)) {
-        ok = wp_aes_block_tls_dec_record(ctx, out, oLen, outLen);
+        ok = wp_aes_block_tls_dec_record(ctx, outStart, oLen, outLen);
     }
 
     WOLFPROV_LEAVE(WP_LOG_COMP_AES, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);

--- a/src/wp_aes_wrap.c
+++ b/src/wp_aes_wrap.c
@@ -349,7 +349,8 @@ static int wp_aes_wrap_update(wp_AesWrapCtx *ctx, unsigned char *out,
         ok = 0;
     }
 
-    if (ok && ((inLen > UINT32_MAX) || (outSize > UINT32_MAX))) {
+    if (ok && (((uint64_t)inLen > (uint64_t)UINT32_MAX) ||
+            ((uint64_t)outSize > (uint64_t)UINT32_MAX))) {
         ok = 0;
     }
 

--- a/src/wp_aes_wrap.c
+++ b/src/wp_aes_wrap.c
@@ -349,6 +349,10 @@ static int wp_aes_wrap_update(wp_AesWrapCtx *ctx, unsigned char *out,
         ok = 0;
     }
 
+    if (ok && ((inLen > UINT32_MAX) || (outSize > UINT32_MAX))) {
+        ok = 0;
+    }
+
     if (ok && (inLen == 0)) {
         *outLen = 0;
     }

--- a/src/wp_dec_epki2pki.c
+++ b/src/wp_dec_epki2pki.c
@@ -118,9 +118,15 @@ static int wp_DecryptPKCS8Key(byte* input, word32 sz, const char* password,
     EncryptedInfo info;
     int algoId;
 
-    pem = OPENSSL_malloc(sz * 2);
-    if (pem == NULL) {
-        ret = MEMORY_E;
+    /* sz * 2 must not overflow word32 before allocating and encoding. */
+    if (sz > (0xFFFFFFFFU / 2)) {
+        ret = BAD_FUNC_ARG;
+    }
+    if (ret == 0) {
+        pem = OPENSSL_malloc((size_t)sz * 2);
+        if (pem == NULL) {
+            ret = MEMORY_E;
+        }
     }
     if (ret == 0) {
         ret = wc_DerToPem(input, sz, pem, sz * 2, PKCS8_ENC_PRIVATEKEY_TYPE);

--- a/src/wp_dec_epki2pki.c
+++ b/src/wp_dec_epki2pki.c
@@ -232,6 +232,9 @@ static int wp_epki2pki_decode(wp_Epki2Pki* ctx, OSSL_CORE_BIO* coreBio,
             pwCbArg))) {
         done = 1;
     }
+    if ((!done) && ok && (passwordLen > sizeof(password))) {
+        ok = 0;
+    }
     if ((!done) && ok) {
     #if LIBWOLFSSL_VERSION_HEX >= 0x05000000
         rc = wc_DecryptPKCS8Key(data, len, password, (int)passwordLen);

--- a/src/wp_dec_pem2der.c
+++ b/src/wp_dec_pem2der.c
@@ -160,12 +160,18 @@ static int wp_pem2der_convert(const char* data, word32 len, DerBuffer** pDer,
     WOLFPROV_ENTER(WP_LOG_COMP_PK, "wp_pem2der_convert");
 
     /* Skip '-----BEGIN <name>-----\n'. */
-    base64Data = data + 16 + nameLen + 1;
-    base64Len = len - (16 + nameLen + 1);
-    footer = XSTRSTR(base64Data, "-----END ");
-    if (footer == NULL) {
+    if (len <= (word32)(16 + nameLen + 1)) {
         info->consumed = len;
         ok = 0;
+    }
+    if (ok) {
+        base64Data = data + 16 + nameLen + 1;
+        base64Len = len - (16 + nameLen + 1);
+        footer = XSTRSTR(base64Data, "-----END ");
+        if (footer == NULL) {
+            info->consumed = len;
+            ok = 0;
+        }
     }
     if (ok) {
         /* Include footer and '\n'. */
@@ -233,7 +239,11 @@ static int wp_pem2der_decode_data(const unsigned char* data, word32 len,
 
     /* Identify the type of object by looking at the header. */
     /* TODO: support more PEM headers. */
-    if (XMEMCMP(data, "-----BEGIN CERTIFICATE-----", 27) == 0) {
+    /* Header detection reads fixed-length prefixes; reject short input. */
+    if (len < 41) {
+        ok = 0;
+    }
+    else if (XMEMCMP(data, "-----BEGIN CERTIFICATE-----", 27) == 0) {
         type = CERT_TYPE;
         obj = OSSL_OBJECT_CERT;
     }

--- a/src/wp_dec_pem2der.c
+++ b/src/wp_dec_pem2der.c
@@ -124,6 +124,9 @@ static int wp_pem_password_cb(char* passwd, int sz, int rw, void* userdata)
     if (!osslCb->cb(passwd, sz, &len, NULL, osslCb->cbArg)) {
         ret = -1;
     }
+    else if (len > (size_t)sz) {
+        ret = -1;
+    }
     else {
         ret = (int)len;
     }

--- a/src/wp_des.c
+++ b/src/wp_des.c
@@ -489,6 +489,10 @@ static int wp_des3_block_update(wp_Des3BlockCtx *ctx, unsigned char *out,
         }
         *outLen = oLen;
     }
+    if (ok && (ctx->tls_version > 0) && (!ctx->enc) &&
+            (oLen < (size_t)(2 * DES_BLOCK_SIZE))) {
+        ok = 0;
+    }
     if (ok && (ctx->tls_version > 0) && (!ctx->enc)) {
         unsigned char pad = out[oLen-1];
         int padStart = DES_BLOCK_SIZE - pad - 1;

--- a/src/wp_des.c
+++ b/src/wp_des.c
@@ -420,6 +420,7 @@ static int wp_des3_block_update(wp_Des3BlockCtx *ctx, unsigned char *out,
     int ok = 1;
     size_t oLen = 0;
     size_t nextBlocks;
+    unsigned char *outStart = out;
 
     WOLFPROV_ENTER(WP_LOG_COMP_DES, "wp_des3_block_update");
 
@@ -494,14 +495,14 @@ static int wp_des3_block_update(wp_Des3BlockCtx *ctx, unsigned char *out,
         ok = 0;
     }
     if (ok && (ctx->tls_version > 0) && (!ctx->enc)) {
-        unsigned char pad = out[oLen-1];
+        unsigned char pad = outStart[oLen-1];
         int padStart = DES_BLOCK_SIZE - pad - 1;
         unsigned char invalid = (pad < DES_BLOCK_SIZE) - 1;
         int i;
 
         for (i = DES_BLOCK_SIZE - 1; i >= 0; i--) {
             byte check = wp_ct_int_mask_gte(i, padStart);
-            check &= wp_ct_byte_mask_ne(out[oLen - DES_BLOCK_SIZE + i], pad);
+            check &= wp_ct_byte_mask_ne(outStart[oLen - DES_BLOCK_SIZE + i], pad);
             invalid |= check;
         }
         *outLen = oLen - pad - 1 - DES_BLOCK_SIZE;

--- a/src/wp_des.c
+++ b/src/wp_des.c
@@ -505,8 +505,13 @@ static int wp_des3_block_update(wp_Des3BlockCtx *ctx, unsigned char *out,
             check &= wp_ct_byte_mask_ne(outStart[oLen - DES_BLOCK_SIZE + i], pad);
             invalid |= check;
         }
-        *outLen = oLen - pad - 1 - DES_BLOCK_SIZE;
         ok = invalid == 0;
+        if (ok) {
+            *outLen = oLen - pad - 1 - DES_BLOCK_SIZE;
+        }
+        else {
+            *outLen = 0;
+        }
     }
 
     WOLFPROV_LEAVE(WP_LOG_COMP_DES, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);

--- a/src/wp_dh_kmgmt.c
+++ b/src/wp_dh_kmgmt.c
@@ -1027,16 +1027,32 @@ static int wp_dh_validate(const wp_Dh* dh, int selection, int checkType)
     if (((selection & OSSL_KEYMGMT_SELECT_DOMAIN_PARAMETERS) != 0) &&
         (dh->id == 0)) {
         int isPrime = 0;
+        int pm1Init = 0;
         mp_int* p = (mp_int*)&dh->key.p;
         mp_int* g = (mp_int*)&dh->key.g;
+        mp_int pm1;
 
         /* Explicit domain parameters: p must be prime and g in [2, p-1). */
-        rc = mp_prime_is_prime(p, 8, &isPrime);
-        if ((rc != 0) || (!isPrime)) {
+        if (mp_init(&pm1) != 0) {
             ok = 0;
         }
-        if (ok && ((mp_cmp_d(g, 2) == MP_LT) || (mp_cmp(g, p) != MP_LT))) {
+        else {
+            pm1Init = 1;
+        }
+        if (ok) {
+            rc = mp_prime_is_prime(p, 8, &isPrime);
+            if ((rc != 0) || (!isPrime)) {
+                ok = 0;
+            }
+        }
+        if (ok && (mp_sub_d(p, 1, &pm1) != 0)) {
             ok = 0;
+        }
+        if (ok && ((mp_cmp_d(g, 2) == MP_LT) || (mp_cmp(g, &pm1) != MP_LT))) {
+            ok = 0;
+        }
+        if (pm1Init) {
+            mp_clear(&pm1);
         }
     }
     if (ok && ((selection & OSSL_KEYMGMT_SELECT_PUBLIC_KEY) != 0)) {

--- a/src/wp_dh_kmgmt.c
+++ b/src/wp_dh_kmgmt.c
@@ -1026,7 +1026,18 @@ static int wp_dh_validate(const wp_Dh* dh, int selection, int checkType)
 
     if (((selection & OSSL_KEYMGMT_SELECT_DOMAIN_PARAMETERS) != 0) &&
         (dh->id == 0)) {
-        /* TODO: check explicit parameters. */
+        int isPrime = 0;
+        mp_int* p = (mp_int*)&dh->key.p;
+        mp_int* g = (mp_int*)&dh->key.g;
+
+        /* Explicit domain parameters: p must be prime and g in [2, p-1). */
+        rc = mp_prime_is_prime(p, 8, &isPrime);
+        if ((rc != 0) || (!isPrime)) {
+            ok = 0;
+        }
+        if (ok && ((mp_cmp_d(g, 2) == MP_LT) || (mp_cmp(g, p) != MP_LT))) {
+            ok = 0;
+        }
     }
     if (ok && ((selection & OSSL_KEYMGMT_SELECT_PUBLIC_KEY) != 0)) {
     #if LIBWOLFSSL_VERSION_HEX >= 0x05000000

--- a/src/wp_dh_kmgmt.c
+++ b/src/wp_dh_kmgmt.c
@@ -1082,13 +1082,23 @@ static int wp_dh_import_group(wp_Dh* dh, const OSSL_PARAM params[])
     int ok = 1;
     const OSSL_PARAM* p;
     const char* name = NULL;
+    char nameBuf[WP_MAX_DH_GROUP_NAME_SZ];
 
     WOLFPROV_ENTER(WP_LOG_COMP_DH, "wp_dh_import_group");
 
     /* Look for the group name first. */
-    if (!wp_params_get_utf8_string_ptr(params, OSSL_PKEY_PARAM_GROUP_NAME,
-            &name)) {
-        ok = 0;
+    p = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_GROUP_NAME);
+    if (p != NULL) {
+        /* p->data may not be NUL-terminated; copy into a bounded buffer. */
+        if ((p->data_type != OSSL_PARAM_UTF8_STRING) || (p->data == NULL) ||
+                (p->data_size >= sizeof(nameBuf))) {
+            ok = 0;
+        }
+        else {
+            XMEMCPY(nameBuf, p->data, p->data_size);
+            nameBuf[p->data_size] = '\0';
+            name = nameBuf;
+        }
     }
     /* When name was found, set the parameters based on the mapping. */
     if (ok && (name != NULL) && (!wp_dh_map_group_name(dh, name))) {

--- a/src/wp_ecc_kmgmt.c
+++ b/src/wp_ecc_kmgmt.c
@@ -1101,11 +1101,17 @@ static int wp_ecc_import_group(wp_Ecc* ecc, const OSSL_PARAM params[])
     p = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_GROUP_NAME);
     if (p != NULL) {
         const char* name = NULL;
+        char nameBuf[WP_MAX_EC_GROUP_NAME_SZ];
 
         if (p->data_type == OSSL_PARAM_UTF8_STRING) {
-            name = (const char*)p->data;
-            if (name == NULL) {
+            /* p->data may not be NUL-terminated; copy into a bounded buffer. */
+            if ((p->data == NULL) || (p->data_size >= sizeof(nameBuf))) {
                 ok = 0;
+            }
+            else {
+                XMEMCPY(nameBuf, p->data, p->data_size);
+                nameBuf[p->data_size] = '\0';
+                name = nameBuf;
             }
         }
         else if (p->data_type == OSSL_PARAM_UTF8_PTR) {

--- a/src/wp_ecc_kmgmt.c
+++ b/src/wp_ecc_kmgmt.c
@@ -1150,6 +1150,26 @@ static int wp_ecc_import_keypair(wp_Ecc* ecc, const OSSL_PARAM params[],
             NULL))) {
         ok = 0;
     }
+    if (ok && priv) {
+        int idx = wc_ecc_get_curve_idx(ecc->curveId);
+        const ecc_set_type* dp = (idx >= 0) ? wc_ecc_get_curve_params(idx) :
+            NULL;
+        mp_int order;
+#if (!defined(HAVE_FIPS) || FIPS_VERSION_GE(5,3)) && LIBWOLFSSL_VERSION_HEX >= 0x05006002
+        mp_int* d = wc_ecc_key_get_priv(&ecc->key);
+#else
+        mp_int* d = &(ecc->key.k);
+#endif
+
+        /* Reject a private scalar outside [1, n-1] (FIPS 186-4). */
+        if ((dp != NULL) && (mp_init(&order) == MP_OKAY)) {
+            if ((mp_read_radix(&order, dp->order, 16) == MP_OKAY) &&
+                (mp_cmp(d, &order) != MP_LT)) {
+                ok = 0;
+            }
+            mp_clear(&order);
+        }
+    }
     if (ok &&
 #if (!defined(HAVE_FIPS) || FIPS_VERSION_GE(5,3)) && LIBWOLFSSL_VERSION_HEX >= 0x05006002
             (!mp_iszero(wc_ecc_key_get_priv(&ecc->key)))

--- a/src/wp_ecc_kmgmt.c
+++ b/src/wp_ecc_kmgmt.c
@@ -1168,7 +1168,7 @@ static int wp_ecc_import_keypair(wp_Ecc* ecc, const OSSL_PARAM params[],
         mp_int* d = &(ecc->key.k);
 #endif
 
-        /* Reject a private scalar >= group order n (FIPS 186-4); d == 0 is caught by the private-key gate below. Fail closed if the order is unavailable. */
+        /* Reject scalar >= order n (FIPS 186-4); fail closed if n missing. */
         if (dp == NULL) {
             ok = 0;
         }

--- a/src/wp_ecc_kmgmt.c
+++ b/src/wp_ecc_kmgmt.c
@@ -1160,6 +1160,7 @@ static int wp_ecc_import_keypair(wp_Ecc* ecc, const OSSL_PARAM params[],
         int idx = wc_ecc_get_curve_idx(ecc->curveId);
         const ecc_set_type* dp = (idx >= 0) ? wc_ecc_get_curve_params(idx) :
             NULL;
+        int orderInit = 0;
         mp_int order;
 #if (!defined(HAVE_FIPS) || FIPS_VERSION_GE(5,3)) && LIBWOLFSSL_VERSION_HEX >= 0x05006002
         mp_int* d = wc_ecc_key_get_priv(&ecc->key);
@@ -1167,12 +1168,25 @@ static int wp_ecc_import_keypair(wp_Ecc* ecc, const OSSL_PARAM params[],
         mp_int* d = &(ecc->key.k);
 #endif
 
-        /* Reject a private scalar >= group order n (FIPS 186-4); d == 0 is caught by the private-key gate below. */
-        if ((dp != NULL) && (mp_init(&order) == MP_OKAY)) {
-            if ((mp_read_radix(&order, dp->order, 16) == MP_OKAY) &&
-                (mp_cmp(d, &order) != MP_LT)) {
+        /* Reject a private scalar >= group order n (FIPS 186-4); d == 0 is caught by the private-key gate below. Fail closed if the order is unavailable. */
+        if (dp == NULL) {
+            ok = 0;
+        }
+        if (ok) {
+            if (mp_init(&order) != MP_OKAY) {
                 ok = 0;
             }
+            else {
+                orderInit = 1;
+            }
+        }
+        if (ok && (mp_read_radix(&order, dp->order, 16) != MP_OKAY)) {
+            ok = 0;
+        }
+        if (ok && (mp_cmp(d, &order) != MP_LT)) {
+            ok = 0;
+        }
+        if (orderInit) {
             mp_clear(&order);
         }
     }

--- a/src/wp_ecc_kmgmt.c
+++ b/src/wp_ecc_kmgmt.c
@@ -1167,7 +1167,7 @@ static int wp_ecc_import_keypair(wp_Ecc* ecc, const OSSL_PARAM params[],
         mp_int* d = &(ecc->key.k);
 #endif
 
-        /* Reject a private scalar outside [1, n-1] (FIPS 186-4). */
+        /* Reject a private scalar >= group order n (FIPS 186-4); d == 0 is caught by the private-key gate below. */
         if ((dp != NULL) && (mp_init(&order) == MP_OKAY)) {
             if ((mp_read_radix(&order, dp->order, 16) == MP_OKAY) &&
                 (mp_cmp(d, &order) != MP_LT)) {

--- a/src/wp_ecdsa_sig.c
+++ b/src/wp_ecdsa_sig.c
@@ -487,42 +487,33 @@ static int wp_ecdsa_setup_md(wp_EcdsaSigCtx *ctx, const char *mdName,
 
     if (mdName != NULL) {
         int rc;
+        enum wc_HashType hashType;
 
-#if LIBWOLFSSL_VERSION_HEX >= 0x05007004
-        ctx->hash.type = wp_name_to_wc_hash_type(ctx->libCtx, mdName, mdProps);
-        if ((ctx->hash.type == WC_HASH_TYPE_NONE) ||
-            (ctx->hash.type == WC_HASH_TYPE_MD5))
-#else
-        ctx->hashType = wp_name_to_wc_hash_type(ctx->libCtx, mdName, mdProps);
-        if ((ctx->hashType == WC_HASH_TYPE_NONE) ||
-            (ctx->hashType == WC_HASH_TYPE_MD5))
-#endif
-        {
+        hashType = wp_name_to_wc_hash_type(ctx->libCtx, mdName, mdProps);
+        if ((hashType == WC_HASH_TYPE_NONE) ||
+            (hashType == WC_HASH_TYPE_MD5)) {
             ok = 0;
         }
 #ifdef HAVE_FIPS
-#if LIBWOLFSSL_VERSION_HEX >= 0x05007004
-        if ((ctx->hash.type == WC_HASH_TYPE_SHA) && (op == EVP_PKEY_OP_SIGN))
-#else
-        if ((ctx->hashType == WC_HASH_TYPE_SHA) && (op == EVP_PKEY_OP_SIGN))
-#endif
-        {
+        if (ok && (hashType == WC_HASH_TYPE_SHA) &&
+            (op == EVP_PKEY_OP_SIGN)) {
             ok = 0;
         }
 #endif
 
         if (ok) {
-#if LIBWOLFSSL_VERSION_HEX >= 0x05007004
-            rc = wc_HashInit_ex(&ctx->hash, ctx->hash.type, NULL, INVALID_DEVID);
-#else
-            rc = wc_HashInit_ex(&ctx->hash, ctx->hashType, NULL, INVALID_DEVID);
-#endif
+            rc = wc_HashInit_ex(&ctx->hash, hashType, NULL, INVALID_DEVID);
             if (rc != 0) {
                 WOLFPROV_MSG_DEBUG_RETCODE(WP_LOG_LEVEL_DEBUG, "wc_HashInit_ex", rc);
                 ok = 0;
             }
         }
         if (ok) {
+#if LIBWOLFSSL_VERSION_HEX >= 0x05007004
+            ctx->hash.type = hashType;
+#else
+            ctx->hashType = hashType;
+#endif
             OPENSSL_strlcpy(ctx->mdName, mdName, sizeof(ctx->mdName));
         }
     }

--- a/src/wp_ecx_kmgmt.c
+++ b/src/wp_ecx_kmgmt.c
@@ -975,6 +975,9 @@ static int wp_ecx_import(wp_Ecx* ecx, int selection, const OSSL_PARAM params[])
             &privData, &len)) {
             ok = 0;
         }
+        if (ok && (privData != NULL) && (len == 0)) {
+            ok = 0;
+        }
         if (ok && (privData != NULL)) {
             ecx->unclamped[0] = privData[0];
             ecx->unclamped[1] = privData[len - 1];

--- a/src/wp_hmac.c
+++ b/src/wp_hmac.c
@@ -122,17 +122,26 @@ static int wp_hmac_set_key(wp_HmacCtx* macCtx, const unsigned char* key,
     size_t keyLen, int restart)
 {
     int ok = 1;
-    word32 blockSize = wc_HashGetBlockSize(macCtx->type);
+    int blockSizeRet = wc_HashGetBlockSize(macCtx->type);
+    word32 blockSize = 0;
 
     WOLFPROV_ENTER(WP_LOG_COMP_MAC, "wp_hmac_set_key");
 
     WP_CHECK_FIPS_ALGO(WP_CAST_ALGO_HMAC);
 
-    if (macCtx->keyLen > 0) {
+    /* wc_HashGetBlockSize returns a negative error when no digest is set. */
+    if (blockSizeRet <= 0) {
+        ok = 0;
+    }
+    else {
+        blockSize = (word32)blockSizeRet;
+    }
+
+    if (ok && (macCtx->keyLen > 0)) {
         OPENSSL_secure_clear_free(macCtx->key, macCtx->keyLen);
     }
 
-    if (keyLen < blockSize) {
+    if (ok && (keyLen < blockSize)) {
         /* wolfSSL FIPS needs a key that is at least block size in length with
          * the unused parts zeroed out.
          */
@@ -145,7 +154,7 @@ static int wp_hmac_set_key(wp_HmacCtx* macCtx, const unsigned char* key,
             ok = 0;
         }
     }
-    else {
+    else if (ok) {
         macCtx->keyLen = keyLen;
         macCtx->key = OPENSSL_secure_malloc(keyLen);
         if (macCtx->key == NULL) {

--- a/src/wp_hmac.c
+++ b/src/wp_hmac.c
@@ -102,7 +102,7 @@ static void wp_hmac_free(wp_HmacCtx* macCtx)
     if (macCtx != NULL) {
         wc_HmacFree(&macCtx->hmac);
         OPENSSL_secure_clear_free(macCtx->key, macCtx->keyLen);
-        OPENSSL_free(macCtx);
+        OPENSSL_clear_free(macCtx, sizeof(*macCtx));
     }
 }
 

--- a/src/wp_internal.c
+++ b/src/wp_internal.c
@@ -1212,7 +1212,7 @@ int wp_read_der_bio(WOLFPROV_CTX *provctx, OSSL_CORE_BIO *coreBio, unsigned char
             ok = 0;
         }
         if (ok && (readLen > 0) &&
-                ((size_t)*len + (size_t)readLen > UINT32_MAX)) {
+                ((uint64_t)*len + (uint64_t)readLen > (uint64_t)UINT32_MAX)) {
             ok = 0;
         }
         if (ok && (readLen > 0)) {

--- a/src/wp_internal.c
+++ b/src/wp_internal.c
@@ -1074,6 +1074,9 @@ int wp_encrypt_key(WOLFPROV_CTX* provCtx, const char* cipherName,
     if (!pwCb(password, passwordSz, &passwordSz, NULL, pwCbArg)) {
         ok = 0;
     }
+    if (ok && (passwordSz > sizeof(password))) {
+        ok = 0;
+    }
     if (ok) {
         XMEMSET(info, 0, sizeof(info));
         XSTRNCPY(info->name, cipherName, NAME_SZ-1);

--- a/src/wp_internal.c
+++ b/src/wp_internal.c
@@ -1003,6 +1003,7 @@ static int wp_BufferKeyEncrypt(wp_EncryptedInfo* info, byte* der, word32 derSz,
 #ifndef NO_PWDBASED
     if ((ret = wc_PBKDF1(key, password, passwordSz, info->iv, PKCS5_SALT_SZ, 1,
                                         info->keySz, hashType)) != 0) {
+        ForceZero(key, WC_MAX_SYM_KEY_SIZE);
 #ifdef WOLFSSL_SMALL_STACK
         XFREE(key, NULL, DYNAMIC_TYPE_SYMMETRIC_KEY);
 #endif
@@ -1022,6 +1023,7 @@ static int wp_BufferKeyEncrypt(wp_EncryptedInfo* info, byte* der, word32 derSz,
             info->iv);
 #endif /* !NO_AES && HAVE_AES_CBC */
 
+    ForceZero(key, WC_MAX_SYM_KEY_SIZE);
 #ifdef WOLFSSL_SMALL_STACK
     XFREE(key, NULL, DYNAMIC_TYPE_SYMMETRIC_KEY);
 #endif

--- a/src/wp_internal.c
+++ b/src/wp_internal.c
@@ -39,8 +39,20 @@
 #ifndef WP_SINGLE_THREADED
 
 #if defined(WP_HAVE_SEED_SRC) && defined(WP_HAVE_RANDOM)
+#if !defined(WP_SINGLE_THREADED) && !defined(_WIN32)
+#include <pthread.h>
+#endif
 /* Global mutex for urandom file access (used by seed callback) */
 static wolfSSL_Mutex urandomMutex;
+
+#if !defined(WP_SINGLE_THREADED) && !defined(_WIN32)
+/* Re-init the mutex in a forked child so an inherited locked mutex cannot
+ * deadlock entropy reads. */
+static void wolfprov_urandom_atfork_child(void)
+{
+    wc_InitMutex(&urandomMutex);
+}
+#endif
 
 /**
  * Initialize the urandom mutex on library load.
@@ -52,6 +64,9 @@ __attribute__((constructor))
 static void wolfprov_init_urandom_mutex(void)
 {
     wc_InitMutex(&urandomMutex);
+#if !defined(WP_SINGLE_THREADED) && !defined(_WIN32)
+    (void)pthread_atfork(NULL, NULL, wolfprov_urandom_atfork_child);
+#endif
 }
 
 /**

--- a/src/wp_internal.c
+++ b/src/wp_internal.c
@@ -1196,6 +1196,10 @@ int wp_read_der_bio(WOLFPROV_CTX *provctx, OSSL_CORE_BIO *coreBio, unsigned char
             WOLFPROV_MSG(WP_LOG_COMP_PROVIDER, "BIO_read error (%d) in %s:%d", readLen, __FILE__, __LINE__);
             ok = 0;
         }
+        if (ok && (readLen > 0) &&
+                ((size_t)*len + (size_t)readLen > UINT32_MAX)) {
+            ok = 0;
+        }
         if (ok && (readLen > 0)) {
             /* Reallocate for new data. */
             p = OPENSSL_realloc(*data, *len + readLen);

--- a/src/wp_kdf_exch.c
+++ b/src/wp_kdf_exch.c
@@ -119,28 +119,10 @@ static void wp_kdf_ctx_free(wp_KdfCtx* ctx)
  */
 static wp_KdfCtx* wp_kdf_ctx_dup(wp_KdfCtx* src)
 {
-    wp_KdfCtx* dst = NULL;
-
-    if (wolfssl_prov_is_running()) {
-        dst = wp_kdf_ctx_new(src->provCtx, src->name);
-    }
-    if (dst != NULL) {
-        int ok = 1;
-
-        if ((src->key != NULL) && (!wp_kdf_up_ref(src->key))) {
-            ok = 0;
-        }
-        if (ok) {
-            dst->key = src->key;
-        }
-
-        if (!ok) {
-            wp_kdf_ctx_free(dst);
-            dst = NULL;
-        }
-    }
-
-    return dst;
+    /* The inner EVP_KDF_CTX state cannot be duplicated faithfully, so report
+     * that duplication is unsupported rather than return an empty context. */
+    (void)src;
+    return NULL;
 }
 
 /**

--- a/src/wp_params.c
+++ b/src/wp_params.c
@@ -465,7 +465,8 @@ int wp_params_get_utf8_string(const OSSL_PARAM* params, const char* key,
         ok = 0;
     }
     if ((p != NULL) && ok) {
-        XSTRNCPY(str, p->data, len);
+        XMEMCPY(str, p->data, p->data_size);
+        str[p->data_size] = '\0';
     }
 
     WOLFPROV_LEAVE(WP_LOG_COMP_PROVIDER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);

--- a/src/wp_params.c
+++ b/src/wp_params.c
@@ -461,7 +461,7 @@ int wp_params_get_utf8_string(const OSSL_PARAM* params, const char* key,
     if ((p != NULL) && (p->data_type != OSSL_PARAM_UTF8_STRING)) {
         ok = 0;
     }
-    if ((p != NULL) && ok && (p->data_size > len)) {
+    if ((p != NULL) && ok && (p->data_size >= len)) {
         ok = 0;
     }
     if ((p != NULL) && ok) {

--- a/src/wp_pbkdf2.c
+++ b/src/wp_pbkdf2.c
@@ -435,6 +435,10 @@ static int wp_kdf_pkcs12_derive(wp_Pbkdf2Ctx* ctx, unsigned char* key,
     if (ok && ((ctx->keyUse < 1) || (ctx->keyUse > 3))) {
         ok = 0;
     }
+    /* Reject iteration counts that would truncate in the int cast below. */
+    if (ok && (ctx->iterations > (uint64_t)INT_MAX)) {
+        ok = 0;
+    }
 
     if (ok) {
         int rc;

--- a/src/wp_pbkdf2.c
+++ b/src/wp_pbkdf2.c
@@ -431,6 +431,10 @@ static int wp_kdf_pkcs12_derive(wp_Pbkdf2Ctx* ctx, unsigned char* key,
     if (ok && (keyLen == 0)) {
         ok = 0;
     }
+    /* RFC 7292 diversifier id is 1 (key), 2 (IV) or 3 (MAC). */
+    if (ok && ((ctx->keyUse < 1) || (ctx->keyUse > 3))) {
+        ok = 0;
+    }
 
     if (ok) {
         int rc;

--- a/src/wp_pbkdf2.c
+++ b/src/wp_pbkdf2.c
@@ -18,6 +18,7 @@
  * along with wolfProvider. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <limits.h>
 #include <string.h>
 
 #include <openssl/core_dispatch.h>
@@ -296,6 +297,11 @@ static int wp_kdf_pbkdf2_derive(wp_Pbkdf2Ctx* ctx, unsigned char* key,
         }
     }
     /* wc_PBKDF2_ex fails when ctx->iterations is 0. */
+
+    /* Reject iteration counts that would truncate in the int cast below. */
+    if (ok && (ctx->iterations > (uint64_t)INT_MAX)) {
+        ok = 0;
+    }
 
     if (ok) {
         int rc;

--- a/src/wp_rsa_kmgmt.c
+++ b/src/wp_rsa_kmgmt.c
@@ -2500,6 +2500,9 @@ static int wp_rsa_decode_enc_pki(wp_Rsa* rsa, unsigned char* data, word32 len,
     if (ok && !pwCb(password, passwordSz, &passwordSz, NULL, pwCbArg)) {
         ok = 0;
     }
+    if (ok && (passwordSz > sizeof(password))) {
+        ok = 0;
+    }
     if (ok) {
         /* Decrypt to encoded private key. */
         int ret = wc_DecryptPKCS8Key(data, len, password, (int)passwordSz);

--- a/src/wp_rsa_kmgmt.c
+++ b/src/wp_rsa_kmgmt.c
@@ -2818,8 +2818,8 @@ int wp_rsa_pss_encode_alg_id(const wp_Rsa* rsa, const char* mdName,
         else {
             if (pssAlgId != NULL) {
                 XMEMCPY(pssAlgId + i, saltLenDer2, sizeof(saltLenDer2));
-                pssAlgId[i + sizeof(saltLenDer2)] = 0;
-                pssAlgId[i + sizeof(saltLenDer2) + 1] = saltLen;
+                pssAlgId[i + sizeof(saltLenDer2)] = (byte)(saltLen >> 8);
+                pssAlgId[i + sizeof(saltLenDer2) + 1] = (byte)(saltLen & 0xff);
                 pssAlgId[seq1LenIdx] += sizeof(saltLenDer2) + 2;
                 pssAlgId[seq2LenIdx] += sizeof(saltLenDer2) + 2;
             }

--- a/src/wp_wolfprov.c
+++ b/src/wp_wolfprov.c
@@ -1389,6 +1389,7 @@ int wolfssl_provider_init(const OSSL_CORE_HANDLE* handle,
     const OSSL_DISPATCH* in, const OSSL_DISPATCH** out, void** provCtx)
 {
     int ok = 1;
+    const OSSL_DISPATCH* origIn = in;
 
     wolfProv_LogInit();
 
@@ -1480,7 +1481,7 @@ int wolfssl_provider_init(const OSSL_CORE_HANDLE* handle,
          * uninitialized libctx in certain init flows. Instead create
          * a new child libctx. The child libctx being NULL is allowed. */
         wolfssl_prov_ctx_set0_lib_ctx(*provCtx,
-            OSSL_LIB_CTX_new_child(handle, in));
+            OSSL_LIB_CTX_new_child(handle, origIn));
         /* Cache the handle in provider context. */
         wolfssl_prov_ctx_set0_handle(*provCtx, handle);
 

--- a/test/test_dh.c
+++ b/test/test_dh.c
@@ -1331,4 +1331,55 @@ int test_dh_fromdata_oversize(void *data)
     return err;
 }
 
+/*
+ * Explicit FFC domain parameters with a composite modulus must be rejected by
+ * EVP_PKEY_param_check (the explicit-parameter path was previously a no-op).
+ */
+int test_dh_param_check_explicit(void *data)
+{
+    int err = 0;
+    EVP_PKEY_CTX *ctx = NULL;
+    EVP_PKEY_CTX *checkCtx = NULL;
+    EVP_PKEY *pkey = NULL;
+    OSSL_PARAM params[3];
+    unsigned char p_composite[256];
+    unsigned char g_buf[1] = { 0x02 };
+
+    (void)data;
+
+    /* 2048-bit even value: composite, so not a valid DH modulus. */
+    memset(p_composite, 0xFF, sizeof(p_composite));
+    p_composite[sizeof(p_composite) - 1] = 0xFE;
+
+    ctx = EVP_PKEY_CTX_new_from_name(wpLibCtx, "DH", NULL);
+    if (ctx == NULL) {
+        err = 1;
+    }
+    if (err == 0) {
+        err = EVP_PKEY_fromdata_init(ctx) != 1;
+    }
+    if (err == 0) {
+        params[0] = OSSL_PARAM_construct_BN(OSSL_PKEY_PARAM_FFC_P,
+                                            p_composite, sizeof(p_composite));
+        params[1] = OSSL_PARAM_construct_BN(OSSL_PKEY_PARAM_FFC_G,
+                                            g_buf, sizeof(g_buf));
+        params[2] = OSSL_PARAM_construct_end();
+        err = EVP_PKEY_fromdata(ctx, &pkey, EVP_PKEY_KEY_PARAMETERS,
+                                params) != 1;
+    }
+    if (err == 0) {
+        checkCtx = EVP_PKEY_CTX_new_from_pkey(wpLibCtx, pkey, NULL);
+        err = checkCtx == NULL;
+    }
+    if (err == 0 && EVP_PKEY_param_check(checkCtx) == 1) {
+        PRINT_ERR_MSG("param_check accepted a composite DH modulus");
+        err = 1;
+    }
+
+    EVP_PKEY_CTX_free(checkCtx);
+    EVP_PKEY_free(pkey);
+    EVP_PKEY_CTX_free(ctx);
+    return err;
+}
+
 #endif /* WP_HAVE_DH */

--- a/test/test_dh.c
+++ b/test/test_dh.c
@@ -1382,4 +1382,50 @@ int test_dh_param_check_explicit(void *data)
     return err;
 }
 
+/*
+ * A non-NUL-terminated GROUP_NAME param must not cause an out-of-bounds read
+ * in the DH group-name comparison.
+ */
+int test_dh_import_group_no_nul(void *data)
+{
+    int err = 0;
+    EVP_PKEY_CTX *ctx = NULL;
+    EVP_PKEY *pkey = NULL;
+    OSSL_PARAM params[2];
+    char *name = NULL;
+
+    (void)data;
+
+    name = OPENSSL_malloc(9);
+    if (name == NULL) {
+        err = 1;
+    }
+    if (err == 0) {
+        memcpy(name, "ffdhe2048", 9);
+        ctx = EVP_PKEY_CTX_new_from_name(wpLibCtx, "DH", NULL);
+        err = ctx == NULL;
+    }
+    if (err == 0) {
+        err = EVP_PKEY_fromdata_init(ctx) != 1;
+    }
+    if (err == 0) {
+        params[0].key = OSSL_PKEY_PARAM_GROUP_NAME;
+        params[0].data_type = OSSL_PARAM_UTF8_STRING;
+        params[0].data = name;
+        params[0].data_size = 9;
+        params[0].return_size = 0;
+        params[1] = OSSL_PARAM_construct_end();
+        if (EVP_PKEY_fromdata(ctx, &pkey, EVP_PKEY_KEY_PARAMETERS,
+                params) != 1) {
+            PRINT_ERR_MSG("DH group import failed for valid group name");
+            err = 1;
+        }
+    }
+
+    EVP_PKEY_free(pkey);
+    EVP_PKEY_CTX_free(ctx);
+    OPENSSL_free(name);
+    return err;
+}
+
 #endif /* WP_HAVE_DH */

--- a/test/test_dh.c
+++ b/test/test_dh.c
@@ -1347,9 +1347,9 @@ int test_dh_param_check_explicit(void *data)
 
     (void)data;
 
-    /* 2048-bit even value: composite, so not a valid DH modulus. */
+    /* Even modulus (byte 0 = LSB, FFC_P parsed little-endian): composite. */
     memset(p_composite, 0xFF, sizeof(p_composite));
-    p_composite[sizeof(p_composite) - 1] = 0xFE;
+    p_composite[0] = 0xFE;
 
     ctx = EVP_PKEY_CTX_new_from_name(wpLibCtx, "DH", NULL);
     if (ctx == NULL) {

--- a/test/test_ecc.c
+++ b/test/test_ecc.c
@@ -21,6 +21,7 @@
 #include "unit.h"
 
 #include <openssl/store.h>
+#include <openssl/decoder.h>
 #include <openssl/core_names.h>
 #include <openssl/param_build.h>
 
@@ -2675,6 +2676,40 @@ static int test_ec_import_group_no_nul(void)
     EVP_PKEY_free(pkey);
     EVP_PKEY_CTX_free(ctx);
     OPENSSL_free(name);
+    return err;
+}
+
+/*
+ * A truncated PEM (header only) must be rejected without an out-of-bounds read
+ * in wp_pem2der_convert (base64Data past the buffer / base64Len underflow).
+ */
+int test_ec_decode_short_pem(void *data)
+{
+    int err = 0;
+    OSSL_DECODER_CTX *dctx = NULL;
+    EVP_PKEY *pkey = NULL;
+    static const char shortPem[] = "-----BEGIN EC PARAMETERS-----\n";
+    const unsigned char *p = (const unsigned char *)shortPem;
+    size_t pLen = sizeof(shortPem) - 1;
+
+    (void)data;
+
+    dctx = OSSL_DECODER_CTX_new_for_pkey(&pkey, "PEM", NULL, "EC",
+        EVP_PKEY_KEY_PARAMETERS, wpLibCtx, NULL);
+    if (dctx == NULL) {
+        err = 1;
+    }
+    if (err == 0) {
+        /* Truncated PEM simply fails to decode; must not read out of bounds. */
+        (void)OSSL_DECODER_from_data(dctx, &p, &pLen);
+        if (pkey != NULL) {
+            PRINT_ERR_MSG("Truncated PEM unexpectedly produced a key");
+            err = 1;
+        }
+    }
+
+    OSSL_DECODER_CTX_free(dctx);
+    EVP_PKEY_free(pkey);
     return err;
 }
 

--- a/test/test_ecc.c
+++ b/test/test_ecc.c
@@ -2633,6 +2633,51 @@ static int test_ec_import_priv_out_of_range(void)
     return err;
 }
 
+/*
+ * A non-NUL-terminated GROUP_NAME UTF8_STRING param must not cause an
+ * out-of-bounds read in the group-name comparison.
+ */
+static int test_ec_import_group_no_nul(void)
+{
+    int err = 0;
+    EVP_PKEY_CTX *ctx = NULL;
+    EVP_PKEY *pkey = NULL;
+    OSSL_PARAM params[2];
+    char *name = NULL;
+
+    /* "prime256v1" with no NUL terminator, sized exactly. */
+    name = OPENSSL_malloc(10);
+    if (name == NULL) {
+        err = 1;
+    }
+    if (err == 0) {
+        memcpy(name, "prime256v1", 10);
+        ctx = EVP_PKEY_CTX_new_from_name(wpLibCtx, "EC", NULL);
+        err = ctx == NULL;
+    }
+    if (err == 0) {
+        err = EVP_PKEY_fromdata_init(ctx) != 1;
+    }
+    if (err == 0) {
+        params[0].key = OSSL_PKEY_PARAM_GROUP_NAME;
+        params[0].data_type = OSSL_PARAM_UTF8_STRING;
+        params[0].data = name;
+        params[0].data_size = 10;
+        params[0].return_size = 0;
+        params[1] = OSSL_PARAM_construct_end();
+        if (EVP_PKEY_fromdata(ctx, &pkey, EVP_PKEY_KEY_PARAMETERS,
+                params) != 1) {
+            PRINT_ERR_MSG("EC group import failed for valid curve name");
+            err = 1;
+        }
+    }
+
+    EVP_PKEY_free(pkey);
+    EVP_PKEY_CTX_free(ctx);
+    OPENSSL_free(name);
+    return err;
+}
+
 int test_ec_import(void* data)
 {
     int err = 0;
@@ -2644,6 +2689,9 @@ int test_ec_import(void* data)
     }
     if (err == 0) {
         err = test_ec_import_priv_out_of_range();
+    }
+    if (err == 0) {
+        err = test_ec_import_group_no_nul();
     }
 
     return err;

--- a/test/test_ecc.c
+++ b/test/test_ecc.c
@@ -1622,6 +1622,54 @@ int test_ecdsa_verify_md_len_mismatch(void *data)
 
     return err;
 }
+
+/*
+ * A digest rejected by wp_ecdsa_setup_md (e.g. MD5) must not overwrite the
+ * previously configured digest. After the failed set, the context still
+ * enforces SHA-256's 32-byte size, so a raw sign of a 16-byte input fails.
+ */
+int test_ecdsa_setup_md_reject_atomic(void *data)
+{
+    int err = 0;
+    EVP_PKEY *pkey = NULL;
+    EVP_PKEY_CTX *ctx = NULL;
+    const unsigned char *p = ecc_key_der_256;
+    unsigned char digest[32];
+    unsigned char sig[80];
+    size_t sigLen = sizeof(sig);
+
+    (void)data;
+
+    memset(digest, 0x5A, sizeof(digest));
+
+    pkey = d2i_PrivateKey(EVP_PKEY_EC, NULL, &p, sizeof(ecc_key_der_256));
+    if (pkey == NULL) {
+        err = 1;
+    }
+    if (err == 0) {
+        ctx = EVP_PKEY_CTX_new_from_pkey(wpLibCtx, pkey, NULL);
+        err = ctx == NULL;
+    }
+    if (err == 0) {
+        err = EVP_PKEY_sign_init(ctx) <= 0;
+    }
+    if (err == 0) {
+        err = EVP_PKEY_CTX_set_signature_md(ctx, EVP_sha256()) <= 0;
+    }
+    if (err == 0 && EVP_PKEY_CTX_set_signature_md(ctx, EVP_md5()) > 0) {
+        PRINT_ERR_MSG("MD5 unexpectedly accepted for ECDSA");
+        err = 1;
+    }
+    if (err == 0 && EVP_PKEY_sign(ctx, sig, &sigLen, digest, 16) > 0) {
+        PRINT_ERR_MSG("ECDSA signed a 16-byte input after a rejected digest");
+        err = 1;
+    }
+
+    EVP_PKEY_CTX_free(ctx);
+    EVP_PKEY_free(pkey);
+
+    return err;
+}
 #endif /* WP_HAVE_EC_P256 */
 
 #ifdef WP_HAVE_EC_P384

--- a/test/test_ecc.c
+++ b/test/test_ecc.c
@@ -2578,6 +2578,61 @@ static int test_ec_import_pub(void)
     return err;
 }
 
+/*
+ * A private scalar equal to the curve order n is outside [1, n-1] and must be
+ * rejected on import (FIPS 186-4).
+ */
+static int test_ec_import_priv_out_of_range(void)
+{
+    int err = 0;
+    EVP_PKEY_CTX *ctx = NULL;
+    EVP_PKEY *pkey = NULL;
+    OSSL_PARAM *params = NULL;
+    OSSL_PARAM_BLD *bld = NULL;
+    BIGNUM *priv = NULL;
+    /* P-256 group order n. */
+    static const unsigned char p256_order[] = {
+        0xff, 0xff, 0xff, 0xff, 0x00, 0x00, 0x00, 0x00,
+        0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+        0xbc, 0xe6, 0xfa, 0xad, 0xa7, 0x17, 0x9e, 0x84,
+        0xf3, 0xb9, 0xca, 0xc2, 0xfc, 0x63, 0x25, 0x51
+    };
+
+    err = (bld = OSSL_PARAM_BLD_new()) == NULL;
+    if (err == 0) {
+        err = OSSL_PARAM_BLD_push_utf8_string(bld, OSSL_PKEY_PARAM_GROUP_NAME,
+                ecc_p256_group_str, 0) != 1;
+    }
+    if (err == 0) {
+        err = (priv = BN_bin2bn(p256_order, sizeof(p256_order), NULL)) == NULL;
+    }
+    if (err == 0) {
+        err = OSSL_PARAM_BLD_push_BN(bld, OSSL_PKEY_PARAM_PRIV_KEY, priv) != 1;
+    }
+    if (err == 0) {
+        err = (params = OSSL_PARAM_BLD_to_param(bld)) == NULL;
+    }
+    if (err == 0) {
+        err = (ctx = EVP_PKEY_CTX_new_from_name(wpLibCtx, "EC", NULL)) == NULL;
+    }
+    if (err == 0) {
+        err = EVP_PKEY_fromdata_init(ctx) != 1;
+    }
+    if (err == 0 &&
+            EVP_PKEY_fromdata(ctx, &pkey, EVP_PKEY_KEYPAIR, params) == 1) {
+        PRINT_ERR_MSG("EC import accepted private scalar d == n");
+        err = 1;
+    }
+
+    EVP_PKEY_free(pkey);
+    EVP_PKEY_CTX_free(ctx);
+    OSSL_PARAM_free(params);
+    OSSL_PARAM_BLD_free(bld);
+    BN_free(priv);
+
+    return err;
+}
+
 int test_ec_import(void* data)
 {
     int err = 0;
@@ -2586,6 +2641,9 @@ int test_ec_import(void* data)
     err = test_ec_import_priv();
     if (err == 0) {
         err = test_ec_import_pub();
+    }
+    if (err == 0) {
+        err = test_ec_import_priv_out_of_range();
     }
 
     return err;

--- a/test/test_ecx.c
+++ b/test/test_ecx.c
@@ -758,6 +758,45 @@ int test_ecx_x25519_raw_priv_roundtrip(void *data)
     EVP_PKEY_free(pkey);
     return err;
 }
+
+/* A zero-length private key octet string must be rejected without an
+ * out-of-bounds read (privData[len-1] with len==0). */
+int test_ecx_import_zero_priv(void *data)
+{
+    int err = 0;
+    EVP_PKEY_CTX *ctx = NULL;
+    EVP_PKEY *pkey = NULL;
+    unsigned char *buf = NULL;
+    OSSL_PARAM params[2];
+
+    (void)data;
+
+    buf = OPENSSL_malloc(1);
+    if (buf == NULL) {
+        err = 1;
+    }
+    if (err == 0) {
+        ctx = EVP_PKEY_CTX_new_from_name(wpLibCtx, "X25519", NULL);
+        err = ctx == NULL;
+    }
+    if (err == 0) {
+        err = EVP_PKEY_fromdata_init(ctx) != 1;
+    }
+    if (err == 0) {
+        params[0] = OSSL_PARAM_construct_octet_string(OSSL_PKEY_PARAM_PRIV_KEY,
+            buf, 0);
+        params[1] = OSSL_PARAM_construct_end();
+        if (EVP_PKEY_fromdata(ctx, &pkey, EVP_PKEY_KEYPAIR, params) == 1) {
+            PRINT_ERR_MSG("X25519 import accepted zero-length private key");
+            err = 1;
+        }
+    }
+
+    EVP_PKEY_free(pkey);
+    EVP_PKEY_CTX_free(ctx);
+    OPENSSL_free(buf);
+    return err;
+}
 #endif /* WP_HAVE_X25519 */
 
 int test_ecx_dup(void *data)

--- a/test/test_hkdf.c
+++ b/test/test_hkdf.c
@@ -614,22 +614,13 @@ static int test_hkdf_extract_only_bad_len(OSSL_LIB_CTX *libCtx)
 #define NUM_MODES     3
 
 #ifdef WP_HAVE_SHA256
-/*
- * A duplicated HKDF context must carry the full KDF state, not just the key
- * reference, so a derive from the dup produces the same key as the original.
- */
-static int test_hkdf_dup_calc(void)
+/* HKDF ctx dup is unsupported: it must return NULL, not a broken context. */
+static int test_hkdf_dup_unsupported(void)
 {
     int err = 0;
     EVP_PKEY_CTX *ctx = NULL;
     EVP_PKEY_CTX *dupCtx = NULL;
     unsigned char inKey[32] = { 0, };
-    unsigned char salt[32] = { 0, };
-    unsigned char info[32] = { 0, };
-    unsigned char key1[32];
-    unsigned char key2[32];
-    size_t len1 = sizeof(key1);
-    size_t len2 = sizeof(key2);
 
     ctx = EVP_PKEY_CTX_new_from_name(wpLibCtx, "HKDF", NULL);
     if (ctx == NULL) {
@@ -645,26 +636,9 @@ static int test_hkdf_dup_calc(void)
         err = EVP_PKEY_CTX_set1_hkdf_key(ctx, inKey, sizeof(inKey)) != 1;
     }
     if (err == 0) {
-        err = EVP_PKEY_CTX_set1_hkdf_salt(ctx, salt, sizeof(salt)) != 1;
-    }
-    if (err == 0) {
-        err = EVP_PKEY_CTX_add1_hkdf_info(ctx, info, sizeof(info)) != 1;
-    }
-    if (err == 0) {
-        /* Dup may be unsupported (NULL); but a returned ctx must carry the
-         * full state, not derive a wrong/empty key. */
         dupCtx = EVP_PKEY_CTX_dup(ctx);
-    }
-    if (err == 0) {
-        err = EVP_PKEY_derive(ctx, key1, &len1) != 1;
-    }
-    if (err == 0 && dupCtx != NULL) {
-        if (EVP_PKEY_derive(dupCtx, key2, &len2) != 1) {
-            PRINT_ERR_MSG("Duplicated HKDF ctx failed to derive");
-            err = 1;
-        }
-        else if (len1 != len2 || memcmp(key1, key2, len1) != 0) {
-            PRINT_ERR_MSG("Duplicated HKDF ctx produced a different key");
+        if (dupCtx != NULL) {
+            PRINT_ERR_MSG("HKDF ctx dup unexpectedly returned a context");
             err = 1;
         }
     }
@@ -717,7 +691,7 @@ int test_hkdf(void *data)
     }
 #ifdef WP_HAVE_SHA256
     if (err == 0) {
-        err = test_hkdf_dup_calc();
+        err = test_hkdf_dup_unsupported();
     }
 #endif
 

--- a/test/test_hkdf.c
+++ b/test/test_hkdf.c
@@ -613,6 +613,68 @@ static int test_hkdf_extract_only_bad_len(OSSL_LIB_CTX *libCtx)
 
 #define NUM_MODES     3
 
+#ifdef WP_HAVE_SHA256
+/*
+ * A duplicated HKDF context must carry the full KDF state, not just the key
+ * reference, so a derive from the dup produces the same key as the original.
+ */
+static int test_hkdf_dup_calc(void)
+{
+    int err = 0;
+    EVP_PKEY_CTX *ctx = NULL;
+    EVP_PKEY_CTX *dupCtx = NULL;
+    unsigned char inKey[32] = { 0, };
+    unsigned char salt[32] = { 0, };
+    unsigned char info[32] = { 0, };
+    unsigned char key1[32];
+    unsigned char key2[32];
+    size_t len1 = sizeof(key1);
+    size_t len2 = sizeof(key2);
+
+    ctx = EVP_PKEY_CTX_new_from_name(wpLibCtx, "HKDF", NULL);
+    if (ctx == NULL) {
+        err = 1;
+    }
+    if (err == 0) {
+        err = EVP_PKEY_derive_init(ctx) != 1;
+    }
+    if (err == 0) {
+        err = EVP_PKEY_CTX_set_hkdf_md(ctx, EVP_sha256()) != 1;
+    }
+    if (err == 0) {
+        err = EVP_PKEY_CTX_set1_hkdf_key(ctx, inKey, sizeof(inKey)) != 1;
+    }
+    if (err == 0) {
+        err = EVP_PKEY_CTX_set1_hkdf_salt(ctx, salt, sizeof(salt)) != 1;
+    }
+    if (err == 0) {
+        err = EVP_PKEY_CTX_add1_hkdf_info(ctx, info, sizeof(info)) != 1;
+    }
+    if (err == 0) {
+        /* Dup may be unsupported (NULL); but a returned ctx must carry the
+         * full state, not derive a wrong/empty key. */
+        dupCtx = EVP_PKEY_CTX_dup(ctx);
+    }
+    if (err == 0) {
+        err = EVP_PKEY_derive(ctx, key1, &len1) != 1;
+    }
+    if (err == 0 && dupCtx != NULL) {
+        if (EVP_PKEY_derive(dupCtx, key2, &len2) != 1) {
+            PRINT_ERR_MSG("Duplicated HKDF ctx failed to derive");
+            err = 1;
+        }
+        else if (len1 != len2 || memcmp(key1, key2, len1) != 0) {
+            PRINT_ERR_MSG("Duplicated HKDF ctx produced a different key");
+            err = 1;
+        }
+    }
+
+    EVP_PKEY_CTX_free(dupCtx);
+    EVP_PKEY_CTX_free(ctx);
+    return err;
+}
+#endif /* WP_HAVE_SHA256 */
+
 int test_hkdf(void *data)
 {
     int err = 0;
@@ -653,6 +715,11 @@ int test_hkdf(void *data)
     if (err == 0) {
         err = test_hkdf_extract_only_bad_len(wpLibCtx);
     }
+#ifdef WP_HAVE_SHA256
+    if (err == 0) {
+        err = test_hkdf_dup_calc();
+    }
+#endif
 
     return err;
 }

--- a/test/test_hmac.c
+++ b/test/test_hmac.c
@@ -295,6 +295,39 @@ int test_hmac_create(void *data)
     return ret;
 }
 
+/* HMAC init with a key but no digest must fail cleanly, not size the key
+ * buffer from a negative wc_HashGetBlockSize() (~4 GiB allocation). */
+int test_hmac_key_no_digest(void *data)
+{
+    int err = 0;
+    EVP_MAC *emac = NULL;
+    EVP_MAC_CTX *mctx = NULL;
+    unsigned char key[16];
+
+    (void)data;
+
+    memset(key, 0x0B, sizeof(key));
+
+    emac = EVP_MAC_fetch(wpLibCtx, "HMAC", NULL);
+    if (emac == NULL) {
+        err = 1;
+    }
+    if (err == 0) {
+        mctx = EVP_MAC_CTX_new(emac);
+        err = mctx == NULL;
+    }
+    if (err == 0) {
+        if (EVP_MAC_init(mctx, key, sizeof(key), NULL) == 1) {
+            PRINT_ERR_MSG("HMAC init succeeded without a digest");
+            err = 1;
+        }
+    }
+
+    EVP_MAC_CTX_free(mctx);
+    EVP_MAC_free(emac);
+    return err;
+}
+
 /******************************************************************************/
 
 /**

--- a/test/test_pbkdf2.c
+++ b/test/test_pbkdf2.c
@@ -275,6 +275,45 @@ static int test_pbkdf2_bounds(void)
     return err;
 }
 
+/*
+ * A PBKDF2 iteration count above INT_MAX must not silently truncate to a small
+ * value. iter = 2^32 + 1 collapses to 1 in a plain (int) cast, which would
+ * derive the same key as a single iteration.
+ */
+static int test_pbkdf2_iter_truncation(void)
+{
+    int err = 0;
+    int retHuge = 0;
+    int ret1 = 0;
+    unsigned char keyHuge[32];
+    unsigned char key1[32];
+    static const unsigned char salt16[16] = {
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16
+    };
+    uint64_t hugeIter = ((uint64_t)1 << 32) + 1;
+
+    memset(keyHuge, 0, sizeof(keyHuge));
+    memset(key1, 0, sizeof(key1));
+
+    err = pbkdf2_derive(wpLibCtx, hugeIter, salt16, sizeof(salt16), 0, 0,
+        keyHuge, sizeof(keyHuge), &retHuge);
+    if (err == 0) {
+        err = pbkdf2_derive(wpLibCtx, 1, salt16, sizeof(salt16), 0, 0,
+            key1, sizeof(key1), &ret1);
+    }
+    if ((err == 0) && (ret1 <= 0)) {
+        PRINT_MSG("PBKDF2 baseline iter=1 derive failed");
+        err = 1;
+    }
+    if ((err == 0) && (retHuge > 0) &&
+            (memcmp(keyHuge, key1, sizeof(key1)) == 0)) {
+        PRINT_MSG("PBKDF2 iteration count above INT_MAX truncated to 1");
+        err = 1;
+    }
+
+    return err;
+}
+
 int test_pbkdf2(void *data)
 {
     int err = 0;
@@ -287,6 +326,11 @@ int test_pbkdf2(void *data)
     if (err == 0) {
         PRINT_MSG("PBKDF2 OpenSSL vs wolfProvider");
         err = test_pbkdf2_bounds();
+    }
+
+    if (err == 0) {
+        PRINT_MSG("PBKDF2 iteration count truncation");
+        err = test_pbkdf2_iter_truncation();
     }
 
     return err;

--- a/test/test_pbkdf2.c
+++ b/test/test_pbkdf2.c
@@ -314,6 +314,39 @@ static int test_pbkdf2_iter_truncation(void)
     return err;
 }
 
+/* PKCS12KDF must reject a diversifier id outside the RFC 7292 {1,2,3} range. */
+static int test_pkcs12_bad_id(void)
+{
+    int err = 0;
+    int deriveRet = 0;
+    unsigned char out[24];
+    static unsigned char pass[] = "password";
+    static unsigned char salt[8] = { 1, 2, 3, 4, 5, 6, 7, 8 };
+    uint64_t iter = 2048;
+    int id = 4;
+    char digest[] = "SHA256";
+    OSSL_PARAM params[6];
+    OSSL_PARAM* p = params;
+
+    *p++ = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_PASSWORD,
+        pass, sizeof(pass) - 1);
+    *p++ = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_SALT,
+        salt, sizeof(salt));
+    *p++ = OSSL_PARAM_construct_uint64(OSSL_KDF_PARAM_ITER, &iter);
+    *p++ = OSSL_PARAM_construct_utf8_string(OSSL_KDF_PARAM_DIGEST, digest, 0);
+    *p++ = OSSL_PARAM_construct_int(OSSL_KDF_PARAM_PKCS12_ID, &id);
+    *p = OSSL_PARAM_construct_end();
+
+    err = test_kdf_derive(wpLibCtx, "PKCS12KDF", params, out, sizeof(out),
+        &deriveRet);
+    if (err == 0 && deriveRet > 0) {
+        PRINT_MSG("PKCS12KDF accepted invalid diversifier id");
+        err = 1;
+    }
+
+    return err;
+}
+
 int test_pbkdf2(void *data)
 {
     int err = 0;
@@ -322,6 +355,11 @@ int test_pbkdf2(void *data)
 
     PRINT_MSG("PKCS12KDF OpenSSL vs wolfProvider");
     err = test_pkcs12_kdf();
+
+    if (err == 0) {
+        PRINT_MSG("PKCS12KDF invalid diversifier id");
+        err = test_pkcs12_bad_id();
+    }
 
     if (err == 0) {
         PRINT_MSG("PBKDF2 OpenSSL vs wolfProvider");

--- a/test/test_rsa.c
+++ b/test/test_rsa.c
@@ -20,6 +20,7 @@
 
 #include "unit.h"
 #include <wolfprovider/wp_fips.h>
+#include <wolfprovider/alg_funcs.h>
 #include <wolfssl/wolfcrypt/asn.h>
 
 #include <openssl/store.h>
@@ -966,6 +967,49 @@ static int test_rsa_pss_restrict_params(OSSL_LIB_CTX *libCtx)
     return err;
 }
 
+/*
+ * A salt length >= 256 must encode both bytes of the 2-byte DER INTEGER in the
+ * RSA-PSS AlgorithmIdentifier. saltLen 300 (0x012C) needs the high byte 0x01;
+ * a dropped high byte decodes as 44. rsa is unused for an explicit salt length.
+ */
+static int test_rsa_pss_saltlen_encode(void)
+{
+    int err = 0;
+    int ok;
+    int saltLen = 300;
+    byte algId[128];
+    word32 len = 0;
+    word32 i;
+    int found = 0;
+    static const byte saltMarker[] = { 0xa2, 0x04, 0x02, 0x02 };
+
+    ok = wp_rsa_pss_encode_alg_id(NULL, "SHA256", "SHA256", saltLen, algId,
+        &len);
+    if (ok != 1) {
+        PRINT_ERR_MSG("PSS AlgId encode failed");
+        err = 1;
+    }
+    for (i = 0; (err == 0) && (i + sizeof(saltMarker) + 1 < len); i++) {
+        if (memcmp(algId + i, saltMarker, sizeof(saltMarker)) == 0) {
+            int encoded = (algId[i + sizeof(saltMarker)] << 8) |
+                algId[i + sizeof(saltMarker) + 1];
+            found = 1;
+            if (encoded != saltLen) {
+                PRINT_ERR_MSG("PSS salt length encoded as %d, expected %d",
+                    encoded, saltLen);
+                err = 1;
+            }
+            break;
+        }
+    }
+    if ((err == 0) && !found) {
+        PRINT_ERR_MSG("PSS 2-byte salt length marker not found");
+        err = 1;
+    }
+
+    return err;
+}
+
 int test_rsa_pss_restrictions(void *data)
 {
     int err;
@@ -977,6 +1021,10 @@ int test_rsa_pss_restrictions(void *data)
     if (err == 0) {
         PRINT_MSG("Test WolfProvider");
         err = test_rsa_pss_restrict_params(wpLibCtx) == 1;
+    }
+    if (err == 0) {
+        PRINT_MSG("PSS salt length >= 256 encoding");
+        err = test_rsa_pss_saltlen_encode();
     }
 
     return err;

--- a/test/test_tls_cbc.c
+++ b/test/test_tls_cbc.c
@@ -533,6 +533,97 @@ int test_des3_tls_cbc_bad_pad(void *data)
     return test_des3_tls_cbc_bad_pad_helper(wpLibCtx);
 }
 
+/*
+ * Positive DES3 TLS 1.2 CBC decrypt: a valid record must decrypt back to the
+ * original plaintext with the explicit-IV block and padding stripped.
+ */
+static int test_des3_tls_cbc_dec_helper(OSSL_LIB_CTX *libCtx)
+{
+    int err = 0;
+    EVP_CIPHER *cipher = NULL;
+    EVP_CIPHER_CTX *ctx = NULL;
+    OSSL_PARAM params[2];
+    unsigned int tlsVer = TLS1_2_VERSION;
+    unsigned char key[24];
+    unsigned char iv[DES3_BS];
+    /* 37 bytes: not block-aligned, so padding is non-trivial. */
+    unsigned char pt[37];
+    unsigned char buf[64];
+    int ptLen = (int)sizeof(pt);
+    int encLen = 0;
+    int decLen = 0;
+
+    memset(key, 0xAA, sizeof(key));
+    memset(iv, 0xBB, sizeof(iv));
+    memset(pt, 0x42, sizeof(pt));
+
+    cipher = EVP_CIPHER_fetch(libCtx, "DES-EDE3-CBC", "");
+    if (cipher == NULL) {
+        err = 1;
+    }
+
+    /* Encrypt the record [explicit_IV][plaintext] in TLS mode. */
+    if (err == 0) {
+        ctx = EVP_CIPHER_CTX_new();
+        err = ctx == NULL;
+    }
+    if (err == 0) {
+        err = EVP_CipherInit_ex(ctx, cipher, NULL, key, iv, 1) != 1;
+    }
+    if (err == 0) {
+        params[0] = OSSL_PARAM_construct_uint(OSSL_CIPHER_PARAM_TLS_VERSION,
+                                              &tlsVer);
+        params[1] = OSSL_PARAM_construct_end();
+        err = EVP_CIPHER_CTX_set_params(ctx, params) != 1;
+    }
+    if (err == 0) {
+        memcpy(buf, iv, DES3_BS);
+        memcpy(buf + DES3_BS, pt, ptLen);
+        err = EVP_CipherUpdate(ctx, buf, &encLen, buf, DES3_BS + ptLen) != 1;
+    }
+    EVP_CIPHER_CTX_free(ctx);
+    ctx = NULL;
+
+    /* Decrypt in TLS mode: IV and padding stripped, plaintext at buf+DES3_BS. */
+    if (err == 0) {
+        ctx = EVP_CIPHER_CTX_new();
+        err = ctx == NULL;
+    }
+    if (err == 0) {
+        err = EVP_CipherInit_ex(ctx, cipher, NULL, key, iv, 0) != 1;
+    }
+    if (err == 0) {
+        params[0] = OSSL_PARAM_construct_uint(OSSL_CIPHER_PARAM_TLS_VERSION,
+                                              &tlsVer);
+        params[1] = OSSL_PARAM_construct_end();
+        err = EVP_CIPHER_CTX_set_params(ctx, params) != 1;
+    }
+    if (err == 0) {
+        err = EVP_CipherUpdate(ctx, buf, &decLen, buf, encLen) != 1;
+    }
+    if (err == 0 && decLen != ptLen) {
+        PRINT_ERR_MSG("DES3 TLS CBC dec outLen mismatch: got %d, expected %d",
+                      decLen, ptLen);
+        err = 1;
+    }
+    if (err == 0 && memcmp(buf + DES3_BS, pt, ptLen) != 0) {
+        PRINT_ERR_MSG("DES3 TLS CBC dec plaintext mismatch");
+        err = 1;
+    }
+
+    EVP_CIPHER_CTX_free(ctx);
+    EVP_CIPHER_free(cipher);
+    return err;
+}
+
+int test_des3_tls_cbc_dec(void *data)
+{
+    (void)data;
+
+    PRINT_MSG("DES3 TLS 1.2 CBC decrypt roundtrip (wolfProvider)");
+    return test_des3_tls_cbc_dec_helper(wpLibCtx);
+}
+
 #undef DES3_BS
 
 /*

--- a/test/test_tls_cbc.c
+++ b/test/test_tls_cbc.c
@@ -385,8 +385,10 @@ static int test_aes_tls_cbc_split_helper(OSSL_LIB_CTX *libCtx,
         err = EVP_CIPHER_CTX_set_params(ctx, params) != 1;
     }
     if (err == 0) {
+        /* Only the second update completes the split record and must succeed. */
         (void)EVP_CipherUpdate(ctx, out, &l1, buf, split);
-        (void)EVP_CipherUpdate(ctx, out, &l2, buf + split, encLen - split);
+        err = EVP_CipherUpdate(ctx, out + l1, &l2, buf + split,
+                               encLen - split) != 1;
     }
 
     OPENSSL_free(out);

--- a/test/test_tls_cbc.c
+++ b/test/test_tls_cbc.c
@@ -534,10 +534,12 @@ int test_des3_tls_cbc_bad_pad(void *data)
 }
 
 /*
- * Positive DES3 TLS 1.2 CBC decrypt: a valid record must decrypt back to the
- * original plaintext with the explicit-IV block and padding stripped.
+ * Positive DES3 TLS 1.2 CBC decrypt of a valid record split across two
+ * EVP_CipherUpdate calls, so the second update completes a buffered block and
+ * advances the output pointer past the record base. This exercises the
+ * record-base-pointer padding strip; a valid record must decrypt successfully.
  */
-static int test_des3_tls_cbc_dec_helper(OSSL_LIB_CTX *libCtx)
+int test_des3_tls_cbc_dec(void *data)
 {
     int err = 0;
     EVP_CIPHER *cipher = NULL;
@@ -549,15 +551,22 @@ static int test_des3_tls_cbc_dec_helper(OSSL_LIB_CTX *libCtx)
     /* 37 bytes: not block-aligned, so padding is non-trivial. */
     unsigned char pt[37];
     unsigned char buf[64];
+    unsigned char *out = NULL;
     int ptLen = (int)sizeof(pt);
     int encLen = 0;
-    int decLen = 0;
+    int l1 = 0;
+    int l2 = 0;
+    int split = DES3_BS + 1; /* one byte left buffered after update 1 */
+
+    (void)data;
 
     memset(key, 0xAA, sizeof(key));
     memset(iv, 0xBB, sizeof(iv));
     memset(pt, 0x42, sizeof(pt));
 
-    cipher = EVP_CIPHER_fetch(libCtx, "DES-EDE3-CBC", "");
+    PRINT_MSG("DES3 TLS 1.2 CBC split-record decrypt (wolfProvider)");
+
+    cipher = EVP_CIPHER_fetch(wpLibCtx, "DES-EDE3-CBC", "");
     if (cipher == NULL) {
         err = 1;
     }
@@ -584,7 +593,14 @@ static int test_des3_tls_cbc_dec_helper(OSSL_LIB_CTX *libCtx)
     EVP_CIPHER_CTX_free(ctx);
     ctx = NULL;
 
-    /* Decrypt in TLS mode: IV and padding stripped, plaintext at buf+DES3_BS. */
+    /* Output buffer sized to the produced plaintext so an overread past the
+     * written region is caught under sanitizers. */
+    if (err == 0) {
+        out = OPENSSL_malloc((size_t)(encLen - DES3_BS));
+        err = out == NULL;
+    }
+
+    /* Decrypt in TLS mode split across two updates. */
     if (err == 0) {
         ctx = EVP_CIPHER_CTX_new();
         err = ctx == NULL;
@@ -599,29 +615,16 @@ static int test_des3_tls_cbc_dec_helper(OSSL_LIB_CTX *libCtx)
         err = EVP_CIPHER_CTX_set_params(ctx, params) != 1;
     }
     if (err == 0) {
-        err = EVP_CipherUpdate(ctx, buf, &decLen, buf, encLen) != 1;
-    }
-    if (err == 0 && decLen != ptLen) {
-        PRINT_ERR_MSG("DES3 TLS CBC dec outLen mismatch: got %d, expected %d",
-                      decLen, ptLen);
-        err = 1;
-    }
-    if (err == 0 && memcmp(buf + DES3_BS, pt, ptLen) != 0) {
-        PRINT_ERR_MSG("DES3 TLS CBC dec plaintext mismatch");
-        err = 1;
+        /* Only the second update completes the record; must succeed. */
+        (void)EVP_CipherUpdate(ctx, out, &l1, buf, split);
+        err = EVP_CipherUpdate(ctx, out + l1, &l2, buf + split,
+                               encLen - split) != 1;
     }
 
+    OPENSSL_free(out);
     EVP_CIPHER_CTX_free(ctx);
     EVP_CIPHER_free(cipher);
     return err;
-}
-
-int test_des3_tls_cbc_dec(void *data)
-{
-    (void)data;
-
-    PRINT_MSG("DES3 TLS 1.2 CBC decrypt roundtrip (wolfProvider)");
-    return test_des3_tls_cbc_dec_helper(wpLibCtx);
 }
 
 #undef DES3_BS

--- a/test/test_tls_cbc.c
+++ b/test/test_tls_cbc.c
@@ -327,6 +327,90 @@ static int test_aes_tls_cbc_bad_pad_helper(OSSL_LIB_CTX *libCtx,
     return err;
 }
 
+/*
+ * Decrypt a TLS 1.2 CBC record split across two EVP_CipherUpdate calls so the
+ * second completes a buffered block. Exercises the buffered-block path that
+ * advanced the output pointer before the record's IV/padding processing.
+ */
+static int test_aes_tls_cbc_split_helper(OSSL_LIB_CTX *libCtx,
+    const char *cipherName, int keyLen, int macSize)
+{
+    int err = 0;
+    EVP_CIPHER *cipher = NULL;
+    EVP_CIPHER_CTX *ctx = NULL;
+    OSSL_PARAM params[3];
+    unsigned int tlsVer = TLS1_2_VERSION;
+    size_t macSz = (size_t)macSize;
+    unsigned char key[32];
+    unsigned char iv[BS];
+    unsigned char mac[48];
+    unsigned char buf[BS + sizeof(testPlain) + 48 + BS];
+    unsigned char *out = NULL;
+    int encLen = 0;
+    int l1 = 0;
+    int l2 = 0;
+    int split = BS + 1; /* leave one byte buffered after the first update */
+
+    memset(key, 0xAA, keyLen);
+    memset(iv, 0xBB, BS);
+    memset(mac, 0xCC, macSize);
+
+    cipher = EVP_CIPHER_fetch(libCtx, cipherName, "");
+    if (cipher == NULL) {
+        err = 1;
+    }
+    if (err == 0) {
+        err = test_tls_cbc_enc(cipher, key, iv, testPlain, sizeof(testPlain),
+                               mac, macSize, buf, &encLen);
+    }
+    /* Output buffer sized to the produced plaintext so an overread past the
+     * written region is caught. */
+    if (err == 0) {
+        out = OPENSSL_malloc((size_t)(encLen - BS));
+        err = out == NULL;
+    }
+    if (err == 0) {
+        ctx = EVP_CIPHER_CTX_new();
+        err = ctx == NULL;
+    }
+    if (err == 0) {
+        err = EVP_CipherInit_ex(ctx, cipher, NULL, key, iv, 0) != 1;
+    }
+    if (err == 0) {
+        params[0] = OSSL_PARAM_construct_uint(OSSL_CIPHER_PARAM_TLS_VERSION,
+                                              &tlsVer);
+        params[1] = OSSL_PARAM_construct_size_t(OSSL_CIPHER_PARAM_TLS_MAC_SIZE,
+                                                &macSz);
+        params[2] = OSSL_PARAM_construct_end();
+        err = EVP_CIPHER_CTX_set_params(ctx, params) != 1;
+    }
+    if (err == 0) {
+        (void)EVP_CipherUpdate(ctx, out, &l1, buf, split);
+        (void)EVP_CipherUpdate(ctx, out, &l2, buf + split, encLen - split);
+    }
+
+    OPENSSL_free(out);
+    EVP_CIPHER_CTX_free(ctx);
+    EVP_CIPHER_free(cipher);
+    return err;
+}
+
+int test_aes_tls_cbc_split(void *data)
+{
+    int err = 0;
+
+    (void)data;
+
+    PRINT_MSG("TLS 1.2 AES-256-CBC split-record decrypt (wolfProvider)");
+    err = test_aes_tls_cbc_split_helper(wpLibCtx, "AES-256-CBC", 32, 48);
+    if (err == 0) {
+        PRINT_MSG("TLS 1.2 AES-128-CBC split-record decrypt (wolfProvider)");
+        err = test_aes_tls_cbc_split_helper(wpLibCtx, "AES-128-CBC", 16, 32);
+    }
+
+    return err;
+}
+
 int test_aes_tls_cbc_bad_pad(void *data)
 {
     int err = 0;

--- a/test/unit.c
+++ b/test/unit.c
@@ -401,6 +401,7 @@ TEST_CASE test_case[] = {
         TEST_DECL(test_ecdsa_setup_md_reject_atomic, NULL),
     #endif
     TEST_DECL(test_ec_decode, NULL),
+    TEST_DECL(test_ec_decode_short_pem, NULL),
     TEST_DECL(test_ec_import, NULL),
     TEST_DECL(test_ec_auto_derive_pubkey, NULL),
     TEST_DECL(test_ec_null_init, NULL),

--- a/test/unit.c
+++ b/test/unit.c
@@ -205,6 +205,7 @@ TEST_CASE test_case[] = {
     TEST_DECL(test_digest_multi_update, NULL),
 #ifdef WP_HAVE_HMAC
     TEST_DECL(test_hmac_create, NULL),
+    TEST_DECL(test_hmac_key_no_digest, NULL),
     TEST_DECL(test_hmac_multi_update, NULL),
     TEST_DECL(test_hmac_dup, NULL),
     TEST_DECL(test_mac_key_match, NULL),

--- a/test/unit.c
+++ b/test/unit.c
@@ -396,6 +396,7 @@ TEST_CASE test_case[] = {
         TEST_DECL(test_ecdsa_p256, NULL),
         TEST_DECL(test_ecdsa_verify_undersized_hash, NULL),
         TEST_DECL(test_ecdsa_verify_md_len_mismatch, NULL),
+        TEST_DECL(test_ecdsa_setup_md_reject_atomic, NULL),
     #endif
     TEST_DECL(test_ec_decode, NULL),
     TEST_DECL(test_ec_import, NULL),

--- a/test/unit.c
+++ b/test/unit.c
@@ -505,6 +505,7 @@ TEST_CASE test_case[] = {
 #ifdef WP_HAVE_DES3CBC
     #if !defined(HAVE_FIPS) || defined(WP_ALLOW_NON_FIPS)
         TEST_DECL(test_des3_tls_cbc_bad_pad, NULL),
+        TEST_DECL(test_des3_tls_cbc_dec, NULL),
     #endif
 #endif
 

--- a/test/unit.c
+++ b/test/unit.c
@@ -484,6 +484,7 @@ TEST_CASE test_case[] = {
     TEST_DECL(test_ecx_null_init, NULL),
 #ifdef WP_HAVE_X25519
     TEST_DECL(test_ecx_x25519_raw_priv_roundtrip, NULL),
+    TEST_DECL(test_ecx_import_zero_priv, NULL),
 #endif
     TEST_DECL(test_ecx_dup, NULL),
 #endif

--- a/test/unit.c
+++ b/test/unit.c
@@ -316,6 +316,7 @@ TEST_CASE test_case[] = {
 #endif
     TEST_DECL(test_dh_fromdata_oversize, NULL),
     TEST_DECL(test_dh_param_check_explicit, NULL),
+    TEST_DECL(test_dh_import_group_no_nul, NULL),
 #ifndef WOLFPROV_QUICKTEST
     TEST_DECL(test_dh_get_params, NULL),
 #endif

--- a/test/unit.c
+++ b/test/unit.c
@@ -499,6 +499,7 @@ TEST_CASE test_case[] = {
     TEST_DECL(test_tls12_cbc_ossl, NULL),
     TEST_DECL(test_tls12_cbc, NULL),
     TEST_DECL(test_aes_tls_cbc_bad_pad, NULL),
+    TEST_DECL(test_aes_tls_cbc_split, NULL),
 #endif
 #ifdef WP_HAVE_DES3CBC
     #if !defined(HAVE_FIPS) || defined(WP_ALLOW_NON_FIPS)

--- a/test/unit.c
+++ b/test/unit.c
@@ -315,6 +315,7 @@ TEST_CASE test_case[] = {
     TEST_DECL(test_dh_x963_kdf, NULL),
 #endif
     TEST_DECL(test_dh_fromdata_oversize, NULL),
+    TEST_DECL(test_dh_param_check_explicit, NULL),
 #ifndef WOLFPROV_QUICKTEST
     TEST_DECL(test_dh_get_params, NULL),
 #endif

--- a/test/unit.h
+++ b/test/unit.h
@@ -438,6 +438,7 @@ int test_ecdsa_p256_pkey(void *data);
 int test_ecdsa_p256(void *data);
 int test_ecdsa_verify_undersized_hash(void *data);
 int test_ecdsa_verify_md_len_mismatch(void *data);
+int test_ecdsa_setup_md_reject_atomic(void *data);
 #endif /* WP_HAVE_EC_P256 */
 
 #ifdef WP_HAVE_EC_P384

--- a/test/unit.h
+++ b/test/unit.h
@@ -496,6 +496,7 @@ int test_x509_cert(void *data);
 int test_tls12_cbc(void *data);
 int test_tls12_cbc_ossl(void *data);
 int test_aes_tls_cbc_bad_pad(void *data);
+int test_aes_tls_cbc_split(void *data);
 #endif
 
 #ifdef WP_HAVE_DES3CBC

--- a/test/unit.h
+++ b/test/unit.h
@@ -505,6 +505,7 @@ int test_aes_tls_cbc_split(void *data);
 #ifdef WP_HAVE_DES3CBC
 #if !defined(HAVE_FIPS) || defined(WP_ALLOW_NON_FIPS)
 int test_des3_tls_cbc_bad_pad(void *data);
+int test_des3_tls_cbc_dec(void *data);
 #endif
 #endif
 

--- a/test/unit.h
+++ b/test/unit.h
@@ -323,6 +323,7 @@ int test_dh_x963_kdf(void *data);
 #endif
 int test_dh_fromdata_oversize(void *data);
 int test_dh_param_check_explicit(void *data);
+int test_dh_import_group_no_nul(void *data);
 #endif /* WP_HAVE_DH */
 
 #ifdef WP_HAVE_ECC

--- a/test/unit.h
+++ b/test/unit.h
@@ -44,6 +44,8 @@
 #include <wolfprovider/settings.h>
 #include <wolfprovider/wp_logging.h>
 
+/* Parse wolfSSL's AES_BLOCK_SIZE enum before the fallback macro can shadow it. */
+#include <wolfssl/wolfcrypt/aes.h>
 #ifndef AES_BLOCK_SIZE
     #define AES_BLOCK_SIZE 16
 #endif

--- a/test/unit.h
+++ b/test/unit.h
@@ -121,6 +121,7 @@ int test_digest_multi_update(void *data);
 
 #ifdef WP_HAVE_HMAC
 int test_hmac_create(void *data);
+int test_hmac_key_no_digest(void *data);
 int test_hmac_multi_update(void *data);
 int test_hmac_dup(void *data);
 int test_mac_key_match(void *data);

--- a/test/unit.h
+++ b/test/unit.h
@@ -481,6 +481,7 @@ int test_ecx_misc(void *data);
 int test_ecx_null_init(void *data);
 #ifdef WP_HAVE_X25519
 int test_ecx_x25519_raw_priv_roundtrip(void *data);
+int test_ecx_import_zero_priv(void *data);
 #endif /* WP_HAVE_X25519 */
 int test_ecx_dup(void *data);
 #endif

--- a/test/unit.h
+++ b/test/unit.h
@@ -457,6 +457,7 @@ int test_ec_load_cert(void* data);
 #endif /* WP_HAVE_ECDSA */
 
 int test_ec_decode(void* data);
+int test_ec_decode_short_pem(void* data);
 int test_ec_import(void* data);
 int test_ec_auto_derive_pubkey(void* data);
 int test_ec_null_init(void* data);

--- a/test/unit.h
+++ b/test/unit.h
@@ -322,6 +322,7 @@ int test_dh_pad(void *data);
 int test_dh_x963_kdf(void *data);
 #endif
 int test_dh_fromdata_oversize(void *data);
+int test_dh_param_check_explicit(void *data);
 #endif /* WP_HAVE_DH */
 
 #ifdef WP_HAVE_ECC


### PR DESCRIPTION
```
F-4824, F-5921, F-4292, F-4291, F-5198, F-5925, F-4699, F-5918, F-5913, F-4289, F-5866, F-5805, F-4698,
F-4384, F-4937, F-4826, F-4938, F-4940, F-5924, F-5923, F-5544, F-6682, F-5185, F-5184, F-5922, F-6670,
F-4941
```
CI:ALL did fully run and pass on this