### PR TITLE
Export CFLAGS/LDFLAGS before ./config so OpenSSL rpath is actually baked in

### DIFF
--- a/scripts/utils-openssl.sh
+++ b/scripts/utils-openssl.sh
@@ -425,7 +425,9 @@ install_openssl() {
             CONFIG_CMD+=" no-external-tests no-tests"
         fi
 
-        $CONFIG_CMD >>$LOG_FILE 2>&1
+        # Scope flags to ./config: OpenSSL bakes LDFLAGS (rpath) in at configure time.
+        CFLAGS="${OPENSSL_CFLAGS}" CXXFLAGS="${OPENSSL_CXXFLAGS}" LDFLAGS="${OPENSSL_LDFLAGS}" \
+            $CONFIG_CMD >>$LOG_FILE 2>&1
         RET=$?
         if [ $RET != 0 ]; then
             printf "ERROR.\n"
@@ -434,10 +436,6 @@ install_openssl() {
             exit 1
         fi
         printf "Done.\n"
-
-        export CFLAGS="${OPENSSL_CFLAGS}"
-        export CXXFLAGS="${OPENSSL_CXXFLAGS}"
-        export LDFLAGS="${OPENSSL_LDFLAGS}"
 
         printf "\tBuild OpenSSL ${OPENSSL_TAG} ... "
         make -j$NUMCPU >>$LOG_FILE 2>&1


### PR DESCRIPTION
Export `LDFLAGS` before `./config` instead of after, so OpenSSL captures the
`-Wl,-rpath` flags at configure time. Without this the rpath was dropped and the
built `openssl` had none, leaving it dependent on `LD_LIBRARY_PATH` to find
`libssl.so.3` (intermittent `cannot open shared object file` in CI). Now the
binary self-locates its libs. Makes the intent of `b6ca8e1` actually work.

preventative for: https://jenkins-supervisor.wolfssl.com/#/open-issues/524 
