### PR TITLE
kmgmt: add encoder import-object wrappers

### DIFF
--- a/src/wp_dh_kmgmt.c
+++ b/src/wp_dh_kmgmt.c
@@ -3016,6 +3016,30 @@ static int wp_dh_export_object(wp_DhEncDecCtx* ctx, wp_Dh* dh, size_t size,
     return wp_dh_export(dh, ctx->selection, exportCb, exportCbArg);
 }
 
+/**
+ * Create a DH key object and import the key data into it.
+ *
+ * @param [in] ctx        DH encoder/decoder context object.
+ * @param [in] selection  Parts of key to import.
+ * @param [in] params     Array of parameters with key data.
+ * @return  New DH key object on success.
+ * @return  NULL on failure.
+ */
+static wp_Dh* wp_dh_import_object(wp_DhEncDecCtx* ctx, int selection,
+    const OSSL_PARAM params[])
+{
+    wp_Dh* dh;
+
+    WOLFPROV_ENTER(WP_LOG_COMP_DH, "wp_dh_import_object");
+
+    dh = wp_dh_new(ctx->provCtx);
+    if ((dh != NULL) && (!wp_dh_import(dh, selection, params))) {
+        wp_dh_free(dh);
+        dh = NULL;
+    }
+    return dh;
+}
+
 /*
  * DH Parameters
  */
@@ -3100,7 +3124,7 @@ const OSSL_DISPATCH wp_dh_type_specific_der_encoder_functions[] = {
     { OSSL_FUNC_ENCODER_DOES_SELECTION,
                                    (DFUNC)wp_dh_type_specific_does_selection },
     { OSSL_FUNC_ENCODER_ENCODE,         (DFUNC)wp_dh_encode                  },
-    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_dh_import                  },
+    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_dh_import_object           },
     { OSSL_FUNC_ENCODER_FREE_OBJECT,    (DFUNC)wp_dh_free                    },
     { 0, NULL }
 };
@@ -3130,7 +3154,7 @@ const OSSL_DISPATCH wp_dh_type_specific_pem_encoder_functions[] = {
     { OSSL_FUNC_ENCODER_DOES_SELECTION,
                                    (DFUNC)wp_dh_type_specific_does_selection },
     { OSSL_FUNC_ENCODER_ENCODE,         (DFUNC)wp_dh_encode                  },
-    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_dh_import                  },
+    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_dh_import_object           },
     { OSSL_FUNC_ENCODER_FREE_OBJECT,    (DFUNC)wp_dh_free                    },
     { 0, NULL }
 };
@@ -3214,7 +3238,7 @@ const OSSL_DISPATCH wp_dh_spki_der_encoder_functions[] = {
     { OSSL_FUNC_ENCODER_SET_CTX_PARAMS, (DFUNC)wp_dh_enc_dec_set_ctx_params  },
     { OSSL_FUNC_ENCODER_DOES_SELECTION, (DFUNC)wp_dh_spki_does_selection     },
     { OSSL_FUNC_ENCODER_ENCODE,         (DFUNC)wp_dh_encode                  },
-    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_dh_import                  },
+    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_dh_import_object           },
     { OSSL_FUNC_ENCODER_FREE_OBJECT,    (DFUNC)wp_dh_free                    },
     { 0, NULL }
 };
@@ -3242,7 +3266,7 @@ const OSSL_DISPATCH wp_dh_spki_pem_encoder_functions[] = {
     { OSSL_FUNC_ENCODER_SET_CTX_PARAMS, (DFUNC)wp_dh_enc_dec_set_ctx_params  },
     { OSSL_FUNC_ENCODER_DOES_SELECTION, (DFUNC)wp_dh_spki_does_selection     },
     { OSSL_FUNC_ENCODER_ENCODE,         (DFUNC)wp_dh_encode                  },
-    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_dh_import                  },
+    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_dh_import_object           },
     { OSSL_FUNC_ENCODER_FREE_OBJECT,    (DFUNC)wp_dh_free                    },
     { 0, NULL }
 };
@@ -3326,7 +3350,7 @@ const OSSL_DISPATCH wp_dh_pki_der_encoder_functions[] = {
     { OSSL_FUNC_ENCODER_SET_CTX_PARAMS, (DFUNC)wp_dh_enc_dec_set_ctx_params  },
     { OSSL_FUNC_ENCODER_DOES_SELECTION, (DFUNC)wp_dh_pki_does_selection      },
     { OSSL_FUNC_ENCODER_ENCODE,         (DFUNC)wp_dh_encode                  },
-    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_dh_import                  },
+    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_dh_import_object           },
     { OSSL_FUNC_ENCODER_FREE_OBJECT,    (DFUNC)wp_dh_free                    },
     { 0, NULL }
 };
@@ -3354,7 +3378,7 @@ const OSSL_DISPATCH wp_dh_pki_pem_encoder_functions[] = {
     { OSSL_FUNC_ENCODER_SET_CTX_PARAMS, (DFUNC)wp_dh_enc_dec_set_ctx_params  },
     { OSSL_FUNC_ENCODER_DOES_SELECTION, (DFUNC)wp_dh_pki_does_selection      },
     { OSSL_FUNC_ENCODER_ENCODE,         (DFUNC)wp_dh_encode                  },
-    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_dh_import                  },
+    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_dh_import_object           },
     { OSSL_FUNC_ENCODER_FREE_OBJECT,    (DFUNC)wp_dh_free                    },
     { 0, NULL }
 };
@@ -3386,7 +3410,7 @@ const OSSL_DISPATCH wp_dh_epki_der_encoder_functions[] = {
     { OSSL_FUNC_ENCODER_SET_CTX_PARAMS, (DFUNC)wp_dh_enc_dec_set_ctx_params  },
     { OSSL_FUNC_ENCODER_DOES_SELECTION, (DFUNC)wp_dh_pki_does_selection      },
     { OSSL_FUNC_ENCODER_ENCODE,         (DFUNC)wp_dh_encode                  },
-    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_dh_import                  },
+    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_dh_import_object           },
     { OSSL_FUNC_ENCODER_FREE_OBJECT,    (DFUNC)wp_dh_free                    },
     { 0, NULL }
 };
@@ -3414,7 +3438,7 @@ const OSSL_DISPATCH wp_dh_epki_pem_encoder_functions[] = {
     { OSSL_FUNC_ENCODER_SET_CTX_PARAMS, (DFUNC)wp_dh_enc_dec_set_ctx_params  },
     { OSSL_FUNC_ENCODER_DOES_SELECTION, (DFUNC)wp_dh_pki_does_selection      },
     { OSSL_FUNC_ENCODER_ENCODE,         (DFUNC)wp_dh_encode                  },
-    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_dh_import                  },
+    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_dh_import_object           },
     { OSSL_FUNC_ENCODER_FREE_OBJECT,    (DFUNC)wp_dh_free                    },
     { 0, NULL }
 };

--- a/src/wp_ecc_kmgmt.c
+++ b/src/wp_ecc_kmgmt.c
@@ -3128,6 +3128,27 @@ static int wp_ecc_export_object(wp_EccEncDecCtx* ctx, wp_Ecc* ecc, size_t size,
     return wp_ecc_export(ecc, ctx->selection, exportCb, exportCbArg);
 }
 
+/**
+ * Create an ECC key object and import the key data into it.
+ *
+ * @param [in] ctx        ECC encoder/decoder context object.
+ * @param [in] selection  Parts of key to import.
+ * @param [in] params     Array of parameters with key data.
+ * @return  New ECC key object on success.
+ * @return  NULL on failure.
+ */
+static wp_Ecc* wp_ecc_import_object(wp_EccEncDecCtx* ctx, int selection,
+    const OSSL_PARAM params[])
+{
+    wp_Ecc* ecc = wp_ecc_new(ctx->provCtx);
+
+    if ((ecc != NULL) && (!wp_ecc_import(ecc, selection, params))) {
+        wp_ecc_free(ecc);
+        ecc = NULL;
+    }
+    return ecc;
+}
+
 /*
  * ECC Type-Specific
  */
@@ -3211,7 +3232,7 @@ const OSSL_DISPATCH wp_ecc_type_specific_der_encoder_functions[] = {
     { OSSL_FUNC_ENCODER_DOES_SELECTION,
                                    (DFUNC)wp_ecc_type_specific_does_selection },
     { OSSL_FUNC_ENCODER_ENCODE,         (DFUNC)wp_ecc_encode                  },
-    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_ecc_import                  },
+    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_ecc_import_object           },
     { OSSL_FUNC_ENCODER_FREE_OBJECT,    (DFUNC)wp_ecc_free                    },
     { 0, NULL }
 };
@@ -3242,7 +3263,7 @@ const OSSL_DISPATCH wp_ecc_type_specific_pem_encoder_functions[] = {
     { OSSL_FUNC_ENCODER_DOES_SELECTION,
                                    (DFUNC)wp_ecc_type_specific_does_selection },
     { OSSL_FUNC_ENCODER_ENCODE,         (DFUNC)wp_ecc_encode                  },
-    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_ecc_import                  },
+    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_ecc_import_object           },
     { OSSL_FUNC_ENCODER_FREE_OBJECT,    (DFUNC)wp_ecc_free                    },
     { 0, NULL }
 };
@@ -3326,7 +3347,7 @@ const OSSL_DISPATCH wp_ecc_spki_der_encoder_functions[] = {
     { OSSL_FUNC_ENCODER_SET_CTX_PARAMS, (DFUNC)wp_ecc_enc_dec_set_ctx_params  },
     { OSSL_FUNC_ENCODER_DOES_SELECTION, (DFUNC)wp_ecc_spki_does_selection     },
     { OSSL_FUNC_ENCODER_ENCODE,         (DFUNC)wp_ecc_encode                  },
-    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_ecc_import                  },
+    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_ecc_import_object           },
     { OSSL_FUNC_ENCODER_FREE_OBJECT,    (DFUNC)wp_ecc_free                    },
     { 0, NULL }
 };
@@ -3354,7 +3375,7 @@ const OSSL_DISPATCH wp_ecc_spki_pem_encoder_functions[] = {
     { OSSL_FUNC_ENCODER_SET_CTX_PARAMS, (DFUNC)wp_ecc_enc_dec_set_ctx_params  },
     { OSSL_FUNC_ENCODER_DOES_SELECTION, (DFUNC)wp_ecc_spki_does_selection     },
     { OSSL_FUNC_ENCODER_ENCODE,         (DFUNC)wp_ecc_encode                  },
-    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_ecc_import                  },
+    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_ecc_import_object           },
     { OSSL_FUNC_ENCODER_FREE_OBJECT,    (DFUNC)wp_ecc_free                    },
     { 0, NULL }
 };
@@ -3438,7 +3459,7 @@ const OSSL_DISPATCH wp_ecc_pki_der_encoder_functions[] = {
     { OSSL_FUNC_ENCODER_SET_CTX_PARAMS, (DFUNC)wp_ecc_enc_dec_set_ctx_params  },
     { OSSL_FUNC_ENCODER_DOES_SELECTION, (DFUNC)wp_ecc_pki_does_selection      },
     { OSSL_FUNC_ENCODER_ENCODE,         (DFUNC)wp_ecc_encode                  },
-    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_ecc_import                  },
+    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_ecc_import_object           },
     { OSSL_FUNC_ENCODER_FREE_OBJECT,    (DFUNC)wp_ecc_free                    },
     { 0, NULL }
 };
@@ -3466,7 +3487,7 @@ const OSSL_DISPATCH wp_ecc_pki_pem_encoder_functions[] = {
     { OSSL_FUNC_ENCODER_SET_CTX_PARAMS, (DFUNC)wp_ecc_enc_dec_set_ctx_params  },
     { OSSL_FUNC_ENCODER_DOES_SELECTION, (DFUNC)wp_ecc_pki_does_selection      },
     { OSSL_FUNC_ENCODER_ENCODE,         (DFUNC)wp_ecc_encode                  },
-    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_ecc_import                  },
+    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_ecc_import_object           },
     { OSSL_FUNC_ENCODER_FREE_OBJECT,    (DFUNC)wp_ecc_free                    },
     { 0, NULL }
 };
@@ -3498,7 +3519,7 @@ const OSSL_DISPATCH wp_ecc_epki_der_encoder_functions[] = {
     { OSSL_FUNC_ENCODER_SET_CTX_PARAMS, (DFUNC)wp_ecc_enc_dec_set_ctx_params  },
     { OSSL_FUNC_ENCODER_DOES_SELECTION, (DFUNC)wp_ecc_pki_does_selection      },
     { OSSL_FUNC_ENCODER_ENCODE,         (DFUNC)wp_ecc_encode                  },
-    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_ecc_import                  },
+    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_ecc_import_object           },
     { OSSL_FUNC_ENCODER_FREE_OBJECT,    (DFUNC)wp_ecc_free                    },
     { 0, NULL }
 };
@@ -3526,7 +3547,7 @@ const OSSL_DISPATCH wp_ecc_epki_pem_encoder_functions[] = {
     { OSSL_FUNC_ENCODER_SET_CTX_PARAMS, (DFUNC)wp_ecc_enc_dec_set_ctx_params  },
     { OSSL_FUNC_ENCODER_DOES_SELECTION, (DFUNC)wp_ecc_pki_does_selection      },
     { OSSL_FUNC_ENCODER_ENCODE,         (DFUNC)wp_ecc_encode                  },
-    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_ecc_import                  },
+    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_ecc_import_object           },
     { OSSL_FUNC_ENCODER_FREE_OBJECT,    (DFUNC)wp_ecc_free                    },
     { 0, NULL }
 };
@@ -3614,7 +3635,7 @@ const OSSL_DISPATCH wp_ecc_x9_62_der_encoder_functions[] = {
     { OSSL_FUNC_ENCODER_DOES_SELECTION,
                                         (DFUNC)wp_ecc_x9_62_does_selection    },
     { OSSL_FUNC_ENCODER_ENCODE,         (DFUNC)wp_ecc_encode                  },
-    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_ecc_import                  },
+    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_ecc_import_object           },
     { OSSL_FUNC_ENCODER_FREE_OBJECT,    (DFUNC)wp_ecc_free                    },
     { 0, NULL }
 };
@@ -3644,7 +3665,7 @@ const OSSL_DISPATCH wp_ecc_x9_62_pem_encoder_functions[] = {
     { OSSL_FUNC_ENCODER_DOES_SELECTION,
                                         (DFUNC)wp_ecc_x9_62_does_selection    },
     { OSSL_FUNC_ENCODER_ENCODE,         (DFUNC)wp_ecc_encode                  },
-    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_ecc_import                  },
+    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_ecc_import_object           },
     { OSSL_FUNC_ENCODER_FREE_OBJECT,    (DFUNC)wp_ecc_free                    },
     { 0, NULL }
 };

--- a/src/wp_ecx_kmgmt.c
+++ b/src/wp_ecx_kmgmt.c
@@ -2078,6 +2078,59 @@ static int wp_ecx_decode_enc_pki(wp_EcxEncDecCtx* ctx, wp_Ecx* ecx,
 #endif
 
 /**
+ * Create an ECX key object of the type the context was created for.
+ *
+ * @param [in]  provCtx   Provider context.
+ * @param [in]  keyType   Type of ECX key to create.
+ * @param [out] dataType  Data type name of the key. May be NULL.
+ * @return  New ECX key object on success.
+ * @return  NULL on failure.
+ */
+static wp_Ecx* wp_ecx_new_by_type(WOLFPROV_CTX* provCtx, int keyType,
+    const char** dataType)
+{
+    wp_Ecx* ecx;
+    const char* name = NULL;
+
+#ifdef WP_HAVE_X25519
+    if (keyType == WP_KEY_TYPE_X25519) {
+        ecx = wp_x25519_new(provCtx);
+        name = "X25519";
+    }
+    else
+#endif /* WP_HAVE_X25519 */
+#ifdef WP_HAVE_ED25519
+    if (keyType == WP_KEY_TYPE_ED25519) {
+        ecx = wp_ed25519_new(provCtx);
+        name = "ED25519";
+    }
+    else
+#endif /* WP_HAVE_ED25519 */
+#ifdef WP_HAVE_X448
+    if (keyType == WP_KEY_TYPE_X448) {
+        ecx = wp_x448_new(provCtx);
+        name = "X448";
+    }
+    else
+#endif /* WP_HAVE_X448 */
+#ifdef WP_HAVE_ED448
+    if (keyType == WP_KEY_TYPE_ED448) {
+        ecx = wp_ed448_new(provCtx);
+        name = "ED448";
+    }
+    else
+#endif /* WP_HAVE_ED448 */
+    {
+        ecx = NULL;
+    }
+
+    if (dataType != NULL) {
+        *dataType = name;
+    }
+    return ecx;
+}
+
+/**
  * Decode the data in the core BIO.
  *
  * The format of the key must be the same as the decoder's format.
@@ -2116,37 +2169,7 @@ static int wp_ecx_decode(wp_EcxEncDecCtx* ctx, OSSL_CORE_BIO* cBio,
 
     if (ok) {
         ctx->selection = selection;
-#ifdef WP_HAVE_X25519
-        if (ctx->keyType == WP_KEY_TYPE_X25519) {
-            ecx = wp_x25519_new(ctx->provCtx);
-            dataType = "X25519";
-        }
-        else
-#endif /* WP_HAVE_X25519 */
-#ifdef WP_HAVE_ED25519
-        if (ctx->keyType == WP_KEY_TYPE_ED25519) {
-            ecx = wp_ed25519_new(ctx->provCtx);
-            dataType = "ED25519";
-        }
-        else
-#endif /* WP_HAVE_ED25519 */
-#ifdef WP_HAVE_X448
-        if (ctx->keyType == WP_KEY_TYPE_X448) {
-            ecx = wp_x448_new(ctx->provCtx);
-            dataType = "X448";
-        }
-        else
-#endif /* WP_HAVE_X448 */
-#ifdef WP_HAVE_ED448
-        if (ctx->keyType == WP_KEY_TYPE_ED448) {
-            ecx = wp_ed448_new(ctx->provCtx);
-            dataType = "ED448";
-        }
-        else
-#endif /* WP_HAVE_ED448 */
-        {
-            ecx = NULL;
-        }
+        ecx = wp_ecx_new_by_type(ctx->provCtx, ctx->keyType, &dataType);
         if (ecx == NULL) {
             ok = 0;
         }
@@ -2353,6 +2376,27 @@ static int wp_ecx_export_object(wp_EcxEncDecCtx* ctx, wp_Ecx* ecx, size_t size,
     return wp_ecx_export(ecx, ctx->selection, exportCb, exportCbArg);
 }
 
+/**
+ * Create an ECX key object and import the key data into it.
+ *
+ * @param [in] ctx        ECX encoder/decoder context object.
+ * @param [in] selection  Parts of key to import.
+ * @param [in] params     Array of parameters with key data.
+ * @return  New ECX key object on success.
+ * @return  NULL on failure.
+ */
+static wp_Ecx* wp_ecx_import_object(wp_EcxEncDecCtx* ctx, int selection,
+    const OSSL_PARAM params[])
+{
+    wp_Ecx* ecx = wp_ecx_new_by_type(ctx->provCtx, ctx->keyType, NULL);
+
+    if ((ecx != NULL) && (!wp_ecx_import(ecx, selection, params))) {
+        wp_ecx_free(ecx);
+        ecx = NULL;
+    }
+    return ecx;
+}
+
 /*
  * ECX SubkectPublicKeyInfo
  */
@@ -2537,7 +2581,7 @@ const OSSL_DISPATCH wp_x25519_spki_der_encoder_functions[] = {
     { OSSL_FUNC_ENCODER_SET_CTX_PARAMS, (DFUNC)wp_ecx_enc_dec_set_ctx_params  },
     { OSSL_FUNC_ENCODER_DOES_SELECTION, (DFUNC)wp_ecx_spki_does_selection     },
     { OSSL_FUNC_ENCODER_ENCODE,         (DFUNC)wp_ecx_encode                  },
-    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_ecx_import                  },
+    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_ecx_import_object           },
     { OSSL_FUNC_ENCODER_FREE_OBJECT,    (DFUNC)wp_ecx_free                    },
     { 0, NULL }
 };
@@ -2566,7 +2610,7 @@ const OSSL_DISPATCH wp_x25519_spki_pem_encoder_functions[] = {
     { OSSL_FUNC_ENCODER_SET_CTX_PARAMS, (DFUNC)wp_ecx_enc_dec_set_ctx_params  },
     { OSSL_FUNC_ENCODER_DOES_SELECTION, (DFUNC)wp_ecx_spki_does_selection     },
     { OSSL_FUNC_ENCODER_ENCODE,         (DFUNC)wp_ecx_encode                  },
-    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_ecx_import                  },
+    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_ecx_import_object           },
     { OSSL_FUNC_ENCODER_FREE_OBJECT,    (DFUNC)wp_ecx_free                    },
     { 0, NULL }
 };
@@ -2689,7 +2733,7 @@ const OSSL_DISPATCH wp_x25519_pki_der_encoder_functions[] = {
     { OSSL_FUNC_ENCODER_SET_CTX_PARAMS, (DFUNC)wp_ecx_enc_dec_set_ctx_params  },
     { OSSL_FUNC_ENCODER_DOES_SELECTION, (DFUNC)wp_ecx_pki_does_selection      },
     { OSSL_FUNC_ENCODER_ENCODE,         (DFUNC)wp_ecx_encode                  },
-    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_ecx_import                  },
+    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_ecx_import_object           },
     { OSSL_FUNC_ENCODER_FREE_OBJECT,    (DFUNC)wp_ecx_free                    },
     { 0, NULL }
 };
@@ -2718,7 +2762,7 @@ const OSSL_DISPATCH wp_x25519_pki_pem_encoder_functions[] = {
     { OSSL_FUNC_ENCODER_SET_CTX_PARAMS, (DFUNC)wp_ecx_enc_dec_set_ctx_params  },
     { OSSL_FUNC_ENCODER_DOES_SELECTION, (DFUNC)wp_ecx_pki_does_selection      },
     { OSSL_FUNC_ENCODER_ENCODE,         (DFUNC)wp_ecx_encode                  },
-    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_ecx_import                  },
+    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_ecx_import_object           },
     { OSSL_FUNC_ENCODER_FREE_OBJECT,    (DFUNC)wp_ecx_free                    },
     { 0, NULL }
 };
@@ -2751,7 +2795,7 @@ const OSSL_DISPATCH wp_x25519_epki_der_encoder_functions[] = {
     { OSSL_FUNC_ENCODER_SET_CTX_PARAMS, (DFUNC)wp_ecx_enc_dec_set_ctx_params  },
     { OSSL_FUNC_ENCODER_DOES_SELECTION, (DFUNC)wp_ecx_pki_does_selection      },
     { OSSL_FUNC_ENCODER_ENCODE,         (DFUNC)wp_ecx_encode                  },
-    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_ecx_import                  },
+    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_ecx_import_object           },
     { OSSL_FUNC_ENCODER_FREE_OBJECT,    (DFUNC)wp_ecx_free                    },
     { 0, NULL }
 };
@@ -2780,7 +2824,7 @@ const OSSL_DISPATCH wp_x25519_epki_pem_encoder_functions[] = {
     { OSSL_FUNC_ENCODER_SET_CTX_PARAMS, (DFUNC)wp_ecx_enc_dec_set_ctx_params  },
     { OSSL_FUNC_ENCODER_DOES_SELECTION, (DFUNC)wp_ecx_pki_does_selection      },
     { OSSL_FUNC_ENCODER_ENCODE,         (DFUNC)wp_ecx_encode                  },
-    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_ecx_import                  },
+    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_ecx_import_object           },
     { OSSL_FUNC_ENCODER_FREE_OBJECT,    (DFUNC)wp_ecx_free                    },
     { 0, NULL }
 };
@@ -2882,7 +2926,7 @@ const OSSL_DISPATCH wp_ed25519_spki_der_encoder_functions[] = {
     { OSSL_FUNC_ENCODER_SET_CTX_PARAMS, (DFUNC)wp_ecx_enc_dec_set_ctx_params  },
     { OSSL_FUNC_ENCODER_DOES_SELECTION, (DFUNC)wp_ecx_spki_does_selection     },
     { OSSL_FUNC_ENCODER_ENCODE,         (DFUNC)wp_ecx_encode                  },
-    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_ecx_import                  },
+    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_ecx_import_object           },
     { OSSL_FUNC_ENCODER_FREE_OBJECT,    (DFUNC)wp_ecx_free                    },
     { 0, NULL }
 };
@@ -2911,7 +2955,7 @@ const OSSL_DISPATCH wp_ed25519_spki_pem_encoder_functions[] = {
     { OSSL_FUNC_ENCODER_SET_CTX_PARAMS, (DFUNC)wp_ecx_enc_dec_set_ctx_params  },
     { OSSL_FUNC_ENCODER_DOES_SELECTION, (DFUNC)wp_ecx_spki_does_selection     },
     { OSSL_FUNC_ENCODER_ENCODE,         (DFUNC)wp_ecx_encode                  },
-    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_ecx_import                  },
+    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_ecx_import_object           },
     { OSSL_FUNC_ENCODER_FREE_OBJECT,    (DFUNC)wp_ecx_free                    },
     { 0, NULL }
 };
@@ -2971,7 +3015,7 @@ const OSSL_DISPATCH wp_ed25519_pki_der_encoder_functions[] = {
     { OSSL_FUNC_ENCODER_SET_CTX_PARAMS, (DFUNC)wp_ecx_enc_dec_set_ctx_params  },
     { OSSL_FUNC_ENCODER_DOES_SELECTION, (DFUNC)wp_ecx_pki_does_selection      },
     { OSSL_FUNC_ENCODER_ENCODE,         (DFUNC)wp_ecx_encode                  },
-    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_ecx_import                  },
+    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_ecx_import_object           },
     { OSSL_FUNC_ENCODER_FREE_OBJECT,    (DFUNC)wp_ecx_free                    },
     { 0, NULL }
 };
@@ -3000,7 +3044,7 @@ const OSSL_DISPATCH wp_ed25519_pki_pem_encoder_functions[] = {
     { OSSL_FUNC_ENCODER_SET_CTX_PARAMS, (DFUNC)wp_ecx_enc_dec_set_ctx_params  },
     { OSSL_FUNC_ENCODER_DOES_SELECTION, (DFUNC)wp_ecx_pki_does_selection      },
     { OSSL_FUNC_ENCODER_ENCODE,         (DFUNC)wp_ecx_encode                  },
-    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_ecx_import                  },
+    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_ecx_import_object           },
     { OSSL_FUNC_ENCODER_FREE_OBJECT,    (DFUNC)wp_ecx_free                    },
     { 0, NULL }
 };
@@ -3033,7 +3077,7 @@ const OSSL_DISPATCH wp_ed25519_epki_der_encoder_functions[] = {
     { OSSL_FUNC_ENCODER_SET_CTX_PARAMS, (DFUNC)wp_ecx_enc_dec_set_ctx_params  },
     { OSSL_FUNC_ENCODER_DOES_SELECTION, (DFUNC)wp_ecx_pki_does_selection      },
     { OSSL_FUNC_ENCODER_ENCODE,         (DFUNC)wp_ecx_encode                  },
-    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_ecx_import                  },
+    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_ecx_import_object           },
     { OSSL_FUNC_ENCODER_FREE_OBJECT,    (DFUNC)wp_ecx_free                    },
     { 0, NULL }
 };
@@ -3062,7 +3106,7 @@ const OSSL_DISPATCH wp_ed25519_epki_pem_encoder_functions[] = {
     { OSSL_FUNC_ENCODER_SET_CTX_PARAMS, (DFUNC)wp_ecx_enc_dec_set_ctx_params  },
     { OSSL_FUNC_ENCODER_DOES_SELECTION, (DFUNC)wp_ecx_pki_does_selection      },
     { OSSL_FUNC_ENCODER_ENCODE,         (DFUNC)wp_ecx_encode                  },
-    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_ecx_import                  },
+    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_ecx_import_object           },
     { OSSL_FUNC_ENCODER_FREE_OBJECT,    (DFUNC)wp_ecx_free                    },
     { 0, NULL }
 };
@@ -3188,7 +3232,7 @@ const OSSL_DISPATCH wp_x448_spki_der_encoder_functions[] = {
     { OSSL_FUNC_ENCODER_SET_CTX_PARAMS, (DFUNC)wp_ecx_enc_dec_set_ctx_params  },
     { OSSL_FUNC_ENCODER_DOES_SELECTION, (DFUNC)wp_ecx_spki_does_selection     },
     { OSSL_FUNC_ENCODER_ENCODE,         (DFUNC)wp_ecx_encode                  },
-    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_ecx_import                  },
+    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_ecx_import_object           },
     { OSSL_FUNC_ENCODER_FREE_OBJECT,    (DFUNC)wp_ecx_free                    },
     { 0, NULL }
 };
@@ -3217,7 +3261,7 @@ const OSSL_DISPATCH wp_x448_spki_pem_encoder_functions[] = {
     { OSSL_FUNC_ENCODER_SET_CTX_PARAMS, (DFUNC)wp_ecx_enc_dec_set_ctx_params  },
     { OSSL_FUNC_ENCODER_DOES_SELECTION, (DFUNC)wp_ecx_spki_does_selection     },
     { OSSL_FUNC_ENCODER_ENCODE,         (DFUNC)wp_ecx_encode                  },
-    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_ecx_import                  },
+    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_ecx_import_object           },
     { OSSL_FUNC_ENCODER_FREE_OBJECT,    (DFUNC)wp_ecx_free                    },
     { 0, NULL }
 };
@@ -3340,7 +3384,7 @@ const OSSL_DISPATCH wp_x448_pki_der_encoder_functions[] = {
     { OSSL_FUNC_ENCODER_SET_CTX_PARAMS, (DFUNC)wp_ecx_enc_dec_set_ctx_params  },
     { OSSL_FUNC_ENCODER_DOES_SELECTION, (DFUNC)wp_ecx_pki_does_selection      },
     { OSSL_FUNC_ENCODER_ENCODE,         (DFUNC)wp_ecx_encode                  },
-    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_ecx_import                  },
+    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_ecx_import_object           },
     { OSSL_FUNC_ENCODER_FREE_OBJECT,    (DFUNC)wp_ecx_free                    },
     { 0, NULL }
 };
@@ -3369,7 +3413,7 @@ const OSSL_DISPATCH wp_x448_pki_pem_encoder_functions[] = {
     { OSSL_FUNC_ENCODER_SET_CTX_PARAMS, (DFUNC)wp_ecx_enc_dec_set_ctx_params  },
     { OSSL_FUNC_ENCODER_DOES_SELECTION, (DFUNC)wp_ecx_pki_does_selection      },
     { OSSL_FUNC_ENCODER_ENCODE,         (DFUNC)wp_ecx_encode                  },
-    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_ecx_import                  },
+    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_ecx_import_object           },
     { OSSL_FUNC_ENCODER_FREE_OBJECT,    (DFUNC)wp_ecx_free                    },
     { 0, NULL }
 };
@@ -3402,7 +3446,7 @@ const OSSL_DISPATCH wp_x448_epki_der_encoder_functions[] = {
     { OSSL_FUNC_ENCODER_SET_CTX_PARAMS, (DFUNC)wp_ecx_enc_dec_set_ctx_params  },
     { OSSL_FUNC_ENCODER_DOES_SELECTION, (DFUNC)wp_ecx_pki_does_selection      },
     { OSSL_FUNC_ENCODER_ENCODE,         (DFUNC)wp_ecx_encode                  },
-    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_ecx_import                  },
+    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_ecx_import_object           },
     { OSSL_FUNC_ENCODER_FREE_OBJECT,    (DFUNC)wp_ecx_free                    },
     { 0, NULL }
 };
@@ -3431,7 +3475,7 @@ const OSSL_DISPATCH wp_x448_epki_pem_encoder_functions[] = {
     { OSSL_FUNC_ENCODER_SET_CTX_PARAMS, (DFUNC)wp_ecx_enc_dec_set_ctx_params  },
     { OSSL_FUNC_ENCODER_DOES_SELECTION, (DFUNC)wp_ecx_pki_does_selection      },
     { OSSL_FUNC_ENCODER_ENCODE,         (DFUNC)wp_ecx_encode                  },
-    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_ecx_import                  },
+    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_ecx_import_object           },
     { OSSL_FUNC_ENCODER_FREE_OBJECT,    (DFUNC)wp_ecx_free                    },
     { 0, NULL }
 };
@@ -3532,7 +3576,7 @@ const OSSL_DISPATCH wp_ed448_spki_der_encoder_functions[] = {
     { OSSL_FUNC_ENCODER_SET_CTX_PARAMS, (DFUNC)wp_ecx_enc_dec_set_ctx_params  },
     { OSSL_FUNC_ENCODER_DOES_SELECTION, (DFUNC)wp_ecx_spki_does_selection     },
     { OSSL_FUNC_ENCODER_ENCODE,         (DFUNC)wp_ecx_encode                  },
-    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_ecx_import                  },
+    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_ecx_import_object           },
     { OSSL_FUNC_ENCODER_FREE_OBJECT,    (DFUNC)wp_ecx_free                    },
     { 0, NULL }
 };
@@ -3561,7 +3605,7 @@ const OSSL_DISPATCH wp_ed448_spki_pem_encoder_functions[] = {
     { OSSL_FUNC_ENCODER_SET_CTX_PARAMS, (DFUNC)wp_ecx_enc_dec_set_ctx_params  },
     { OSSL_FUNC_ENCODER_DOES_SELECTION, (DFUNC)wp_ecx_spki_does_selection     },
     { OSSL_FUNC_ENCODER_ENCODE,         (DFUNC)wp_ecx_encode                  },
-    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_ecx_import                  },
+    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_ecx_import_object           },
     { OSSL_FUNC_ENCODER_FREE_OBJECT,    (DFUNC)wp_ecx_free                    },
     { 0, NULL }
 };
@@ -3621,7 +3665,7 @@ const OSSL_DISPATCH wp_ed448_pki_der_encoder_functions[] = {
     { OSSL_FUNC_ENCODER_SET_CTX_PARAMS, (DFUNC)wp_ecx_enc_dec_set_ctx_params  },
     { OSSL_FUNC_ENCODER_DOES_SELECTION, (DFUNC)wp_ecx_pki_does_selection      },
     { OSSL_FUNC_ENCODER_ENCODE,         (DFUNC)wp_ecx_encode                  },
-    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_ecx_import                  },
+    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_ecx_import_object           },
     { OSSL_FUNC_ENCODER_FREE_OBJECT,    (DFUNC)wp_ecx_free                    },
     { 0, NULL }
 };
@@ -3650,7 +3694,7 @@ const OSSL_DISPATCH wp_ed448_pki_pem_encoder_functions[] = {
     { OSSL_FUNC_ENCODER_SET_CTX_PARAMS, (DFUNC)wp_ecx_enc_dec_set_ctx_params  },
     { OSSL_FUNC_ENCODER_DOES_SELECTION, (DFUNC)wp_ecx_pki_does_selection      },
     { OSSL_FUNC_ENCODER_ENCODE,         (DFUNC)wp_ecx_encode                  },
-    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_ecx_import                  },
+    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_ecx_import_object           },
     { OSSL_FUNC_ENCODER_FREE_OBJECT,    (DFUNC)wp_ecx_free                    },
     { 0, NULL }
 };
@@ -3683,7 +3727,7 @@ const OSSL_DISPATCH wp_ed448_epki_der_encoder_functions[] = {
     { OSSL_FUNC_ENCODER_SET_CTX_PARAMS, (DFUNC)wp_ecx_enc_dec_set_ctx_params  },
     { OSSL_FUNC_ENCODER_DOES_SELECTION, (DFUNC)wp_ecx_pki_does_selection      },
     { OSSL_FUNC_ENCODER_ENCODE,         (DFUNC)wp_ecx_encode                  },
-    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_ecx_import                  },
+    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_ecx_import_object           },
     { OSSL_FUNC_ENCODER_FREE_OBJECT,    (DFUNC)wp_ecx_free                    },
     { 0, NULL }
 };
@@ -3712,7 +3756,7 @@ const OSSL_DISPATCH wp_ed448_epki_pem_encoder_functions[] = {
     { OSSL_FUNC_ENCODER_SET_CTX_PARAMS, (DFUNC)wp_ecx_enc_dec_set_ctx_params  },
     { OSSL_FUNC_ENCODER_DOES_SELECTION, (DFUNC)wp_ecx_pki_does_selection      },
     { OSSL_FUNC_ENCODER_ENCODE,         (DFUNC)wp_ecx_encode                  },
-    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_ecx_import                  },
+    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_ecx_import_object           },
     { OSSL_FUNC_ENCODER_FREE_OBJECT,    (DFUNC)wp_ecx_free                    },
     { 0, NULL }
 };

--- a/src/wp_mldsa_kmgmt.c
+++ b/src/wp_mldsa_kmgmt.c
@@ -1669,6 +1669,30 @@ static int wp_mldsa_export_object(wp_MlDsaEncDecCtx* ctx, wp_MlDsa* mldsa,
 }
 
 /**
+ * Create an ML-DSA key object and import the key data into it.
+ *
+ * @param [in] ctx        ML-DSA encoder/decoder context object.
+ * @param [in] selection  Parts of key to import.
+ * @param [in] params     Array of parameters with key data.
+ * @return  New ML-DSA key object on success.
+ * @return  NULL on failure.
+ */
+static wp_MlDsa* wp_mldsa_import_object(wp_MlDsaEncDecCtx* ctx, int selection,
+    const OSSL_PARAM params[])
+{
+    wp_MlDsa* mldsa = NULL;
+
+    if (ctx->newKey != NULL) {
+        mldsa = ctx->newKey(ctx->provCtx);
+    }
+    if ((mldsa != NULL) && (!wp_mldsa_import(mldsa, selection, params))) {
+        wp_mldsa_free(mldsa);
+        mldsa = NULL;
+    }
+    return mldsa;
+}
+
+/**
  * Return whether the SPKI decoder/encoder handles this part of the key.
  *
  * @param [in] provCtx    Provider context. Unused.
@@ -1846,7 +1870,7 @@ const OSSL_DISPATCH wp_##alg##_##fmt##_##enc##_encoder_functions[] = {          
                                 (DFUNC)wp_mldsa_enc_dec_set_ctx_params       },\
     { OSSL_FUNC_ENCODER_DOES_SELECTION, (DFUNC)dsel                        },  \
     { OSSL_FUNC_ENCODER_ENCODE,         (DFUNC)wp_mldsa_encode               },\
-    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_mldsa_import               },\
+    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_mldsa_import_object        },\
     { OSSL_FUNC_ENCODER_FREE_OBJECT,    (DFUNC)wp_mldsa_free                 },\
     { 0, NULL }                                                               \
 };

--- a/src/wp_rsa_kmgmt.c
+++ b/src/wp_rsa_kmgmt.c
@@ -3721,6 +3721,27 @@ static int wp_rsa_export_object(wp_RsaEncDecCtx* ctx, wp_Rsa* rsa, size_t size,
     return wp_rsa_export(rsa, ctx->selection, exportCb, exportCbArg);
 }
 
+/**
+ * Create an RSA key object and import the key data into it.
+ *
+ * @param [in] ctx        RSA encoder/decoder context object.
+ * @param [in] selection  Parts of key to import.
+ * @param [in] params     Array of parameters with key data.
+ * @return  New RSA key object on success.
+ * @return  NULL on failure.
+ */
+static wp_Rsa* wp_rsa_import_object(wp_RsaEncDecCtx* ctx, int selection,
+    const OSSL_PARAM params[])
+{
+    wp_Rsa* rsa = wp_rsa_base_new(ctx->provCtx, ctx->type);
+
+    if ((rsa != NULL) && (!wp_rsa_import(rsa, selection, params))) {
+        wp_rsa_free(rsa);
+        rsa = NULL;
+    }
+    return rsa;
+}
+
 /*
  * RSA SubjectPublicKeyInfo
  */
@@ -3802,7 +3823,7 @@ const OSSL_DISPATCH wp_rsa_spki_der_encoder_functions[] = {
     { OSSL_FUNC_ENCODER_SET_CTX_PARAMS, (DFUNC)wp_rsa_enc_dec_set_ctx_params  },
     { OSSL_FUNC_ENCODER_DOES_SELECTION, (DFUNC)wp_rsa_spki_does_selection     },
     { OSSL_FUNC_ENCODER_ENCODE,         (DFUNC)wp_rsa_encode                  },
-    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_rsa_import                  },
+    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_rsa_import_object           },
     { OSSL_FUNC_ENCODER_FREE_OBJECT,    (DFUNC)wp_rsa_free                    },
     { 0, NULL }
 };
@@ -3831,7 +3852,7 @@ const OSSL_DISPATCH wp_rsa_spki_pem_encoder_functions[] = {
     { OSSL_FUNC_ENCODER_SET_CTX_PARAMS, (DFUNC)wp_rsa_enc_dec_set_ctx_params  },
     { OSSL_FUNC_ENCODER_DOES_SELECTION, (DFUNC)wp_rsa_spki_does_selection     },
     { OSSL_FUNC_ENCODER_ENCODE,         (DFUNC)wp_rsa_encode                  },
-    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_rsa_import                  },
+    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_rsa_import_object           },
     { OSSL_FUNC_ENCODER_FREE_OBJECT,    (DFUNC)wp_rsa_free                    },
     { 0, NULL }
 };
@@ -3917,7 +3938,7 @@ const OSSL_DISPATCH wp_rsa_pki_der_encoder_functions[] = {
     { OSSL_FUNC_ENCODER_SET_CTX_PARAMS, (DFUNC)wp_rsa_enc_dec_set_ctx_params  },
     { OSSL_FUNC_ENCODER_DOES_SELECTION, (DFUNC)wp_rsa_pki_does_selection      },
     { OSSL_FUNC_ENCODER_ENCODE,         (DFUNC)wp_rsa_encode                  },
-    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_rsa_import                  },
+    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_rsa_import_object           },
     { OSSL_FUNC_ENCODER_FREE_OBJECT,    (DFUNC)wp_rsa_free                    },
     { 0, NULL }
 };
@@ -3946,7 +3967,7 @@ const OSSL_DISPATCH wp_rsa_pki_pem_encoder_functions[] = {
     { OSSL_FUNC_ENCODER_SET_CTX_PARAMS, (DFUNC)wp_rsa_enc_dec_set_ctx_params  },
     { OSSL_FUNC_ENCODER_DOES_SELECTION, (DFUNC)wp_rsa_pki_does_selection      },
     { OSSL_FUNC_ENCODER_ENCODE,         (DFUNC)wp_rsa_encode                  },
-    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_rsa_import                  },
+    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_rsa_import_object           },
     { OSSL_FUNC_ENCODER_FREE_OBJECT,    (DFUNC)wp_rsa_free                    },
     { 0, NULL }
 };
@@ -3979,7 +4000,7 @@ const OSSL_DISPATCH wp_rsa_epki_der_encoder_functions[] = {
     { OSSL_FUNC_ENCODER_SET_CTX_PARAMS, (DFUNC)wp_rsa_enc_dec_set_ctx_params  },
     { OSSL_FUNC_ENCODER_DOES_SELECTION, (DFUNC)wp_rsa_pki_does_selection      },
     { OSSL_FUNC_ENCODER_ENCODE,         (DFUNC)wp_rsa_encode                  },
-    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_rsa_import                  },
+    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_rsa_import_object           },
     { OSSL_FUNC_ENCODER_FREE_OBJECT,    (DFUNC)wp_rsa_free                    },
     { 0, NULL }
 };
@@ -4008,7 +4029,7 @@ const OSSL_DISPATCH wp_rsa_epki_pem_encoder_functions[] = {
     { OSSL_FUNC_ENCODER_SET_CTX_PARAMS, (DFUNC)wp_rsa_enc_dec_set_ctx_params  },
     { OSSL_FUNC_ENCODER_DOES_SELECTION, (DFUNC)wp_rsa_pki_does_selection      },
     { OSSL_FUNC_ENCODER_ENCODE,         (DFUNC)wp_rsa_encode                  },
-    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_rsa_import                  },
+    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_rsa_import_object           },
     { OSSL_FUNC_ENCODER_FREE_OBJECT,    (DFUNC)wp_rsa_free                    },
     { 0, NULL }
 };
@@ -4124,7 +4145,7 @@ const OSSL_DISPATCH wp_rsa_kp_der_encoder_functions[] = {
     { OSSL_FUNC_ENCODER_SET_CTX_PARAMS, (DFUNC)wp_rsa_enc_dec_set_ctx_params  },
     { OSSL_FUNC_ENCODER_DOES_SELECTION, (DFUNC)wp_rsa_kp_does_selection       },
     { OSSL_FUNC_ENCODER_ENCODE,         (DFUNC)wp_rsa_encode                  },
-    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_rsa_import                  },
+    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_rsa_import_object           },
     { OSSL_FUNC_ENCODER_FREE_OBJECT,    (DFUNC)wp_rsa_free                    },
     { 0, NULL }
 };
@@ -4155,7 +4176,7 @@ const OSSL_DISPATCH wp_rsa_kp_pem_encoder_functions[] = {
     { OSSL_FUNC_ENCODER_SET_CTX_PARAMS, (DFUNC)wp_rsa_enc_dec_set_ctx_params  },
     { OSSL_FUNC_ENCODER_DOES_SELECTION, (DFUNC)wp_rsa_kp_does_selection       },
     { OSSL_FUNC_ENCODER_ENCODE,         (DFUNC)wp_rsa_encode                  },
-    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_rsa_import                  },
+    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_rsa_import_object           },
     { OSSL_FUNC_ENCODER_FREE_OBJECT,    (DFUNC)wp_rsa_free                    },
     { 0, NULL }
 };
@@ -4213,7 +4234,7 @@ const OSSL_DISPATCH wp_rsapss_spki_der_encoder_functions[] = {
     { OSSL_FUNC_ENCODER_SET_CTX_PARAMS, (DFUNC)wp_rsa_enc_dec_set_ctx_params  },
     { OSSL_FUNC_ENCODER_DOES_SELECTION, (DFUNC)wp_rsa_spki_does_selection     },
     { OSSL_FUNC_ENCODER_ENCODE,         (DFUNC)wp_rsa_encode                  },
-    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_rsa_import                  },
+    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_rsa_import_object           },
     { OSSL_FUNC_ENCODER_FREE_OBJECT,    (DFUNC)wp_rsa_free                    },
     { 0, NULL }
 };
@@ -4242,7 +4263,7 @@ const OSSL_DISPATCH wp_rsapss_spki_pem_encoder_functions[] = {
     { OSSL_FUNC_ENCODER_SET_CTX_PARAMS, (DFUNC)wp_rsa_enc_dec_set_ctx_params  },
     { OSSL_FUNC_ENCODER_DOES_SELECTION, (DFUNC)wp_rsa_spki_does_selection     },
     { OSSL_FUNC_ENCODER_ENCODE,         (DFUNC)wp_rsa_encode                  },
-    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_rsa_import                  },
+    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_rsa_import_object           },
     { OSSL_FUNC_ENCODER_FREE_OBJECT,    (DFUNC)wp_rsa_free                    },
     { 0, NULL }
 };
@@ -4300,7 +4321,7 @@ const OSSL_DISPATCH wp_rsapss_pki_der_encoder_functions[] = {
     { OSSL_FUNC_ENCODER_SET_CTX_PARAMS, (DFUNC)wp_rsa_enc_dec_set_ctx_params  },
     { OSSL_FUNC_ENCODER_DOES_SELECTION, (DFUNC)wp_rsa_pki_does_selection      },
     { OSSL_FUNC_ENCODER_ENCODE,         (DFUNC)wp_rsa_encode                  },
-    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_rsa_import                  },
+    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_rsa_import_object           },
     { OSSL_FUNC_ENCODER_FREE_OBJECT,    (DFUNC)wp_rsa_free                    },
     { 0, NULL }
 };
@@ -4329,7 +4350,7 @@ const OSSL_DISPATCH wp_rsapss_pki_pem_encoder_functions[] = {
     { OSSL_FUNC_ENCODER_SET_CTX_PARAMS, (DFUNC)wp_rsa_enc_dec_set_ctx_params  },
     { OSSL_FUNC_ENCODER_DOES_SELECTION, (DFUNC)wp_rsa_pki_does_selection      },
     { OSSL_FUNC_ENCODER_ENCODE,         (DFUNC)wp_rsa_encode                  },
-    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_rsa_import                  },
+    { OSSL_FUNC_ENCODER_IMPORT_OBJECT,  (DFUNC)wp_rsa_import_object           },
     { OSSL_FUNC_ENCODER_FREE_OBJECT,    (DFUNC)wp_rsa_free                    },
     { 0, NULL }
 };

--- a/test/test_dh.c
+++ b/test/test_dh.c
@@ -1735,4 +1735,47 @@ int test_dh_pgen_min_bits(void *data)
     return err;
 }
 
+
+/*
+ * Encoding a key that another provider manages goes through the encoder's
+ * import-object: OpenSSL hands it the encoder context and uses the key object
+ * it returns.
+ */
+int test_dh_encoder_import_object(void *data)
+{
+    int err;
+    EVP_PKEY_CTX* ctx = NULL;
+    EVP_PKEY* pkey = NULL;
+    OSSL_PARAM params[2];
+    char groupName[] = "ffdhe2048";
+
+    (void)data;
+
+    params[0] = OSSL_PARAM_construct_utf8_string(OSSL_PKEY_PARAM_GROUP_NAME,
+        groupName, 0);
+    params[1] = OSSL_PARAM_construct_end();
+
+    err = (ctx = EVP_PKEY_CTX_new_from_name(osslLibCtx, "DH", NULL)) == NULL;
+    if (err == 0) {
+        err = EVP_PKEY_keygen_init(ctx) != 1;
+    }
+    if (err == 0) {
+        err = EVP_PKEY_CTX_set_params(ctx, params) != 1;
+    }
+    if (err == 0) {
+        err = EVP_PKEY_generate(ctx, &pkey) != 1;
+    }
+    if (err == 0) {
+        err = test_encoder_import_object("DH",
+            "output=der,structure=PrivateKeyInfo", pkey,
+            OSSL_KEYMGMT_SELECT_KEYPAIR |
+            OSSL_KEYMGMT_SELECT_ALL_PARAMETERS);
+    }
+
+    EVP_PKEY_free(pkey);
+    EVP_PKEY_CTX_free(ctx);
+
+    return err;
+}
+
 #endif /* WP_HAVE_DH */

--- a/test/test_ecc.c
+++ b/test/test_ecc.c
@@ -3316,4 +3316,36 @@ int test_ec_tls_group_p192(void *data)
     return err;
 }
 
+
+#ifdef WP_HAVE_EC_P256
+/*
+ * Encoding a key that another provider manages goes through the encoder's
+ * import-object: OpenSSL hands it the encoder context and uses the key object
+ * it returns.
+ */
+int test_ecc_encoder_import_object(void *data)
+{
+    int err;
+    EVP_PKEY* pkey = NULL;
+
+    (void)data;
+
+    pkey = EVP_PKEY_Q_keygen(osslLibCtx, NULL, "EC", "P-256");
+    err = (pkey == NULL);
+    if (err == 0) {
+        /* Not ALL_PARAMETERS: that pulls in policy flags like the ECDH
+         * cofactor, which are not key material. */
+        err = test_encoder_import_object("EC",
+            "output=pem,structure=SubjectPublicKeyInfo", pkey,
+            OSSL_KEYMGMT_SELECT_PUBLIC_KEY |
+            OSSL_KEYMGMT_SELECT_DOMAIN_PARAMETERS);
+    }
+
+    EVP_PKEY_free(pkey);
+
+    return err;
+}
+
+#endif /* WP_HAVE_EC_P256 */
+
 #endif /* WP_HAVE_ECC */

--- a/test/test_ecx.c
+++ b/test/test_ecx.c
@@ -1260,3 +1260,46 @@ int test_ecx_x_security_bits(void *data)
 
 #endif /* defined(WP_HAVE_X25519) || defined(WP_HAVE_X448) */
 
+#if defined(WP_HAVE_X25519) || defined(WP_HAVE_ED25519) || \
+    defined(WP_HAVE_X448) || defined(WP_HAVE_ED448)
+/*
+ * Encoding a key that another provider manages goes through the encoder's
+ * import-object: OpenSSL hands it the encoder context and uses the key object
+ * it returns. Cover every key type wp_ecx_new_by_type() handles.
+ */
+int test_ecx_encoder_import_object(void *data)
+{
+    static const char* names[] = {
+#ifdef WP_HAVE_X25519
+        "X25519",
+#endif
+#ifdef WP_HAVE_ED25519
+        "ED25519",
+#endif
+#ifdef WP_HAVE_X448
+        "X448",
+#endif
+#ifdef WP_HAVE_ED448
+        "ED448",
+#endif
+    };
+    int err = 0;
+    EVP_PKEY* pkey;
+    size_t i;
+
+    (void)data;
+
+    for (i = 0; (err == 0) && (i < ARRAY_SIZE(names)); i++) {
+        pkey = EVP_PKEY_Q_keygen(osslLibCtx, NULL, names[i]);
+        err = (pkey == NULL);
+        if (err == 0) {
+            err = test_encoder_import_object(names[i],
+                "output=der,structure=PrivateKeyInfo", pkey,
+                OSSL_KEYMGMT_SELECT_KEYPAIR);
+        }
+        EVP_PKEY_free(pkey);
+    }
+
+    return err;
+}
+#endif

--- a/test/test_mldsa.c
+++ b/test/test_mldsa.c
@@ -1262,4 +1262,30 @@ int test_mldsa_encode_epki(void* data)
 }
 #endif /* WP_HAVE_EPKI_TEST */
 
+
+/*
+ * Encoding a key that another provider manages goes through the encoder's
+ * import-object: OpenSSL hands it the encoder context and uses the key object
+ * it returns.
+ */
+int test_mldsa_encoder_import_object(void *data)
+{
+    int err;
+    EVP_PKEY* pkey = NULL;
+
+    (void)data;
+
+    pkey = EVP_PKEY_Q_keygen(osslLibCtx, NULL, "ML-DSA-44");
+    err = (pkey == NULL);
+    if (err == 0) {
+        err = test_encoder_import_object("ML-DSA-44",
+            "output=pem,structure=SubjectPublicKeyInfo", pkey,
+            OSSL_KEYMGMT_SELECT_PUBLIC_KEY);
+    }
+
+    EVP_PKEY_free(pkey);
+
+    return err;
+}
+
 #endif /* WP_HAVE_MLDSA */

--- a/test/test_pkey.c
+++ b/test/test_pkey.c
@@ -22,6 +22,9 @@
 #include <openssl/encoder.h>
 #include <openssl/decoder.h>
 #include <openssl/err.h>
+#include <openssl/core_dispatch.h>
+#include <openssl/params.h>
+#include <openssl/bn.h>
 
 int test_digest_sign(EVP_PKEY *pkey, OSSL_LIB_CTX* libCtx, unsigned char *data,
     size_t len, const char *md, const EVP_MD *mgf1Md, unsigned char *sig,
@@ -558,6 +561,296 @@ int test_epki_encode_decode(EVP_PKEY* pkey, const char* fmt,
     OPENSSL_free(data);
     EVP_PKEY_free(badKey);
     EVP_PKEY_free(pkey2);
+
+    return err;
+}
+
+/**
+ * Get a provider's query-operation upcall.
+ *
+ * @param [in] prov  Provider to look in.
+ * @return  Query operation function on success.
+ * @return  NULL when the provider does not offer one.
+ */
+static OSSL_FUNC_provider_query_operation_fn* test_prov_query(
+    OSSL_PROVIDER* prov)
+{
+    OSSL_FUNC_provider_query_operation_fn* query = NULL;
+    const OSSL_DISPATCH* d = OSSL_PROVIDER_get0_dispatch(prov);
+
+    if (d != NULL) {
+        for (; d->function_id != 0; d++) {
+            if (d->function_id == OSSL_FUNC_PROVIDER_QUERY_OPERATION) {
+                query = OSSL_FUNC_provider_query_operation(d);
+                break;
+            }
+        }
+    }
+
+    return query;
+}
+
+/**
+ * Find an implementation in a provider's operation table.
+ *
+ * @param [in] prov   Provider to query.
+ * @param [in] opId   Operation identifier, e.g. OSSL_OP_ENCODER.
+ * @param [in] name   Algorithm name to match, e.g. "RSA".
+ * @param [in] props  Substring the properties must contain. May be NULL.
+ * @return  Dispatch table of the implementation on success.
+ * @return  NULL when no implementation matches.
+ */
+static const OSSL_DISPATCH* test_prov_find(OSSL_PROVIDER* prov, int opId,
+    const char* name, const char* props)
+{
+    const OSSL_DISPATCH* impl = NULL;
+    const OSSL_ALGORITHM* algs = NULL;
+    OSSL_FUNC_provider_query_operation_fn* query = test_prov_query(prov);
+    int noCache = 0;
+    size_t nameLen = XSTRLEN(name);
+    const char* p;
+
+    if (query != NULL) {
+        algs = query(OSSL_PROVIDER_get0_provider_ctx(prov), opId, &noCache);
+    }
+    for (; (impl == NULL) && (algs != NULL) && (algs->algorithm_names != NULL);
+            algs++) {
+        if ((props != NULL) && ((algs->property_definition == NULL) ||
+                (strstr(algs->property_definition, props) == NULL))) {
+            continue;
+        }
+        /* Algorithm names are a colon separated list - match one whole name. */
+        for (p = algs->algorithm_names; p != NULL; p = strchr(p, ':')) {
+            if (p[0] == ':') {
+                p++;
+            }
+            if ((strncmp(p, name, nameLen) == 0) &&
+                    ((p[nameLen] == '\0') || (p[nameLen] == ':'))) {
+                impl = algs->implementation;
+                break;
+            }
+        }
+    }
+
+    return impl;
+}
+
+/**
+ * Get a function out of a dispatch table.
+ *
+ * @param [in] disp  Dispatch table to search.
+ * @param [in] id    Function identifier to find.
+ * @return  Function pointer on success.
+ * @return  NULL when not in the table.
+ */
+static void (*test_disp_get(const OSSL_DISPATCH* disp, int id))(void)
+{
+    void (*fp)(void) = NULL;
+
+    for (; (fp == NULL) && (disp != NULL) && (disp->function_id != 0); disp++) {
+        if (disp->function_id == id) {
+            fp = disp->function;
+        }
+    }
+
+    return fp;
+}
+
+/** Comparison state passed to the key-management export callback. */
+typedef struct {
+    /** Parameters the key was imported from. */
+    const OSSL_PARAM* expected;
+    /** Number of parameters that were compared and matched. */
+    int matched;
+    /** Set when an exported parameter differs from the imported one. */
+    int err;
+} TEST_EXPORT_CMP;
+
+/**
+ * Compare one exported parameter with the value it was imported from.
+ *
+ * @param [in]      got  Exported parameter.
+ * @param [in]      exp  Parameter the key was imported from.
+ * @param [in, out] cmp  Comparison state.
+ */
+static void test_param_cmp(const OSSL_PARAM* got, const OSSL_PARAM* exp,
+    TEST_EXPORT_CMP* cmp)
+{
+    BIGNUM* gotBn = NULL;
+    BIGNUM* expBn = NULL;
+
+    if ((got->data_type == OSSL_PARAM_UNSIGNED_INTEGER) ||
+            (got->data_type == OSSL_PARAM_INTEGER)) {
+        if ((OSSL_PARAM_get_BN(got, &gotBn) != 1) ||
+                (OSSL_PARAM_get_BN(exp, &expBn) != 1) ||
+                (BN_cmp(gotBn, expBn) != 0)) {
+            PRINT_ERR_MSG("Imported key parameter differs: %s", got->key);
+            cmp->err = 1;
+        }
+        else {
+            cmp->matched++;
+        }
+        BN_free(gotBn);
+        BN_free(expBn);
+    }
+    else if ((got->data_type == OSSL_PARAM_OCTET_STRING) ||
+             (got->data_type == OSSL_PARAM_UTF8_STRING)) {
+        /* A zero size means the string is NUL terminated - not a match. */
+        if ((got->data_size == 0) || (got->data_size != exp->data_size) ||
+                (memcmp(got->data, exp->data, got->data_size) != 0)) {
+            PRINT_ERR_MSG("Imported key parameter differs: %s", got->key);
+            cmp->err = 1;
+        }
+        else {
+            cmp->matched++;
+        }
+    }
+}
+
+/**
+ * Key-management export callback - compare against the imported parameters.
+ *
+ * @param [in] params  Parameters exported from the imported key.
+ * @param [in] arg     Comparison state.
+ * @return  1 always - failures are recorded in the comparison state.
+ */
+static int test_export_cmp_cb(const OSSL_PARAM params[], void* arg)
+{
+    TEST_EXPORT_CMP* cmp = (TEST_EXPORT_CMP*)arg;
+    const OSSL_PARAM* exp;
+    int i;
+
+    for (i = 0; (params != NULL) && (params[i].key != NULL); i++) {
+        exp = OSSL_PARAM_locate_const(cmp->expected, params[i].key);
+        if ((exp != NULL) && (exp->data_type == params[i].data_type)) {
+            test_param_cmp(&params[i], exp, cmp);
+        }
+    }
+
+    return 1;
+}
+
+/**
+ * Check an encoder's OSSL_FUNC_ENCODER_IMPORT_OBJECT implementation.
+ *
+ * This is the path OpenSSL takes when it encodes a key that another provider
+ * manages: it hands the encoder context to import-object and uses the returned
+ * key object. Drive it directly so the check does not depend on which encoder
+ * OpenSSL would pick.
+ *
+ * @param [in] algName   Algorithm name of the encoder, e.g. "RSA".
+ * @param [in] encProps  Substring of the encoder properties selecting the
+ *                       structure and output, in the order the provider
+ *                       registers them, e.g. "output=pem,structure=SPKI".
+ * @param [in] pkey      Key held by another provider.
+ * @param [in] selection  Parts of the key to import.
+ * @return  0 on success, non-zero on failure.
+ */
+int test_encoder_import_object(const char* algName, const char* encProps,
+    EVP_PKEY* pkey, int selection)
+{
+    int err = 0;
+    const OSSL_DISPATCH* encDisp = NULL;
+    const OSSL_DISPATCH* kmDisp = NULL;
+    OSSL_FUNC_encoder_newctx_fn* newCtx = NULL;
+    OSSL_FUNC_encoder_freectx_fn* freeCtx = NULL;
+    OSSL_FUNC_encoder_import_object_fn* importObj = NULL;
+    OSSL_FUNC_encoder_free_object_fn* freeObj = NULL;
+    OSSL_FUNC_keymgmt_export_fn* kmExport = NULL;
+    OSSL_PARAM* params = NULL;
+    void* encCtx = NULL;
+    void* key = NULL;
+    int keyOk = 0;
+    TEST_EXPORT_CMP cmp;
+
+    XMEMSET(&cmp, 0, sizeof(cmp));
+
+    PRINT_MSG("Encoder import-object contract: %s (%s)", algName, encProps);
+
+    encDisp = test_prov_find(wpProv, OSSL_OP_ENCODER, algName, encProps);
+    err = (encDisp == NULL);
+    if (err) {
+        PRINT_ERR_MSG("No %s encoder with properties %s", algName, encProps);
+    }
+    if (err == 0) {
+        kmDisp = test_prov_find(wpProv, OSSL_OP_KEYMGMT, algName, NULL);
+        err = (kmDisp == NULL);
+        if (err) {
+            PRINT_ERR_MSG("No %s key management", algName);
+        }
+    }
+    if (err == 0) {
+        newCtx = (OSSL_FUNC_encoder_newctx_fn*)test_disp_get(encDisp,
+            OSSL_FUNC_ENCODER_NEWCTX);
+        freeCtx = (OSSL_FUNC_encoder_freectx_fn*)test_disp_get(encDisp,
+            OSSL_FUNC_ENCODER_FREECTX);
+        importObj = (OSSL_FUNC_encoder_import_object_fn*)test_disp_get(encDisp,
+            OSSL_FUNC_ENCODER_IMPORT_OBJECT);
+        freeObj = (OSSL_FUNC_encoder_free_object_fn*)test_disp_get(encDisp,
+            OSSL_FUNC_ENCODER_FREE_OBJECT);
+        kmExport = (OSSL_FUNC_keymgmt_export_fn*)test_disp_get(kmDisp,
+            OSSL_FUNC_KEYMGMT_EXPORT);
+        err = (newCtx == NULL) || (freeCtx == NULL) || (importObj == NULL) ||
+              (freeObj == NULL) || (kmExport == NULL);
+        if (err) {
+            PRINT_ERR_MSG("Encoder is missing a dispatch entry");
+        }
+    }
+    /* The parameters OpenSSL hands to import-object come from the other
+     * provider's key management export. */
+    if (err == 0) {
+        err = EVP_PKEY_todata(pkey, selection, &params) != 1;
+        if (err) {
+            PRINT_ERR_MSG("Failed to get key data");
+        }
+    }
+    if (err == 0) {
+        encCtx = newCtx(OSSL_PROVIDER_get0_provider_ctx(wpProv));
+        err = (encCtx == NULL);
+        if (err) {
+            PRINT_ERR_MSG("Failed to create encoder context");
+        }
+    }
+    if (err == 0) {
+        key = importObj(encCtx, selection, params);
+        err = (key == NULL);
+        if (err) {
+            PRINT_ERR_MSG("Import object returned no key object");
+        }
+    }
+    if (err == 0) {
+        /* A key-management import returning 1/0 lands here as 1, and the
+         * encoder context is not a key object either. */
+        keyOk = (key != encCtx) && (key != (void*)1);
+        err = !keyOk;
+        if (err) {
+            PRINT_ERR_MSG("Import object did not return a key object");
+        }
+    }
+    if (err == 0) {
+        cmp.expected = params;
+        err = kmExport(key, selection, test_export_cmp_cb, &cmp) != 1;
+        if (err) {
+            PRINT_ERR_MSG("Failed to export the imported key");
+        }
+    }
+    if (err == 0) {
+        err = cmp.err || (cmp.matched == 0);
+        if (err) {
+            PRINT_ERR_MSG("Imported key does not hold the key data");
+        }
+    }
+
+    if (keyOk) {
+        freeObj(key);
+    }
+    if (encCtx != NULL) {
+        freeCtx(encCtx);
+    }
+    OSSL_PARAM_free(params);
+    if (err) {
+        ERR_print_errors_fp(stderr);
+    }
 
     return err;
 }

--- a/test/test_rsa.c
+++ b/test/test_rsa.c
@@ -3472,4 +3472,62 @@ int test_rsa_sha512_256_dupctx(void *data)
 }
 #endif /* WP_HAVE_SHA512_256 */
 
+/*
+ * Encoding a key that another provider manages goes through the encoder's
+ * import-object: OpenSSL hands it the encoder context and uses the key object
+ * it returns.
+ */
+int test_rsa_encoder_import_object(void *data)
+{
+    static const char* names[] = {
+        "RSA",
+#ifdef WP_RSA_PSS_ENCODING
+        "RSA-PSS",
+#endif
+    };
+    int err = 0;
+    EVP_PKEY_CTX* ctx;
+    EVP_PKEY* pkey;
+    size_t bits = 2048;
+    OSSL_PARAM params[2];
+    size_t i;
+
+    (void)data;
+
+    params[0] = OSSL_PARAM_construct_size_t(OSSL_PKEY_PARAM_RSA_BITS, &bits);
+    params[1] = OSSL_PARAM_construct_end();
+
+    /* Both key types the encoder context can carry reach wp_rsa_base_new.
+     * EVP_PKEY_Q_keygen() rejects RSA-PSS before OpenSSL 3.5. */
+    for (i = 0; (err == 0) && (i < sizeof(names) / sizeof(*names)); i++) {
+        ctx = NULL;
+        pkey = NULL;
+
+        err = (ctx = EVP_PKEY_CTX_new_from_name(osslLibCtx, names[i], NULL))
+            == NULL;
+        if (err == 0) {
+            err = EVP_PKEY_keygen_init(ctx) != 1;
+        }
+        if (err == 0) {
+            err = EVP_PKEY_CTX_set_params(ctx, params) != 1;
+        }
+        if (err == 0) {
+            err = EVP_PKEY_generate(ctx, &pkey) != 1;
+        }
+        if (err) {
+            PRINT_ERR_MSG("Failed to generate %s key", names[i]);
+        }
+        if (err == 0) {
+            err = test_encoder_import_object(names[i],
+                "output=pem,structure=SubjectPublicKeyInfo", pkey,
+                OSSL_KEYMGMT_SELECT_PUBLIC_KEY);
+        }
+
+        EVP_PKEY_free(pkey);
+        EVP_PKEY_CTX_free(ctx);
+    }
+
+    return err;
+}
+
 #endif /* WP_HAVE_RSA */

--- a/test/unit.c
+++ b/test/unit.c
@@ -349,6 +349,7 @@ TEST_CASE test_case[] = {
     TEST_DECL(test_dh_param_check_explicit, NULL),
     TEST_DECL(test_dh_import_group_no_nul, NULL),
     TEST_DECL(test_dh_pgen_min_bits, NULL),
+    TEST_DECL(test_dh_encoder_import_object, NULL),
 #ifndef WOLFPROV_QUICKTEST
     TEST_DECL(test_dh_get_params, NULL),
 #endif
@@ -392,6 +393,7 @@ TEST_CASE test_case[] = {
     TEST_DECL(test_rsa_pss_mgf1_get_params, NULL),
     TEST_DECL(test_rsa_kem, NULL),
     TEST_DECL(test_rsa_key_integrity, NULL),
+    TEST_DECL(test_rsa_encoder_import_object, NULL),
 #endif /* WP_HAVE_RSA */
 #ifdef WP_HAVE_EC_P192
     #ifdef WP_HAVE_ECKEYGEN
@@ -519,6 +521,9 @@ TEST_CASE test_case[] = {
 
 #ifdef WP_HAVE_ECC
     TEST_DECL(test_ec_tls_group_p192, NULL),
+    #ifdef WP_HAVE_EC_P256
+        TEST_DECL(test_ecc_encoder_import_object, NULL),
+    #endif
 #endif /* WP_HAVE_ECC */
 
 #ifdef WP_HAVE_PBE
@@ -549,6 +554,10 @@ TEST_CASE test_case[] = {
 #endif
 #if defined(WP_HAVE_X25519) || defined(WP_HAVE_X448)
     TEST_DECL(test_ecx_x_security_bits, NULL),
+#endif
+#if defined(WP_HAVE_X25519) || defined(WP_HAVE_ED25519) || \
+    defined(WP_HAVE_X448) || defined(WP_HAVE_ED448)
+    TEST_DECL(test_ecx_encoder_import_object, NULL),
 #endif
 
     TEST_DECL(test_pkcs7_x509_sign_verify, NULL),
@@ -605,6 +614,7 @@ TEST_CASE test_case[] = {
     TEST_DECL(test_mldsa_reinit_null_key, NULL),
     TEST_DECL(test_mldsa_encode_decode, NULL),
     TEST_DECL(test_mldsa_x509_sign_verify, NULL),
+    TEST_DECL(test_mldsa_encoder_import_object, NULL),
 #endif
 };
 #define TEST_CASE_CNT   (int)(sizeof(test_case) / sizeof(*test_case))

--- a/test/unit.h
+++ b/test/unit.h
@@ -325,6 +325,8 @@ int test_pki_cipher_encrypts(EVP_PKEY* pkey, const char* fmt,
     const char* encProp, OSSL_LIB_CTX* decLibCtx, int cmpKey);
 int test_epki_encode_decode(EVP_PKEY* pkey, const char* fmt,
                   const char* encProp, OSSL_LIB_CTX* decLibCtx);
+int test_encoder_import_object(const char* algName, const char* encProps,
+                  EVP_PKEY* pkey, int selection);
 
 #ifdef WP_HAVE_RSA
 int test_pkey_enc_rsa(EVP_PKEY *pkey, unsigned char *msg, size_t msgLen,
@@ -366,6 +368,7 @@ int test_rsa_kem_prefix_match(void* data);
 int test_rsa_pss_mgf1_get_params(void *data);
 int test_rsa_kem(void *data);
 int test_rsa_key_integrity(void* data);
+int test_rsa_encoder_import_object(void *data);
 #endif /* WP_HAVE_RSA */
 
 #ifdef WP_HAVE_DH
@@ -378,6 +381,7 @@ int test_dh_encode_epki(void *data);
 #endif
 int test_dh_decode(void *data);
 int test_dh_get_params(void *data);
+int test_dh_encoder_import_object(void *data);
 int test_dh_krb5_keygen(void *data);
 int test_dh_pad(void *data);
 int test_dh_derive_small_buffer(void *data);
@@ -533,6 +537,7 @@ int test_ec_tls_group_p192(void* data);
 #ifdef WP_HAVE_EC_P256
 int test_ec_print_public(void* data);
 int test_ec_fromdata_oversize(void* data);
+int test_ecc_encoder_import_object(void *data);
 #endif
 
 #endif /* WP_HAVE_ECC */
@@ -564,6 +569,11 @@ int test_ecx_dup(void *data);
 
 #if defined(WP_HAVE_X25519) || defined(WP_HAVE_X448)
 int test_ecx_x_security_bits(void *data);
+#endif
+
+#if defined(WP_HAVE_X25519) || defined(WP_HAVE_ED25519) || \
+    defined(WP_HAVE_X448) || defined(WP_HAVE_ED448)
+int test_ecx_encoder_import_object(void *data);
 #endif
 
 int test_pkcs7_x509_sign_verify(void *data);
@@ -621,6 +631,7 @@ int test_mldsa_empty_message(void *data);
 int test_mldsa_reinit_null_key(void *data);
 int test_mldsa_encode_decode(void *data);
 int test_mldsa_x509_sign_verify(void *data);
+int test_mldsa_encoder_import_object(void *data);
 #endif
 
 #endif /* UNIT_H */


### PR DESCRIPTION
### Problem
The encoder `OSSL_FUNC_ENCODER_IMPORT_OBJECT` slot must be
`void *(void *encoder_ctx, int selection, const OSSL_PARAM[])`: it receives the
context from `OSSL_FUNC_ENCODER_NEWCTX` and returns a newly allocated key. All 72
encoder dispatch tables registered the key-management import instead, which is
`int (wp_<Alg> *key, int, const OSSL_PARAM[])`. The `DFUNC` cast hides both
mismatches:

- **Arg 1** — OpenSSL passes a `wp_<Alg>EncDecCtx *` (7 scalar fields) where a much
  larger key struct is expected, so the import writes key material past its end.
- **Return** — the `int` 1/0 is read as the object pointer, so `encoder_encode()`
  dereferences it and `encoder_destruct_pkey()` frees it.

`import_object` is called only when the key's keymgmt provider differs from the
encoder's, i.e. `OSSL_ENCODER_CTX_new_for_pkey()` on a foreign key in a
multi-provider `OSSL_LIB_CTX`. Registering the slot is what makes wolfProvider's
encoders eligible for that path — `collect_encoder()` skips a foreign encoder whose
`import_object` is NULL. The sharpest case is a key from OpenSSL's FIPS provider,
which ships no encoders of its own. Not reachable in single-provider or
replace-default deployments. 

### Fix (`src/wp_*_kmgmt.c`)
A correctly typed `wp_<alg>_import_object()` per algorithm, mirroring OpenSSL's own
`ossl_prov_import_key()` and the existing `wp_<alg>_export_object()` wrappers:

```c
static wp_Ecc* wp_ecc_import_object(wp_EccEncDecCtx* ctx, int selection,
    const OSSL_PARAM params[])
{
    wp_Ecc* ecc = wp_ecc_new(ctx->provCtx);

    if ((ecc != NULL) && (!wp_ecc_import(ecc, selection, params))) {
        wp_ecc_free(ecc);
        ecc = NULL;
    }
    return ecc;
}
```

| File | Tables | Key allocated with |
|---|---|---|
| `wp_ecx_kmgmt.c` | 24 | `wp_ecx_new_by_type(ctx->provCtx, ctx->keyType, NULL)` |
| `wp_mldsa_kmgmt.c` | 18 | `ctx->newKey(ctx->provCtx)` |
| `wp_rsa_kmgmt.c` | 12 | `wp_rsa_base_new(ctx->provCtx, ctx->type)` |
| `wp_ecc_kmgmt.c` | 10 | `wp_ecc_new(ctx->provCtx)` |
| `wp_dh_kmgmt.c` | 8 | `wp_dh_new(ctx->provCtx)` |

`OSSL_FUNC_ENCODER_FREE_OBJECT` (`wp_<alg>_free`) is already shaped for a real key
object and is unchanged. `wp_ecx_new_by_type()` factors the key-type chain out of
`wp_ecx_decode()` so both callers share it.

Closes f_11552.

### Tests
`test_encoder_import_object()` in `test/test_pkey.c` drives the dispatch entry
directly, so it does not depend on which encoder OpenSSL would pick: it pulls the
encoder and keymgmt tables from the provider's operation query, runs `NEWCTX` and
`IMPORT_OBJECT` over parameters from `EVP_PKEY_todata()` on a default-provider key,
checks the returned object against the keymgmt export, then calls `FREE_OBJECT` and
`FREECTX`. Per-algorithm drivers cover RSA and RSA-PSS, EC, all four ECX key types,
DH and ML-DSA-44 — every context-dependent allocation branch above.

### Verification
- Clean build under the project's `-Werror` flag set; no new warnings.
- Unit suite 211 passed, 0 failed.
- Negative control: with the fix reverted, EC and X25519 abort with SIGSEGV and
  RSA and DH fail on a NULL object.