### PR TITLE
Tests: fix compile issue with gcc-15

### DIFF
--- a/.github/workflows/multi-compiler.yml
+++ b/.github/workflows/multi-compiler.yml
@@ -41,7 +41,7 @@ jobs:
       fail-fast: false
       # PR-time matrix is intentionally narrow: only compilers that ship
       # in Debian Bookworm (the test-deps image base). Dropped vs the
-      # prior matrix: gcc-9, gcc-10, gcc-13, gcc-14, clang-12. Full
+      # prior matrix: gcc-9, gcc-10, gcc-13, gcc-14, gcc-15, clang-12. Full
       # cross-compiler coverage (including those) runs in the nightly
       # multi-compiler job called from nightly-osp.yml.
       matrix:

--- a/.github/workflows/nightly-multi-compiler.yml
+++ b/.github/workflows/nightly-multi-compiler.yml
@@ -1,12 +1,13 @@
 name: Nightly Multi-Compiler Tests
 
-# Runs the FULL multi-compiler matrix (gcc-9..14, clang-12..15) on
+# Runs the FULL multi-compiler matrix (gcc-9..15, clang-12..15) on
 # Ubuntu runners. PR-time multi-compiler.yml is restricted to the
 # compilers that ship in the test-deps container (Debian Bookworm:
 # gcc-11, gcc-12, clang-13..15) to avoid the apt-get hangs that were
 # cancelling PR jobs after 20 minutes. This nightly job restores
 # coverage of the dropped compilers (gcc-9, gcc-10, gcc-13, gcc-14,
-# clang-12) plus everything in between.
+# clang-12) plus everything in between. gcc-15 is newer than the runner
+# image ships, so it comes from the toolchain PPA.
 
 on:
   workflow_call: {}
@@ -61,6 +62,11 @@ jobs:
             OS: ubuntu-latest
             wolfssl_ref: master
             openssl_ref: master
+          - CC: gcc-15
+            CXX: g++-15
+            OS: ubuntu-latest
+            wolfssl_ref: master
+            openssl_ref: master
           - CC: clang-12
             CXX: clang++-12
             OS: ubuntu-22.04
@@ -102,7 +108,13 @@ jobs:
           # on PATH - skips the slow `apt-get update` whenever possible.
           if ! command -v ${{ matrix.CC }} >/dev/null; then
             sudo apt-get update
-            sudo apt-get install -y ${{ matrix.CC }} ${{ matrix.CXX }}
+            if ! sudo apt-get install -y ${{ matrix.CC }} ${{ matrix.CXX }}; then
+              # Compilers newer than the runner image ships come from the
+              # toolchain PPA.
+              sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+              sudo apt-get update
+              sudo apt-get install -y ${{ matrix.CC }} ${{ matrix.CXX }}
+            fi
           fi
           ${{ matrix.CC }} --version
 

--- a/test/test_mldsa.c
+++ b/test/test_mldsa.c
@@ -592,8 +592,8 @@ int test_mldsa_match(void* data)
  * produce signatures that verify under the original key. */
 int test_mldsa_dupctx(void* data)
 {
-    static const unsigned char part1[16] = "mldsa-dupctx-pt1";
-    static const unsigned char part2[16] = "mldsa-dupctx-pt2";
+    static const unsigned char part1[] = "mldsa-dupctx-pt1";
+    static const unsigned char part2[] = "mldsa-dupctx-pt2";
     int err = 0;
     size_t i;
     EVP_PKEY* k = NULL;
@@ -603,11 +603,11 @@ int test_mldsa_dupctx(void* data)
     unsigned char* sigB = NULL;
     size_t sigALen = 0;
     size_t sigBLen = 0;
-    unsigned char msg[32];
+    unsigned char msg[sizeof(part1) + sizeof(part2)];
 
     (void)data;
-    XMEMCPY(msg, part1, 16);
-    XMEMCPY(msg + 16, part2, 16);
+    XMEMCPY(msg, part1, sizeof(part1));
+    XMEMCPY(msg + sizeof(part1), part2, sizeof(part2));
 
     for (i = 0; (err == 0) && (i < MLDSA_LEVEL_COUNT); i++) {
         PRINT_MSG("Dupctx %s", mldsa_levels[i].name);
@@ -666,7 +666,7 @@ int test_mldsa_dupctx(void* data)
 /* One-shot EVP_PKEY_sign / EVP_PKEY_verify path (not digest_sign). */
 int test_mldsa_oneshot_sign_verify(void* data)
 {
-    static const unsigned char msg[16] = "mldsa-one-shot!!";
+    static const unsigned char msg[] = "mldsa-one-shot!!";
     int err = 0;
     size_t i;
     EVP_PKEY* k = NULL;
@@ -927,7 +927,7 @@ int test_mldsa_empty_message(void* data)
  * context must be reused (OpenSSL reinit contract). */
 int test_mldsa_reinit_null_key(void* data)
 {
-    static const unsigned char msg[16] = "mldsa-reinit-msg";
+    static const unsigned char msg[] = "mldsa-reinit-msg";
     int err = 0;
     EVP_PKEY* k = NULL;
     EVP_MD_CTX* mdctx = NULL;
@@ -978,7 +978,7 @@ int test_mldsa_reinit_null_key(void* data)
  * message that the original public key must verify. */
 int test_mldsa_encode_decode(void* data)
 {
-    static const unsigned char msg[24] = "mldsa-encode-decode-msg!";
+    static const unsigned char msg[] = "mldsa-encode-decode-msg!";
     int err = 0;
     size_t i;
     EVP_PKEY* k = NULL;

--- a/test/test_rsa.c
+++ b/test/test_rsa.c
@@ -3534,8 +3534,8 @@ static int test_rsa_dupctx_verify(EVP_PKEY *pkey, const char *md,
 
 static int test_rsa_dupctx_one_digest(const char *md, void *data)
 {
-    static const unsigned char part1[16] = "rsa-dupctx-part1";
-    static const unsigned char part2[16] = "rsa-dupctx-part2";
+    static const unsigned char part1[] = "rsa-dupctx-part1";
+    static const unsigned char part2[] = "rsa-dupctx-part2";
     int err = 0;
     EVP_PKEY *pkey = NULL;
     const unsigned char *p = rsa_key_der_2048;
@@ -3545,7 +3545,7 @@ static int test_rsa_dupctx_one_digest(const char *md, void *data)
     unsigned char sigB[256];
     size_t sigALen = sizeof(sigA);
     size_t sigBLen = sizeof(sigB);
-    unsigned char msg[32];
+    unsigned char msg[sizeof(part1) + sizeof(part2)];
 
     (void)data;
 


### PR DESCRIPTION
`gcc-15` adds option `-Wunterminated-string-initialization` which does not like strings in fixed sized arrays. There are only a handful of those in WP, in the tests dir, which are fixed in this PR.
