### PR TITLE
F-4287: check public point is on curve

### DIFF
--- a/include/wolfprovider/alg_funcs.h
+++ b/include/wolfprovider/alg_funcs.h
@@ -256,6 +256,8 @@ ecc_key* wp_ecc_get_key(wp_Ecc* ecc);
 WC_RNG* wp_ecc_get_rng(wp_Ecc* ecc);
 int wp_ecc_get_size(wp_Ecc* ecc);
 int wp_ecc_check_usage(wp_Ecc* ecc);
+int wp_ecc_check_pub_point(wp_Ecc* ecc);
+int wp_ecc_check_pub_key(wp_Ecc* ecc);
 wolfSSL_Mutex* wp_ecc_get_mutex(wp_Ecc* ecc);
 
 /* Internal ECX types and functions. */

--- a/src/wp_ecc_kmgmt.c
+++ b/src/wp_ecc_kmgmt.c
@@ -246,9 +246,10 @@ int wp_ecc_check_usage(wp_Ecc* ecc)
 /**
  * Check a point is usable with a curve.
  *
- * Rejects the point at infinity and any point that is not on the curve. A
- * point off the curve lies on a group whose order may be small enough to
- * recover the other party's private key from a key exchange.
+ * Rejects the point at infinity and, where wolfSSL provides the check, any
+ * point that is not on the curve. A point off the curve lies on a group whose
+ * order may be small enough to recover the other party's private key from a
+ * key exchange.
  *
  * @param [in] point    Public key point.
  * @param [in] curveId  wolfSSL identifier of curve point must be on.
@@ -259,7 +260,9 @@ static int wp_ecc_check_point(ecc_point* point, int curveId)
 {
     int ok = 1;
     int idx = ECC_CURVE_INVALID;
+#ifdef USE_ECC_B_PARAM
     int rc;
+#endif
 
     WOLFPROV_ENTER(WP_LOG_COMP_ECC, "wp_ecc_check_point");
 
@@ -270,6 +273,9 @@ static int wp_ecc_check_point(ecc_point* point, int curveId)
     if (ok && wc_ecc_point_is_at_infinity(point)) {
         ok = 0;
     }
+#ifdef USE_ECC_B_PARAM
+    /* wolfSSL only builds the on-curve check when the curve b parameter is
+     * available. */
     if (ok) {
         rc = wc_ecc_point_is_on_curve(point, idx);
         if (rc != 0) {
@@ -278,6 +284,7 @@ static int wp_ecc_check_point(ecc_point* point, int curveId)
             ok = 0;
         }
     }
+#endif
 
     WOLFPROV_LEAVE(WP_LOG_COMP_ECC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
     return ok;

--- a/src/wp_ecc_kmgmt.c
+++ b/src/wp_ecc_kmgmt.c
@@ -243,6 +243,103 @@ int wp_ecc_check_usage(wp_Ecc* ecc)
     return ret;
 }
 
+/**
+ * Check a point is usable with a curve.
+ *
+ * Rejects the point at infinity and any point that is not on the curve. A
+ * point off the curve lies on a group whose order may be small enough to
+ * recover the other party's private key from a key exchange.
+ *
+ * @param [in] point    Public key point.
+ * @param [in] curveId  wolfSSL identifier of curve point must be on.
+ * @return  1 on success.
+ * @return  0 on failure.
+ */
+static int wp_ecc_check_point(ecc_point* point, int curveId)
+{
+    int ok = 1;
+    int idx = ECC_CURVE_INVALID;
+    int rc;
+
+    WOLFPROV_ENTER(WP_LOG_COMP_ECC, "wp_ecc_check_point");
+
+    idx = wc_ecc_get_curve_idx(curveId);
+    if (idx == ECC_CURVE_INVALID) {
+        ok = 0;
+    }
+    if (ok && wc_ecc_point_is_at_infinity(point)) {
+        ok = 0;
+    }
+    if (ok) {
+        rc = wc_ecc_point_is_on_curve(point, idx);
+        if (rc != 0) {
+            WOLFPROV_MSG_DEBUG_RETCODE(WP_LOG_LEVEL_DEBUG,
+                "wc_ecc_point_is_on_curve", rc);
+            ok = 0;
+        }
+    }
+
+    WOLFPROV_LEAVE(WP_LOG_COMP_ECC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    return ok;
+}
+
+/**
+ * Check the public key point is usable with the key's curve.
+ *
+ * @param [in] ecc  ECC key object.
+ * @return  1 on success.
+ * @return  0 on failure.
+ */
+int wp_ecc_check_pub_point(wp_Ecc* ecc)
+{
+    return (ecc != NULL) && wp_ecc_check_point(&ecc->key.pubkey, ecc->curveId);
+}
+
+/**
+ * Check the public key is valid for use with the key's curve.
+ *
+ * As well as the point being on the curve, the point must have the order of
+ * the curve. Any private key held alongside is ignored.
+ *
+ * @param [in] ecc  ECC key object.
+ * @return  1 on success.
+ * @return  0 on failure.
+ */
+int wp_ecc_check_pub_key(wp_Ecc* ecc)
+{
+    int ok = 1;
+    int origType;
+    int rc;
+
+    WOLFPROV_ENTER(WP_LOG_COMP_ECC, "wp_ecc_check_pub_key");
+
+    if ((ecc == NULL) || (!ecc->hasPub)) {
+        ok = 0;
+    }
+    /* Fail closed if the key mutex can't be held for the check. */
+    if (ok && (wp_lock(wp_ecc_get_mutex(ecc)) != 1)) {
+        ok = 0;
+    }
+    if (ok) {
+        /* A private key may be present that does not match the public key,
+         * which is OK. Override the internal type to force a public key only
+         * check. */
+        origType = ecc->key.type;
+        ecc->key.type = ECC_PUBLICKEY;
+        rc = wc_ecc_check_key(&ecc->key);
+        ecc->key.type = origType;
+        wp_unlock(wp_ecc_get_mutex(ecc));
+        if (rc != 0) {
+            WOLFPROV_MSG_DEBUG_RETCODE(WP_LOG_LEVEL_DEBUG, "wc_ecc_check_key",
+                rc);
+            ok = 0;
+        }
+    }
+
+    WOLFPROV_LEAVE(WP_LOG_COMP_ECC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
+    return ok;
+}
+
 /*
  * ECC key
  */
@@ -1134,37 +1231,6 @@ static int wp_ecc_match(wp_Ecc* ecc1, wp_Ecc* ecc2, int selection)
     return ok;
 }
 
-#if LIBWOLFSSL_VERSION_HEX >= 0x05000000
-/**
- * Quick validate the ECC public key.
- *
- * Check for infinity and point is on curve.
- *
- * @param [in] ecc        ECC key object.
- * @return  1 on success.
- * @return  0 on failure.
- */
-static int wp_ecc_validate_public_key_quick(const wp_Ecc* ecc)
-{
-    int ok = 1;
-
-    WOLFPROV_ENTER(WP_LOG_COMP_ECC, "wp_ecc_validate_public_key_quick");
-
-    if (wc_ecc_point_is_at_infinity((ecc_point*)&ecc->key.pubkey)) {
-        ok = 0;
-    }
-#ifdef USE_ECC_B_PARAM
-    if (ok && (!wc_ecc_point_is_on_curve((ecc_point*)&ecc->key.pubkey,
-            ecc->curveId))) {
-        ok = 0;
-    }
-#endif
-
-    WOLFPROV_LEAVE(WP_LOG_COMP_ECC, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__), ok);
-    return ok;
-}
-#endif
-
 /**
  * Validate the ECC key.
  *
@@ -1179,7 +1245,6 @@ static int wp_ecc_validate_public_key_quick(const wp_Ecc* ecc)
 static int wp_ecc_validate(const wp_Ecc* ecc, int selection, int checkType)
 {
     int ok = 1;
-    int origType;
     int rc;
 
     WOLFPROV_ENTER(WP_LOG_COMP_ECC, "wp_ecc_validate");
@@ -1193,37 +1258,13 @@ static int wp_ecc_validate(const wp_Ecc* ecc, int selection, int checkType)
         ok = 0;
     }
     if (ok && (selection & OSSL_KEYMGMT_SELECT_PUBLIC_KEY) != 0) {
-    #if LIBWOLFSSL_VERSION_HEX >= 0x05000000
-        /* TODO: Quick check for older versions? */
         if (checkType == OSSL_KEYMGMT_VALIDATE_QUICK_CHECK) {
-            if (!wp_ecc_validate_public_key_quick(ecc)) {
+            if (!wp_ecc_check_pub_point((wp_Ecc*)ecc)) {
                 ok = 0;
             }
         }
-        else
-    #else
-       (void)checkType;
-    #endif
-        {
-            /* Fail closed if the key mutex can't be held for the check. */
-            if (wp_lock(wp_ecc_get_mutex((wp_Ecc*)ecc)) != 1) {
-                ok = 0;
-            }
-            if (ok) {
-                /* We may have a private key inside that does not match the
-                 * public key that has been set, which is OK. Override the
-                 * internal type to force a public key only check */
-                origType = ecc->key.type;
-                ((wp_Ecc*)ecc)->key.type = ECC_PUBLICKEY;
-                rc = wc_ecc_check_key((ecc_key*)&ecc->key);
-                ((wp_Ecc*)ecc)->key.type = origType;
-                wp_unlock(wp_ecc_get_mutex((wp_Ecc*)ecc));
-                if (rc != 0) {
-                    WOLFPROV_MSG_DEBUG_RETCODE(WP_LOG_LEVEL_DEBUG,
-                        "wc_ecc_check_key", rc);
-                    ok = 0;
-                }
-            }
+        else if (!wp_ecc_check_pub_key((wp_Ecc*)ecc)) {
+            ok = 0;
         }
     }
     if (ok && ((selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY) != 0) &&

--- a/src/wp_ecdh_exch.c
+++ b/src/wp_ecdh_exch.c
@@ -281,12 +281,22 @@ static int wp_ecdh_derive_secret(wp_EcdhCtx* ctx, unsigned char* secret,
 
     WOLFPROV_ENTER(WP_LOG_COMP_ECDH, "wp_ecdh_derive_secret");
 
+    if (ctx->peer == NULL) {
+        ok = 0;
+    }
 #ifdef HAVE_ECC_CDH
-    if (ctx->cofactor) {
+    if (ok && ctx->cofactor) {
         wc_ecc_set_flags(wp_ecc_get_key(ctx->key), WC_ECC_FLAG_COFACTOR);
     }
 #endif
-    if ((ok = wp_ecc_check_usage(ctx->key))) {
+    if (ok && (!wp_ecc_check_usage(ctx->key))) {
+        ok = 0;
+    }
+    /* Peer's key may have been changed since it was set - check it again. */
+    if (ok && (!wp_ecc_check_pub_point(ctx->peer))) {
+        ok = 0;
+    }
+    if (ok) {
         /* Calculate secret. */
         PRIVATE_KEY_UNLOCK();
         rc = wc_ecc_shared_secret(wp_ecc_get_key(ctx->key),
@@ -325,12 +335,15 @@ static int wp_ecdh_derive(wp_EcdhCtx* ctx, unsigned char* secret,
     unsigned char* out;
     size_t outLen;
     unsigned char* tmp = NULL;
-    size_t maxLen = (size_t)wp_ecc_get_size(ctx->key);
+    size_t maxLen = 0;
 
     WOLFPROV_ENTER(WP_LOG_COMP_ECDH, "wp_ecdh_derive");
 
-    if (!wolfssl_prov_is_running()) {
+    if ((!wolfssl_prov_is_running()) || (ctx->key == NULL)) {
         ok = 0;
+    }
+    if (ok) {
+        maxLen = (size_t)wp_ecc_get_size(ctx->key);
     }
 
     /* No output buffer, return maximum size only. */
@@ -403,6 +416,9 @@ static int wp_ecdh_set_peer(wp_EcdhCtx* ctx, wp_Ecc* peer)
     WOLFPROV_ENTER(WP_LOG_COMP_ECDH, "wp_ecdh_set_peer");
 
     if (!wolfssl_prov_is_running()) {
+        ok = 0;
+    }
+    if (ok && (!wp_ecc_check_pub_key(peer))) {
         ok = 0;
     }
     if (ok && (ctx->peer != peer)) {

--- a/test/test_ecc.c
+++ b/test/test_ecc.c
@@ -1102,6 +1102,7 @@ int test_ecdh_invalid_kdf_strings(void *data)
     return err;
 }
 
+#ifdef USE_ECC_B_PARAM
 /* Build a P-256 public key from raw X and Y ordinates. */
 static EVP_PKEY* test_ecdh_peer_from_xy(const BIGNUM* x, const BIGNUM* y)
 {
@@ -1260,6 +1261,7 @@ int test_ecdh_invalid_curve_peer(void *data)
 
     return err;
 }
+#endif /* USE_ECC_B_PARAM */
 
 #if defined(HAVE_X963_KDF) && defined(WP_HAVE_SHA256)
 /* Apply X9.63 KDF using OpenSSL's reference implementation so we can compare

--- a/test/test_ecc.c
+++ b/test/test_ecc.c
@@ -1102,6 +1102,165 @@ int test_ecdh_invalid_kdf_strings(void *data)
     return err;
 }
 
+/* Build a P-256 public key from raw X and Y ordinates. */
+static EVP_PKEY* test_ecdh_peer_from_xy(const BIGNUM* x, const BIGNUM* y)
+{
+    EVP_PKEY_CTX *ctx = NULL;
+    EVP_PKEY *key = NULL;
+    OSSL_PARAM_BLD *bld = NULL;
+    OSSL_PARAM *params = NULL;
+
+    bld = OSSL_PARAM_BLD_new();
+    if (bld != NULL) {
+        if ((OSSL_PARAM_BLD_push_utf8_string(bld, OSSL_PKEY_PARAM_GROUP_NAME,
+                 "prime256v1", 0) == 1) &&
+            (OSSL_PARAM_BLD_push_BN(bld, OSSL_PKEY_PARAM_EC_PUB_X, x) == 1) &&
+            (OSSL_PARAM_BLD_push_BN(bld, OSSL_PKEY_PARAM_EC_PUB_Y, y) == 1)) {
+            params = OSSL_PARAM_BLD_to_param(bld);
+        }
+        OSSL_PARAM_BLD_free(bld);
+    }
+    if (params != NULL) {
+        ctx = EVP_PKEY_CTX_new_from_name(wpLibCtx, "EC", NULL);
+    }
+    if (ctx != NULL) {
+        if ((EVP_PKEY_fromdata_init(ctx) != 1) ||
+            (EVP_PKEY_fromdata(ctx, &key, EVP_PKEY_PUBLIC_KEY, params) != 1)) {
+            EVP_PKEY_free(key);
+            key = NULL;
+        }
+        EVP_PKEY_CTX_free(ctx);
+    }
+    OSSL_PARAM_free(params);
+
+    return key;
+}
+
+/* Set raw X and Y ordinates on an existing key. */
+static int test_ecdh_set_xy(EVP_PKEY* key, const BIGNUM* x, const BIGNUM* y)
+{
+    int rc = 0;
+    OSSL_PARAM_BLD *bld = NULL;
+    OSSL_PARAM *params = NULL;
+
+    bld = OSSL_PARAM_BLD_new();
+    if (bld != NULL) {
+        if ((OSSL_PARAM_BLD_push_BN(bld, OSSL_PKEY_PARAM_EC_PUB_X, x) == 1) &&
+            (OSSL_PARAM_BLD_push_BN(bld, OSSL_PKEY_PARAM_EC_PUB_Y, y) == 1)) {
+            params = OSSL_PARAM_BLD_to_param(bld);
+        }
+        OSSL_PARAM_BLD_free(bld);
+    }
+    if (params != NULL) {
+        rc = EVP_PKEY_set_params(key, params);
+    }
+    OSSL_PARAM_free(params);
+
+    return rc;
+}
+
+/* A public key that is not on the named curve must be rejected wherever it can
+ * be supplied - a key exchange against one leaks our private key. Rejecting it
+ * must also leave a key that already held a good point alone. */
+int test_ecdh_invalid_curve_peer(void *data)
+{
+    int err;
+    EVP_PKEY *key = NULL;
+    EVP_PKEY *peer = NULL;
+    EVP_PKEY *onCurve = NULL;
+    EVP_PKEY *offCurve = NULL;
+    BIGNUM *x = NULL;
+    BIGNUM *y = NULL;
+    BIGNUM *badY = NULL;
+    unsigned char *secret = NULL;
+    const unsigned char *p;
+
+    (void)data;
+
+    PRINT_MSG("Reject ECDH peer key that is not on the curve");
+
+    p = ecc_key_der_256;
+    key = d2i_PrivateKey_ex(EVP_PKEY_EC, NULL, &p, sizeof(ecc_key_der_256),
+        wpLibCtx, NULL);
+    err = key == NULL;
+    if (err == 0) {
+        p = ecc_peerkey_der_256;
+        peer = d2i_PrivateKey_ex(EVP_PKEY_EC, NULL, &p,
+            sizeof(ecc_peerkey_der_256), wpLibCtx, NULL);
+        err = peer == NULL;
+    }
+    if (err == 0) {
+        err = EVP_PKEY_get_bn_param(peer, OSSL_PKEY_PARAM_EC_PUB_X, &x) != 1;
+    }
+    if (err == 0) {
+        err = EVP_PKEY_get_bn_param(peer, OSSL_PKEY_PARAM_EC_PUB_Y, &y) != 1;
+    }
+    if (err == 0) {
+        /* (X, Y + 1) satisfies X != 0 but is not on P-256. */
+        err = (badY = BN_dup(y)) == NULL;
+    }
+    if (err == 0) {
+        err = BN_add_word(badY, 1) != 1;
+    }
+
+    if (err == 0) {
+        PRINT_MSG("Import of an off-curve point must fail");
+        offCurve = test_ecdh_peer_from_xy(x, badY);
+        err = offCurve != NULL;
+        if (err != 0) {
+            PRINT_ERR_MSG("Imported public key not on the curve");
+        }
+    }
+    if (err == 0) {
+        PRINT_MSG("Setting an off-curve point on a live key must fail");
+        err = test_ecdh_set_xy(peer, x, badY) == 1;
+        if (err != 0) {
+            PRINT_ERR_MSG("Set public key not on the curve");
+        }
+    }
+    if (err == 0) {
+        PRINT_MSG("Rejected point must leave the peer key as it was");
+        err = test_ecdh_derive(key, peer, &secret, sizeof(ecc_derived_256));
+        if (err != 0) {
+            PRINT_ERR_MSG("Rejected point destroyed the peer's public key");
+        }
+    }
+    if (err == 0) {
+        err = memcmp(secret, ecc_derived_256, sizeof(ecc_derived_256)) != 0;
+        if (err != 0) {
+            PRINT_ERR_MSG("Secret does not match, expected!");
+        }
+        OPENSSL_free(secret);
+        secret = NULL;
+    }
+
+    if (err == 0) {
+        PRINT_MSG("Ordinates of a real point are still accepted");
+        onCurve = test_ecdh_peer_from_xy(x, y);
+        err = onCurve == NULL;
+    }
+    if (err == 0) {
+        err = test_ecdh_derive(key, onCurve, &secret, sizeof(ecc_derived_256));
+    }
+    if (err == 0) {
+        err = memcmp(secret, ecc_derived_256, sizeof(ecc_derived_256)) != 0;
+        if (err != 0) {
+            PRINT_ERR_MSG("Secret does not match, expected!");
+        }
+    }
+
+    OPENSSL_free(secret);
+    BN_free(badY);
+    BN_free(y);
+    BN_free(x);
+    EVP_PKEY_free(offCurve);
+    EVP_PKEY_free(onCurve);
+    EVP_PKEY_free(peer);
+    EVP_PKEY_free(key);
+
+    return err;
+}
+
 #if defined(HAVE_X963_KDF) && defined(WP_HAVE_SHA256)
 /* Apply X9.63 KDF using OpenSSL's reference implementation so we can compare
  * against wolfProvider's output. */

--- a/test/unit.c
+++ b/test/unit.c
@@ -451,6 +451,7 @@ TEST_CASE test_case[] = {
         TEST_DECL(test_ecdh_p256_keygen, NULL),
     #endif
         TEST_DECL(test_ecdh_invalid_kdf_strings, NULL),
+        TEST_DECL(test_ecdh_invalid_curve_peer, NULL),
         TEST_DECL(test_ecdh_p256, NULL),
         #if defined(HAVE_X963_KDF) && defined(WP_HAVE_SHA256)
         TEST_DECL(test_ecdh_x963_kdf, NULL),

--- a/test/unit.c
+++ b/test/unit.c
@@ -451,7 +451,9 @@ TEST_CASE test_case[] = {
         TEST_DECL(test_ecdh_p256_keygen, NULL),
     #endif
         TEST_DECL(test_ecdh_invalid_kdf_strings, NULL),
+        #ifdef USE_ECC_B_PARAM
         TEST_DECL(test_ecdh_invalid_curve_peer, NULL),
+        #endif
         TEST_DECL(test_ecdh_p256, NULL),
         #if defined(HAVE_X963_KDF) && defined(WP_HAVE_SHA256)
         TEST_DECL(test_ecdh_x963_kdf, NULL),

--- a/test/unit.h
+++ b/test/unit.h
@@ -501,7 +501,9 @@ int test_ecdh_p224(void *data);
 #endif /* WP_HAVE_EC_P224 */
 #ifdef WP_HAVE_EC_P256
 int test_ecdh_invalid_kdf_strings(void *data);
+#ifdef USE_ECC_B_PARAM
 int test_ecdh_invalid_curve_peer(void *data);
+#endif
 #ifdef WP_HAVE_EPKI_TEST
 int test_ecc_encode_epki(void *data);
 #endif

--- a/test/unit.h
+++ b/test/unit.h
@@ -501,6 +501,7 @@ int test_ecdh_p224(void *data);
 #endif /* WP_HAVE_EC_P224 */
 #ifdef WP_HAVE_EC_P256
 int test_ecdh_invalid_kdf_strings(void *data);
+int test_ecdh_invalid_curve_peer(void *data);
 #ifdef WP_HAVE_EPKI_TEST
 int test_ecc_encode_epki(void *data);
 #endif


### PR DESCRIPTION
`wp_ecdh_set_peer` now runs a full public key check (on-curve + correct order). `wp_ecdh_derive_secret` re-checks the point before use.

Relatedly, fixes the quick-validate path, which was dead code behind USE_ECC_B_PARAM and had an inverted wc_ecc_point_is_on_curve test plus a curve id passed where an index was expected.

Fixes F-4287