### PR TITLE
Fix macOS dyld lib path

### DIFF
--- a/scripts/env-setup
+++ b/scripts/env-setup
@@ -58,6 +58,8 @@ WOLFPROV_LIB_PATH="$REPO_ROOT/wolfprov-install/lib"
 # Always reconstruct LD_LIBRARY_PATH with correctly detected OPENSSL_LIB_PATH
 # ${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH} expands to :$LD_LIBRARY_PATH only if LD_LIBRARY_PATH was already set
 export LD_LIBRARY_PATH="$WOLFPROV_LIB_PATH:$WOLFSSL_LIB_PATH:$OPENSSL_LIB_PATH${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+# macOS loader honors DYLD_LIBRARY_PATH, not LD_LIBRARY_PATH
+export DYLD_LIBRARY_PATH="$WOLFPROV_LIB_PATH:$WOLFSSL_LIB_PATH:$OPENSSL_LIB_PATH${DYLD_LIBRARY_PATH:+:$DYLD_LIBRARY_PATH}"
 
 # Set OPENSSL_BIN - use existing if set, otherwise use local build
 if [ -z "${OPENSSL_BIN:-}" ]; then


### PR DESCRIPTION
On macOS the loader honors DYLD_LIBRARY_PATH, not LD_LIBRARY_PATH, but `env-setup` only exported the latter. Tests then relied on rpath alone and broke when OpenSSL bumped its soname (`libssl.so.3` -> `libssl.so.4`). Export DYLD_LIBRARY_PATH alongside LD_LIBRARY_PATH.

Fixes the wolfProvider PRB macOS timeout supervisor issue (`infra:job::wolfProvider/PRB-master-job::timeout`), where the macOS branches failed to load the freshly built OpenSSL libs and hung until the parent 2h timeout.

Preventative for: https://jenkins-supervisor.wolfssl.com/#/open-issues/511