### PR TITLE
Fix silent key truncation on short BIO_write in key encoders

### DIFF
--- a/include/wolfprovider/internal.h
+++ b/include/wolfprovider/internal.h
@@ -266,6 +266,7 @@ int wp_decrypt_key_pkcs8(unsigned char* data, word32* len,
 int wp_read_der_bio(WOLFPROV_CTX* provCtx, OSSL_CORE_BIO *coreBio, unsigned char** data, word32* len);
 int wp_read_pem_bio(WOLFPROV_CTX *provctx, OSSL_CORE_BIO *coreBio,
     unsigned char** data, word32* len);
+int wp_write_bio(BIO* bio, const unsigned char* data, size_t len);
 BIO* wp_corebio_get_bio(WOLFPROV_CTX* provCtx, OSSL_CORE_BIO *coreBio);
 
 #ifdef HAVE_FIPS

--- a/src/wp_dh_kmgmt.c
+++ b/src/wp_dh_kmgmt.c
@@ -2965,10 +2965,7 @@ static int wp_dh_encode(wp_DhEncDecCtx* ctx, OSSL_CORE_BIO *cBio,
         }
     }
     if (ok) {
-        rc = BIO_write(out, keyData, (int)keyLen);
-        if (rc <= 0) {
-            ok = 0;
-        }
+        ok = wp_write_bio(out, keyData, keyLen);
     }
 
     if (private) {

--- a/src/wp_ecc_kmgmt.c
+++ b/src/wp_ecc_kmgmt.c
@@ -3090,10 +3090,7 @@ static int wp_ecc_encode(wp_EccEncDecCtx* ctx, OSSL_CORE_BIO *cBio,
         }
     }
     if (ok) {
-        rc = BIO_write(out, keyData, (int)keyLen);
-        if (rc <= 0) {
-            ok = 0;
-        }
+        ok = wp_write_bio(out, keyData, keyLen);
     }
 
     if (private) {

--- a/src/wp_ecx_kmgmt.c
+++ b/src/wp_ecx_kmgmt.c
@@ -2314,10 +2314,7 @@ static int wp_ecx_encode(wp_EcxEncDecCtx* ctx, OSSL_CORE_BIO *cBio,
         }
     }
     if (ok) {
-        rc = BIO_write(out, keyData, (int)keyLen);
-        if (rc <= 0) {
-            ok = 0;
-        }
+        ok = wp_write_bio(out, keyData, keyLen);
     }
 
     /* derData holds the plaintext private key material. */

--- a/src/wp_internal.c
+++ b/src/wp_internal.c
@@ -1448,6 +1448,46 @@ int wp_read_pem_bio(WOLFPROV_CTX *provctx, OSSL_CORE_BIO *coreBio,
 }
 
 /**
+ * Write all data to a BIO.
+ *
+ * BIO_write may write fewer bytes than requested. Loop until all data is
+ * written so that a short write does not silently truncate the output.
+ *
+ * @param [in] bio   BIO to write to.
+ * @param [in] data  Data to write.
+ * @param [in] len   Length of data in bytes.
+ * @return  1 on success.
+ * @return  0 on failure.
+ */
+int wp_write_bio(BIO* bio, const unsigned char* data, size_t len)
+{
+    int ok = 1;
+    size_t off = 0;
+
+    WOLFPROV_ENTER(WP_LOG_COMP_PROVIDER, "wp_write_bio");
+
+    if ((bio == NULL) || (data == NULL)) {
+        ok = 0;
+    }
+
+    while (ok && (off < len)) {
+        int rc = BIO_write(bio, data + off, (int)(len - off));
+        if (rc > 0) {
+            off += (size_t)rc;
+        }
+        else {
+            WOLFPROV_MSG(WP_LOG_COMP_PROVIDER, "BIO_write error (%d) in %s:%d",
+                rc, __FILE__, __LINE__);
+            ok = 0;
+        }
+    }
+
+    WOLFPROV_LEAVE(WP_LOG_COMP_PROVIDER, __FILE__ ":" WOLFPROV_STRINGIZE(__LINE__),
+        ok);
+    return ok;
+}
+
+/**
  * Get the underlying BIO object from the core BIO.
  *
  * @param [in]  coreBio  Core BIO.

--- a/src/wp_mldsa_kmgmt.c
+++ b/src/wp_mldsa_kmgmt.c
@@ -1628,10 +1628,7 @@ static int wp_mldsa_encode(wp_MlDsaEncDecCtx* ctx, OSSL_CORE_BIO* cBio,
         }
     }
     if (ok) {
-        rc = BIO_write(out, keyData, (int)keyLen);
-        if (rc <= 0) {
-            ok = 0;
-        }
+        ok = wp_write_bio(out, keyData, keyLen);
     }
 
     if (private) {

--- a/src/wp_rsa_kmgmt.c
+++ b/src/wp_rsa_kmgmt.c
@@ -3683,10 +3683,7 @@ static int wp_rsa_encode(wp_RsaEncDecCtx* ctx, OSSL_CORE_BIO* cBio,
         }
     }
     if (ok) {
-        rc = BIO_write(out, keyData, (int)keyLen);
-        if (rc <= 0) {
-            ok = 0;
-        }
+        ok = wp_write_bio(out, keyData, keyLen);
     }
 
     if (private) {

--- a/test/test_ecc.c
+++ b/test/test_ecc.c
@@ -1045,6 +1045,139 @@ int test_ecc_encode_epki(void *data)
 }
 #endif /* WP_HAVE_EPKI_TEST */
 
+/* Sink BIO that accepts one byte per write and keeps every byte it is given.
+ * It reproduces a short-writing BIO so a truncated encoding is detectable. */
+typedef struct {
+    unsigned char buf[4096];
+    size_t len;
+} ShortWriteSink;
+
+static int short_write_bio_write(BIO* b, const char* data, int len)
+{
+    ShortWriteSink* sink = (ShortWriteSink*)BIO_get_data(b);
+
+    BIO_clear_retry_flags(b);
+    if ((sink == NULL) || (len <= 0) || (sink->len >= sizeof(sink->buf))) {
+        return 0;
+    }
+    /* Take a single byte so the writer must loop to make progress. */
+    sink->buf[sink->len++] = (unsigned char)data[0];
+    return 1;
+}
+
+static long short_write_bio_ctrl(BIO* b, int cmd, long num, void* ptr)
+{
+    (void)b;
+    (void)num;
+    (void)ptr;
+    return (cmd == BIO_CTRL_FLUSH) ? 1 : 0;
+}
+
+static int short_write_bio_create(BIO* b)
+{
+    BIO_set_init(b, 1);
+    return 1;
+}
+
+/* Encode pkey twice with the same wolfProvider encoder: once via
+ * OSSL_ENCODER_to_data (a normal full-writing sink) for a reference, and once
+ * through a one-byte-at-a-time BIO. The two encodings must be identical. */
+static int test_ecc_encode_short_write(EVP_PKEY* pkey, int selection,
+    const char* format, const char* structure)
+{
+    int err = 0;
+    OSSL_ENCODER_CTX* ectx = NULL;
+    unsigned char* refData = NULL;
+    size_t refLen = 0;
+    BIO_METHOD* meth = NULL;
+    BIO* bio = NULL;
+    ShortWriteSink sink;
+
+    memset(&sink, 0, sizeof(sink));
+
+    ectx = OSSL_ENCODER_CTX_new_for_pkey(pkey, selection, format, structure,
+        "provider=libwolfprov");
+    err = (ectx == NULL);
+    if (err == 0) {
+        err = (OSSL_ENCODER_to_data(ectx, &refData, &refLen) != 1);
+    }
+    OSSL_ENCODER_CTX_free(ectx);
+    ectx = NULL;
+    if (err == 0) {
+        err = (refLen == 0);
+    }
+
+    if (err == 0) {
+        meth = BIO_meth_new(BIO_get_new_index() | BIO_TYPE_SOURCE_SINK,
+            "short-write");
+        err = (meth == NULL);
+    }
+    if (err == 0) {
+        BIO_meth_set_write(meth, short_write_bio_write);
+        BIO_meth_set_ctrl(meth, short_write_bio_ctrl);
+        BIO_meth_set_create(meth, short_write_bio_create);
+        bio = BIO_new(meth);
+        err = (bio == NULL);
+    }
+    if (err == 0) {
+        BIO_set_data(bio, &sink);
+        ectx = OSSL_ENCODER_CTX_new_for_pkey(pkey, selection, format, structure,
+            "provider=libwolfprov");
+        err = (ectx == NULL);
+    }
+    if (err == 0) {
+        err = (OSSL_ENCODER_to_bio(ectx, bio) != 1);
+    }
+    if (err == 0) {
+        err = (sink.len != refLen);
+        if (err) {
+            PRINT_ERR_MSG("Short write truncated output: %lu of %lu bytes",
+                (unsigned long)sink.len, (unsigned long)refLen);
+        }
+    }
+    if (err == 0) {
+        err = (memcmp(sink.buf, refData, refLen) != 0);
+        if (err) {
+            PRINT_ERR_MSG("Short-write output does not match the reference");
+        }
+    }
+
+    OSSL_ENCODER_CTX_free(ectx);
+    BIO_free(bio);
+    BIO_meth_free(meth);
+    OPENSSL_free(refData);
+
+    return err;
+}
+
+int test_ecc_encode_short_write_bio(void *data)
+{
+    int err = 0;
+    const unsigned char* p = ecc_key_der_256;
+    EVP_PKEY* pkey = NULL;
+
+    (void)data;
+
+    pkey = d2i_PrivateKey_ex(EVP_PKEY_EC, NULL, &p, sizeof(ecc_key_der_256),
+        wpLibCtx, NULL);
+    err = (pkey == NULL);
+
+    if (err == 0) {
+        PRINT_MSG("SubjectPublicKeyInfo DER survives a short-writing BIO");
+        err = test_ecc_encode_short_write(pkey, EVP_PKEY_PUBLIC_KEY, "DER",
+            "SubjectPublicKeyInfo");
+    }
+    if (err == 0) {
+        PRINT_MSG("SubjectPublicKeyInfo PEM survives a short-writing BIO");
+        err = test_ecc_encode_short_write(pkey, EVP_PKEY_PUBLIC_KEY, "PEM",
+            "SubjectPublicKeyInfo");
+    }
+
+    EVP_PKEY_free(pkey);
+
+    return err;
+}
+
 int test_ecdh_invalid_kdf_strings(void *data)
 {
     int err = 0;

--- a/test/test_ecc.c
+++ b/test/test_ecc.c
@@ -1045,139 +1045,6 @@ int test_ecc_encode_epki(void *data)
 }
 #endif /* WP_HAVE_EPKI_TEST */
 
-/* Sink BIO that accepts one byte per write and keeps every byte it is given.
- * It reproduces a short-writing BIO so a truncated encoding is detectable. */
-typedef struct {
-    unsigned char buf[4096];
-    size_t len;
-} ShortWriteSink;
-
-static int short_write_bio_write(BIO* b, const char* data, int len)
-{
-    ShortWriteSink* sink = (ShortWriteSink*)BIO_get_data(b);
-
-    BIO_clear_retry_flags(b);
-    if ((sink == NULL) || (len <= 0) || (sink->len >= sizeof(sink->buf))) {
-        return 0;
-    }
-    /* Take a single byte so the writer must loop to make progress. */
-    sink->buf[sink->len++] = (unsigned char)data[0];
-    return 1;
-}
-
-static long short_write_bio_ctrl(BIO* b, int cmd, long num, void* ptr)
-{
-    (void)b;
-    (void)num;
-    (void)ptr;
-    return (cmd == BIO_CTRL_FLUSH) ? 1 : 0;
-}
-
-static int short_write_bio_create(BIO* b)
-{
-    BIO_set_init(b, 1);
-    return 1;
-}
-
-/* Encode pkey twice with the same wolfProvider encoder: once via
- * OSSL_ENCODER_to_data (a normal full-writing sink) for a reference, and once
- * through a one-byte-at-a-time BIO. The two encodings must be identical. */
-static int test_ecc_encode_short_write(EVP_PKEY* pkey, int selection,
-    const char* format, const char* structure)
-{
-    int err = 0;
-    OSSL_ENCODER_CTX* ectx = NULL;
-    unsigned char* refData = NULL;
-    size_t refLen = 0;
-    BIO_METHOD* meth = NULL;
-    BIO* bio = NULL;
-    ShortWriteSink sink;
-
-    memset(&sink, 0, sizeof(sink));
-
-    ectx = OSSL_ENCODER_CTX_new_for_pkey(pkey, selection, format, structure,
-        "provider=libwolfprov");
-    err = (ectx == NULL);
-    if (err == 0) {
-        err = (OSSL_ENCODER_to_data(ectx, &refData, &refLen) != 1);
-    }
-    OSSL_ENCODER_CTX_free(ectx);
-    ectx = NULL;
-    if (err == 0) {
-        err = (refLen == 0);
-    }
-
-    if (err == 0) {
-        meth = BIO_meth_new(BIO_get_new_index() | BIO_TYPE_SOURCE_SINK,
-            "short-write");
-        err = (meth == NULL);
-    }
-    if (err == 0) {
-        BIO_meth_set_write(meth, short_write_bio_write);
-        BIO_meth_set_ctrl(meth, short_write_bio_ctrl);
-        BIO_meth_set_create(meth, short_write_bio_create);
-        bio = BIO_new(meth);
-        err = (bio == NULL);
-    }
-    if (err == 0) {
-        BIO_set_data(bio, &sink);
-        ectx = OSSL_ENCODER_CTX_new_for_pkey(pkey, selection, format, structure,
-            "provider=libwolfprov");
-        err = (ectx == NULL);
-    }
-    if (err == 0) {
-        err = (OSSL_ENCODER_to_bio(ectx, bio) != 1);
-    }
-    if (err == 0) {
-        err = (sink.len != refLen);
-        if (err) {
-            PRINT_ERR_MSG("Short write truncated output: %lu of %lu bytes",
-                (unsigned long)sink.len, (unsigned long)refLen);
-        }
-    }
-    if (err == 0) {
-        err = (memcmp(sink.buf, refData, refLen) != 0);
-        if (err) {
-            PRINT_ERR_MSG("Short-write output does not match the reference");
-        }
-    }
-
-    OSSL_ENCODER_CTX_free(ectx);
-    BIO_free(bio);
-    BIO_meth_free(meth);
-    OPENSSL_free(refData);
-
-    return err;
-}
-
-int test_ecc_encode_short_write_bio(void *data)
-{
-    int err = 0;
-    const unsigned char* p = ecc_key_der_256;
-    EVP_PKEY* pkey = NULL;
-
-    (void)data;
-
-    pkey = d2i_PrivateKey_ex(EVP_PKEY_EC, NULL, &p, sizeof(ecc_key_der_256),
-        wpLibCtx, NULL);
-    err = (pkey == NULL);
-
-    if (err == 0) {
-        PRINT_MSG("SubjectPublicKeyInfo DER survives a short-writing BIO");
-        err = test_ecc_encode_short_write(pkey, EVP_PKEY_PUBLIC_KEY, "DER",
-            "SubjectPublicKeyInfo");
-    }
-    if (err == 0) {
-        PRINT_MSG("SubjectPublicKeyInfo PEM survives a short-writing BIO");
-        err = test_ecc_encode_short_write(pkey, EVP_PKEY_PUBLIC_KEY, "PEM",
-            "SubjectPublicKeyInfo");
-    }
-
-    EVP_PKEY_free(pkey);
-
-    return err;
-}
-
 int test_ecdh_invalid_kdf_strings(void *data)
 {
     int err = 0;
@@ -1632,6 +1499,141 @@ int test_ecdh_x448_vector(void *data)
 #endif /* WP_HAVE_X448 */
 
 #endif /* WP_HAVE_ECDH */
+
+#ifdef WP_HAVE_EC_P256
+/* Sink BIO that accepts one byte per write and keeps every byte it is given.
+ * It reproduces a short-writing BIO so a truncated encoding is detectable. */
+typedef struct {
+    unsigned char buf[4096];
+    size_t len;
+} ShortWriteSink;
+
+static int short_write_bio_write(BIO* b, const char* data, int len)
+{
+    ShortWriteSink* sink = (ShortWriteSink*)BIO_get_data(b);
+
+    BIO_clear_retry_flags(b);
+    if ((sink == NULL) || (len <= 0) || (sink->len >= sizeof(sink->buf))) {
+        return 0;
+    }
+    /* Take a single byte so the writer must loop to make progress. */
+    sink->buf[sink->len++] = (unsigned char)data[0];
+    return 1;
+}
+
+static long short_write_bio_ctrl(BIO* b, int cmd, long num, void* ptr)
+{
+    (void)b;
+    (void)num;
+    (void)ptr;
+    return (cmd == BIO_CTRL_FLUSH) ? 1 : 0;
+}
+
+static int short_write_bio_create(BIO* b)
+{
+    BIO_set_init(b, 1);
+    return 1;
+}
+
+/* Encode pkey twice with the same wolfProvider encoder: once via
+ * OSSL_ENCODER_to_data (a normal full-writing sink) for a reference, and once
+ * through a one-byte-at-a-time BIO. The two encodings must be identical. */
+static int test_ecc_encode_short_write(EVP_PKEY* pkey, int selection,
+    const char* format, const char* structure)
+{
+    int err = 0;
+    OSSL_ENCODER_CTX* ectx = NULL;
+    unsigned char* refData = NULL;
+    size_t refLen = 0;
+    BIO_METHOD* meth = NULL;
+    BIO* bio = NULL;
+    ShortWriteSink sink;
+
+    memset(&sink, 0, sizeof(sink));
+
+    ectx = OSSL_ENCODER_CTX_new_for_pkey(pkey, selection, format, structure,
+        "provider=libwolfprov");
+    err = (ectx == NULL);
+    if (err == 0) {
+        err = (OSSL_ENCODER_to_data(ectx, &refData, &refLen) != 1);
+    }
+    OSSL_ENCODER_CTX_free(ectx);
+    ectx = NULL;
+    if (err == 0) {
+        err = (refLen == 0);
+    }
+
+    if (err == 0) {
+        meth = BIO_meth_new(BIO_get_new_index() | BIO_TYPE_SOURCE_SINK,
+            "short-write");
+        err = (meth == NULL);
+    }
+    if (err == 0) {
+        BIO_meth_set_write(meth, short_write_bio_write);
+        BIO_meth_set_ctrl(meth, short_write_bio_ctrl);
+        BIO_meth_set_create(meth, short_write_bio_create);
+        bio = BIO_new(meth);
+        err = (bio == NULL);
+    }
+    if (err == 0) {
+        BIO_set_data(bio, &sink);
+        ectx = OSSL_ENCODER_CTX_new_for_pkey(pkey, selection, format, structure,
+            "provider=libwolfprov");
+        err = (ectx == NULL);
+    }
+    if (err == 0) {
+        err = (OSSL_ENCODER_to_bio(ectx, bio) != 1);
+    }
+    if (err == 0) {
+        err = (sink.len != refLen);
+        if (err) {
+            PRINT_ERR_MSG("Short write truncated output: %lu of %lu bytes",
+                (unsigned long)sink.len, (unsigned long)refLen);
+        }
+    }
+    if (err == 0) {
+        err = (memcmp(sink.buf, refData, refLen) != 0);
+        if (err) {
+            PRINT_ERR_MSG("Short-write output does not match the reference");
+        }
+    }
+
+    OSSL_ENCODER_CTX_free(ectx);
+    BIO_free(bio);
+    BIO_meth_free(meth);
+    OPENSSL_free(refData);
+
+    return err;
+}
+
+int test_ecc_encode_short_write_bio(void *data)
+{
+    int err = 0;
+    const unsigned char* p = ecc_key_der_256;
+    EVP_PKEY* pkey = NULL;
+
+    (void)data;
+
+    pkey = d2i_PrivateKey_ex(EVP_PKEY_EC, NULL, &p, sizeof(ecc_key_der_256),
+        wpLibCtx, NULL);
+    err = (pkey == NULL);
+
+    if (err == 0) {
+        PRINT_MSG("SubjectPublicKeyInfo DER survives a short-writing BIO");
+        err = test_ecc_encode_short_write(pkey, EVP_PKEY_PUBLIC_KEY, "DER",
+            "SubjectPublicKeyInfo");
+    }
+    if (err == 0) {
+        PRINT_MSG("SubjectPublicKeyInfo PEM survives a short-writing BIO");
+        err = test_ecc_encode_short_write(pkey, EVP_PKEY_PUBLIC_KEY, "PEM",
+            "SubjectPublicKeyInfo");
+    }
+
+    EVP_PKEY_free(pkey);
+
+    return err;
+}
+#endif /* WP_HAVE_EC_P256 */
 
 #ifdef WP_HAVE_ECDSA
 

--- a/test/unit.c
+++ b/test/unit.c
@@ -424,6 +424,7 @@ TEST_CASE test_case[] = {
     #endif
 #endif
 #ifdef WP_HAVE_EC_P256
+    TEST_DECL(test_ecc_encode_short_write_bio, NULL),
     #ifdef WP_HAVE_EPKI_TEST
         TEST_DECL(test_ecc_encode_epki, NULL),
     #endif

--- a/test/unit.h
+++ b/test/unit.h
@@ -427,6 +427,10 @@ int test_eckeygen_x448(void *data);
 
 #endif /* WP_HAVE_ECKEYGEN */
 
+#ifdef WP_HAVE_EC_P256
+int test_ecc_encode_short_write_bio(void *data);
+#endif /* WP_HAVE_EC_P256 */
+
 #ifdef WP_HAVE_ECDH
 
 #ifdef WP_HAVE_ECKEYGEN
@@ -470,7 +474,6 @@ int test_ecdh_p224(void *data);
 #endif /* WP_HAVE_EC_P224 */
 #ifdef WP_HAVE_EC_P256
 int test_ecdh_invalid_kdf_strings(void *data);
-int test_ecc_encode_short_write_bio(void *data);
 #ifdef WP_HAVE_EPKI_TEST
 int test_ecc_encode_epki(void *data);
 #endif

--- a/test/unit.h
+++ b/test/unit.h
@@ -470,6 +470,7 @@ int test_ecdh_p224(void *data);
 #endif /* WP_HAVE_EC_P224 */
 #ifdef WP_HAVE_EC_P256
 int test_ecdh_invalid_kdf_strings(void *data);
+int test_ecc_encode_short_write_bio(void *data);
 #ifdef WP_HAVE_EPKI_TEST
 int test_ecc_encode_epki(void *data);
 #endif


### PR DESCRIPTION
## PR body

```markdown
## Summary

The wolfProvider key encoders (RSA, ECC, ECX, DH, ML-DSA) wrote the encoded
key to the output BIO with a single `BIO_write` and treated any positive
return as complete success:

```c
rc = BIO_write(out, keyData, (int)keyLen);
if (rc <= 0) {
    ok = 0;
}
```

`BIO_write` is allowed to write fewer bytes than requested (a "short write"),
which returns a positive value smaller than `keyLen`. The old check only
rejected `rc <= 0`, so a short write was reported as success while the DER/PEM
output was silently truncated. Application-supplied BIOs (sockets, pipes,
non-blocking or custom sinks) can legitimately short-write, so a caller could
receive and persist a corrupt, incomplete key with no error.

## Fix

Add a shared helper `wp_write_bio()` in `src/wp_internal.c` that loops until
every byte is written, and use it in all five encoders. The helper mirrors the
existing `wp_read_der_bio` style (`WOLFPROV_ENTER`/`LEAVE`, `ok` flag, Doxygen
header). Each iteration either advances past the bytes written or fails, so
there is no busy-loop or hang.

Encoder sinks are used synchronously, so a non-positive return is treated as a
hard failure rather than spinning on `BIO_should_retry` — it fails closed
instead of truncating.

## Testing

New deterministic regression test `test_ecc_encode_short_write_bio` (unit case
143). It builds a custom BIO that accepts exactly one byte per write, encodes a
P-256 key as DER and PEM `SubjectPublicKeyInfo` through it, and asserts the
captured bytes equal the full reference encoding from `OSSL_ENCODER_to_data`.
No threads or timing — binary pass/fail.

Before/after (case number: `./test/unit.test --list | grep short_write`):

- Test-only commit (fix reverted): `./test/unit.test 143` fails with
  `Short write truncated output: 1 of 91 bytes`.
- Fix applied: `./test/unit.test 143` passes for DER and PEM.
- Full unit suite: 204/204, 0 failures.

## Fenrir

Addresses Fenrir finding 11560 (short-write truncation in key encoders).