### PR TITLE
debian: bump libssl3 dep floor to 3.0.8

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -14,7 +14,7 @@ Build-Depends:
 Package: libwolfprov
 Architecture: any
 Multi-Arch: same
-Depends: ${shlibs:Depends}, ${misc:Depends}, libssl3 (>= 3.0.3), libwolfssl (>= 5.8.2)
+Depends: ${shlibs:Depends}, ${misc:Depends}, libssl3 (>= 3.0.8), libwolfssl (>= 5.8.2)
 Recommends: openssl
 Provides: ${variant:provides}
 XB-Variant: ${variant}


### PR DESCRIPTION
One-line packaging change: `Depends: libssl3 (>= 3.0.3)` → `(>= 3.0.8)` in `debian/control`.

Rather than carrying version-specific workarounds, wolfProvider does not support OpenSSL < 3.0.8. Two defects below that boundary bite wolfProvider:

1. **Silent EC provider bypass**: pre-3.0.8 legacy-to-provider EC key export hardcodes compressed point form (fixed upstream in openssl/openssl@999509c, first released in 3.0.8). `wp_ecc_import` rejects the compressed point and EVP core silently falls back to built-in legacy ECDSA for any d2i-loaded EC key — crypto escapes wolfCrypt with no error. Caught by unit test 116 on Ubuntu jammy (3.0.2).
2. **seed-src init crash**: with `--enable-seed-src`, provider init re-enters libcrypto RAND when wolfProvider is loaded during libcrypto initialization; on pre-3.0.8 this fails the DSO load and SIGSEGVs `openssl list -providers`. 3.0.8+ made RAND/provider init re-entrancy safe.

The new floor makes the package uninstallable on runtimes where those behaviors exist, instead of an arbitrary 3.0.3 that admits both.