### PR TITLE
Skip PQC workflows on draft pull requests

### DIFF
--- a/.github/workflows/wolfssl-pqc-kat.yml
+++ b/.github/workflows/wolfssl-pqc-kat.yml
@@ -30,6 +30,7 @@ permissions:
 jobs:
   discover-versions:
     name: Resolve wolfSSL/OpenSSL matrix
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-22.04
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
@@ -100,6 +101,7 @@ jobs:
   pqc-kat:
     name: ${{ matrix.name }}
     needs: discover-versions
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-22.04
     permissions:
       contents: read

--- a/.github/workflows/wolfssl-pqc-kat.yml
+++ b/.github/workflows/wolfssl-pqc-kat.yml
@@ -18,6 +18,7 @@ on:
     branches: [ 'master', 'main', 'release/**' ]
   pull_request:
     branches: [ '*' ]
+    types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/wolfssl-versions-pqc.yml
+++ b/.github/workflows/wolfssl-versions-pqc.yml
@@ -17,6 +17,7 @@ on:
     branches: [ 'master', 'main', 'release/**' ]
   pull_request:
     branches: [ '*' ]
+    types: [opened, synchronize, reopened, ready_for_review]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/wolfssl-versions-pqc.yml
+++ b/.github/workflows/wolfssl-versions-pqc.yml
@@ -28,6 +28,7 @@ permissions:
 jobs:
   discover-versions:
     name: Resolve wolfSSL version matrix
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-22.04
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
@@ -97,6 +98,7 @@ jobs:
   pqc-build-test:
     name: ${{ matrix.name }}
     needs: discover-versions
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-22.04
     permissions:
       contents: read


### PR DESCRIPTION
- PQC workflows ran on draft pull requests.
- Guard both PQC discovery jobs against draft PRs.
- Guard both dependent PQC matrix jobs against draft PRs.
- Leave smoke tests running on draft PRs. 
- Validate both workflow files as YAML.
<img width="572" height="385" alt="image" src="https://github.com/user-attachments/assets/7fad8934-cdc4-42aa-8027-5e4686fc059e" />
