### PR TITLE
Free FP ECC cache in provider teardown

### DIFF
--- a/src/wp_wolfprov.c
+++ b/src/wp_wolfprov.c
@@ -291,6 +291,10 @@ static void wolfssl_prov_ctx_free(WOLFPROV_CTX* ctx)
     wc_FreeMutex(&ctx->rng_mutex);
 #endif
     wc_FreeRng(&ctx->rng);
+#ifdef FP_ECC
+    /* Free this thread's FP ECC cache; wc_ecc_free() doesn't. */
+    wc_ecc_fp_free();
+#endif
     OPENSSL_free(ctx);
 }
 


### PR DESCRIPTION
`wc_ecc_free()` doesn't release wolfCrypt's fixed-point ECC cache (`fp_cache[]`), and nothing in wolfProvider calls `wc_ecc_fp_free()` — so it's held for the process lifetime. Call it in `wolfssl_prov_ctx_free()`, guarded by `FP_ECC`.

Frees the teardown thread's cache (thread-local under `HAVE_THREAD_LS`); no-op when empty.
