### PR TITLE
F-4935 - Guard word32 length overflow in wp_read_pem_bio

### DIFF
--- a/src/wp_dec_pem2der.c
+++ b/src/wp_dec_pem2der.c
@@ -441,7 +441,7 @@ static int wp_pem2der_decode(wp_Pem2Der* ctx, OSSL_CORE_BIO* coreBio,
     else if (data == NULL) {
         done = 1;
     }
-    if (!done) {
+    if (ok && !done) {
         idx += wp_pem2der_find_header(data + idx, len - idx);
         /* No header means nothing to do. */
         if (idx == len) {

--- a/src/wp_internal.c
+++ b/src/wp_internal.c
@@ -1276,18 +1276,21 @@ int wp_read_der_bio(WOLFPROV_CTX *provctx, OSSL_CORE_BIO *coreBio, unsigned char
     while (ok && (readLen > 0)) {
         readLen = BIO_read(bio, buf, sizeof(buf));
         if (readLen < -1) {
-            WOLFPROV_MSG(WP_LOG_COMP_PROVIDER, "BIO_read error (%d) in %s:%d", readLen, __FILE__, __LINE__);
+            WOLFPROV_MSG(WP_LOG_COMP_PROVIDER, "BIO_read error (%ld) in %s:%d", readLen, __FILE__, __LINE__);
             ok = 0;
         }
         if (ok && (readLen > 0) &&
-                ((uint64_t)*len + (uint64_t)readLen > (uint64_t)UINT32_MAX)) {
+                (!WP_FITS_WORD32((uint64_t)*len + (uint64_t)readLen))) {
+            WOLFPROV_MSG(WP_LOG_COMP_PROVIDER,
+                "Length overflow (%u + %ld) in %s:%d", *len, readLen, __FILE__,
+                __LINE__);
             ok = 0;
         }
         if (ok && (readLen > 0)) {
             /* Reallocate for new data. */
             p = OPENSSL_realloc(*data, *len + readLen);
             if (p == NULL) {
-                WOLFPROV_MSG(WP_LOG_COMP_PROVIDER, "OPENSSL_realloc error (%d) in %s:%d", readLen, __FILE__, __LINE__);
+                WOLFPROV_MSG(WP_LOG_COMP_PROVIDER, "OPENSSL_realloc error (%ld) in %s:%d", readLen, __FILE__, __LINE__);
                 ok = 0;
             }
         }
@@ -1335,8 +1338,15 @@ int wp_read_pem_bio(WOLFPROV_CTX *provctx, OSSL_CORE_BIO *coreBio,
         /* Read a line at a time. */
         readLen = BIO_gets(bio, buf, sizeof(buf));
         if (readLen < -1) {
-            WOLFPROV_MSG(WP_LOG_COMP_PROVIDER, "BIO_read error (%d) in %s:%d",
+            WOLFPROV_MSG(WP_LOG_COMP_PROVIDER, "BIO_gets error (%ld) in %s:%d",
                 readLen, __FILE__, __LINE__);
+            ok = 0;
+        }
+        if (ok && (readLen > 0) &&
+                (!WP_FITS_WORD32((uint64_t)*len + (uint64_t)readLen))) {
+            WOLFPROV_MSG(WP_LOG_COMP_PROVIDER,
+                "Length overflow (%u + %ld) in %s:%d", *len, readLen, __FILE__,
+                __LINE__);
             ok = 0;
         }
         if (ok && (readLen > 0)) {
@@ -1344,7 +1354,7 @@ int wp_read_pem_bio(WOLFPROV_CTX *provctx, OSSL_CORE_BIO *coreBio,
             p = OPENSSL_realloc(*data, *len + readLen);
             if (p == NULL) {
                 WOLFPROV_MSG(WP_LOG_COMP_PROVIDER,
-                    "OPENSSL_realloc error (%d) in %s:%d", readLen, __FILE__,
+                    "OPENSSL_realloc error (%ld) in %s:%d", readLen, __FILE__,
                     __LINE__);
                 ok = 0;
             }


### PR DESCRIPTION
Fenrir F-4935. Ports the word32 bound already in `wp_read_der_bio` (#438).

Reported OOB write does not occur — on LP64 the realloc size computes in `long`, and `CRYPTO_realloc(p, 0)` returns NULL. Impact is truncation after 4GB.

`wp_pem2der_decode` set `ok = 0` on read failure then overwrote it with the decode result. Now gated on `ok`.

Also fixes `%d` used for `long readLen`.

No test — the guard needs a 4GB PEM.